### PR TITLE
Remove empty string check as metric name can be blank.

### DIFF
--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -144,10 +144,6 @@ func getTriggerMetrics(writer http.ResponseWriter, request *http.Request) {
 func deleteTriggerMetric(writer http.ResponseWriter, request *http.Request) {
 	triggerID := middleware.GetTriggerID(request)
 	metricName := request.URL.Query().Get("name")
-	if metricName == "" {
-		render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("Metric name can not be empty")))
-		return
-	}
 	if err := controller.DeleteTriggerMetric(database, metricName, triggerID); err != nil {
 		render.Render(writer, request, err)
 	}


### PR DESCRIPTION
Sometimes metric name can be blank, so empty string check is redundant.

Moira doesn't have to throw error when metric name is empty.

![firefox_2018-04-16_17-08-14](https://user-images.githubusercontent.com/5277948/38808289-0bc04020-4199-11e8-89dd-8306044ba74e.png)
