### PR TITLE
remove unnecessary exec & make metric queue size configurable

### DIFF
--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -28,13 +28,12 @@ func (connector *DbConnector) GetMetricsValues(metrics []string, from int64, unt
 	c := connector.pool.Get()
 	defer c.Close()
 
-	c.Send("MULTI")
 	for _, metric := range metrics {
 		c.Send("ZRANGEBYSCORE", metricDataKey(metric), from, until, "WITHSCORES")
 	}
-	resultByMetrics, err := redis.Values(c.Do("EXEC"))
+	resultByMetrics, err := redis.Values(c.Do(""))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to EXEC: %v", err)
+		return nil, fmt.Errorf("Failed to get metric values: %v", err)
 	}
 
 	res := make(map[string][]*moira.MetricValue, len(resultByMetrics))

--- a/filter/connection/listening.go
+++ b/filter/connection/listening.go
@@ -40,7 +40,7 @@ func NewListener(port string, logger moira.Logger, patternStorage *filter.Patter
 // Listen waits for new data in connection and handles it in ConnectionHandler
 // All handled data sets to metricsChan
 func (listener *MetricsListener) Listen() chan *moira.MatchedMetric {
-	metricsChan := make(chan *moira.MatchedMetric, 10)
+	metricsChan := make(chan *moira.MatchedMetric, 10000)
 	listener.tomb.Go(func() error {
 		for {
 			select {


### PR DESCRIPTION
Large unnecessary transaction in GetMetricValues can hang redis for some time and slowing other related services (api, filter, etc). 
Also metric queue size is configurable now.