### PR TITLE
Change default trigger state to TTLState

### DIFF
--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -44,7 +44,7 @@ func saveTrigger(dataBase moira.Database, trigger *moira.Trigger, triggerID stri
 	} else {
 		lastCheck = moira.CheckData{
 			Metrics: make(map[string]moira.MetricState),
-			State:   checker.OK,
+			State:   checker.ToTriggerState(*trigger.TTLState),
 		}
 		lastCheck.UpdateScore()
 	}

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -42,9 +42,13 @@ func saveTrigger(dataBase moira.Database, trigger *moira.Trigger, triggerID stri
 			}
 		}
 	} else {
+		triggerState := checker.NODATA
+		if trigger.TTLState != nil {
+			triggerState = checker.ToTriggerState(*trigger.TTLState)
+		}
 		lastCheck = moira.CheckData{
 			Metrics: make(map[string]moira.MetricState),
-			State:   checker.ToTriggerState(*trigger.TTLState),
+			State:   triggerState,
 		}
 		lastCheck.UpdateScore()
 	}

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -44,7 +44,7 @@ func saveTrigger(dataBase moira.Database, trigger *moira.Trigger, triggerID stri
 	} else {
 		lastCheck = moira.CheckData{
 			Metrics: make(map[string]moira.MetricState),
-			State:   checker.NODATA,
+			State:   checker.OK,
 		}
 		lastCheck.UpdateScore()
 	}

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -151,6 +151,113 @@ func TestSaveTrigger(t *testing.T) {
 	})
 }
 
+func TestVariousTtlState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+	var ttlState, actualTtlState string
+
+	beginning := time.Unix(0, 0)
+	triggerID := uuid.NewV4().String()
+	trigger := moira.Trigger{ID: triggerID, TTLState: &ttlState}
+	triggerModel := dto.TriggerModel{ID: triggerID, TTLState: &actualTtlState}
+
+	Convey("Various TTLState", t, func() {
+		Convey("NODATA TTLState", func() {
+			ttlState = checker.NODATA
+			actualTtlState = checker.NODATA
+			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
+			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
+			So(err, ShouldBeNil)
+			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
+
+			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
+			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
+			actual, err := GetTrigger(dataBase, triggerID)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel})
+		})
+		Convey("ERROR TTLState", func() {
+			ttlState = checker.ERROR
+			actualTtlState = checker.ERROR
+			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
+			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
+			So(err, ShouldBeNil)
+			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
+
+			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
+			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
+			actual, err := GetTrigger(dataBase, triggerID)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+		})
+		Convey("WARNING TTLState", func() {
+			ttlState = checker.WARN
+			actualTtlState = checker.WARN
+			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
+			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
+			So(err, ShouldBeNil)
+			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
+
+			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
+			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
+			actual, err := GetTrigger(dataBase, triggerID)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+		})
+		Convey("OK TTLState", func() {
+			ttlState = checker.OK
+			actualTtlState = checker.OK
+			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
+			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
+			So(err, ShouldBeNil)
+			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
+
+			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
+			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
+			actual, err := GetTrigger(dataBase, triggerID)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+
+		})
+		Convey("DEL TTLState", func() {
+			ttlState = checker.DEL
+			actualTtlState = checker.OK
+			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
+			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
+			So(err, ShouldBeNil)
+			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
+
+			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
+			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
+			actual, err := GetTrigger(dataBase, triggerID)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+		})
+	})
+}
+
 func TestGetTrigger(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -156,104 +156,95 @@ func TestVariousTtlState(t *testing.T) {
 	defer mockCtrl.Finish()
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 
-	var ttlState, actualTtlState string
+	var ttlState string
 
-	beginning := time.Unix(0, 0)
 	triggerID := uuid.NewV4().String()
 	trigger := moira.Trigger{ID: triggerID, TTLState: &ttlState}
-	triggerModel := dto.TriggerModel{ID: triggerID, TTLState: &actualTtlState}
+	lastCheck := moira.CheckData{
+		Metrics: make(map[string]moira.MetricState),
+		State:   checker.NODATA,
+		Score:   1000,
+	}
 
 	Convey("Various TTLState", t, func() {
 		Convey("NODATA TTLState", func() {
 			ttlState = checker.NODATA
-			actualTtlState = checker.NODATA
+			lastCheck.State = checker.NODATA
+			actualLastCheck := lastCheck
+
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
 			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-
-			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
-			actual, err := GetTrigger(dataBase, triggerID)
-			So(err, ShouldBeNil)
-			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel})
+			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
+
 		Convey("ERROR TTLState", func() {
 			ttlState = checker.ERROR
-			actualTtlState = checker.ERROR
+			lastCheck.State = checker.ERROR
+			actualLastCheck := lastCheck
+
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
 			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-
-			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
-			actual, err := GetTrigger(dataBase, triggerID)
-			So(err, ShouldBeNil)
-			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
-		Convey("WARNING TTLState", func() {
+
+		Convey("WARN TTLState", func() {
 			ttlState = checker.WARN
-			actualTtlState = checker.WARN
+			lastCheck.State = checker.WARN
+			actualLastCheck := lastCheck
+
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
 			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-
-			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
-			actual, err := GetTrigger(dataBase, triggerID)
-			So(err, ShouldBeNil)
-			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
+
 		Convey("OK TTLState", func() {
 			ttlState = checker.OK
-			actualTtlState = checker.OK
+			lastCheck.State = checker.OK
+			actualLastCheck := lastCheck
+
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
 			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-
-			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
-			actual, err := GetTrigger(dataBase, triggerID)
-			So(err, ShouldBeNil)
-			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
-
+			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
+
 		Convey("DEL TTLState", func() {
 			ttlState = checker.DEL
-			actualTtlState = checker.OK
+			lastCheck.State = checker.OK
+			actualLastCheck := lastCheck
+
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
 			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-
-			dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-			dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
-			actual, err := GetTrigger(dataBase, triggerID)
-			So(err, ShouldBeNil)
-			So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
+			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
 	})
 }

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -170,81 +170,76 @@ func TestVariousTtlState(t *testing.T) {
 		Convey("NODATA TTLState", func() {
 			ttlState = checker.NODATA
 			lastCheck.State = checker.NODATA
-			actualLastCheck := lastCheck
+			lastCheck.Score = 1000
 
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
-			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &lastCheck).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
 
 		Convey("ERROR TTLState", func() {
 			ttlState = checker.ERROR
 			lastCheck.State = checker.ERROR
-			actualLastCheck := lastCheck
+			lastCheck.Score = 100
 
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
-			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &lastCheck).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
 
 		Convey("WARN TTLState", func() {
 			ttlState = checker.WARN
 			lastCheck.State = checker.WARN
-			actualLastCheck := lastCheck
+			lastCheck.Score = 1
 
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
-			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &lastCheck).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
 
 		Convey("OK TTLState", func() {
 			ttlState = checker.OK
 			lastCheck.State = checker.OK
-			actualLastCheck := lastCheck
+			lastCheck.Score = 0
 
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
-			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &lastCheck).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
 
 		Convey("DEL TTLState", func() {
 			ttlState = checker.DEL
 			lastCheck.State = checker.OK
-			actualLastCheck := lastCheck
+			lastCheck.Score = 0
 
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
-			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, database.ErrNil)
-			dataBase.EXPECT().SetTriggerLastCheck(triggerID, gomock.Any()).Return(nil)
+			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(moira.CheckData{}, database.ErrNil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &lastCheck).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-			So(actualLastCheck, ShouldResemble, lastCheck)
 		})
 	})
 }

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -2,16 +2,18 @@ package controller
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/api"
 	"github.com/moira-alert/moira/api/dto"
+	"github.com/moira-alert/moira/checker"
 	"github.com/moira-alert/moira/database"
 	"github.com/moira-alert/moira/mock/moira-alert"
 	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
-	"time"
 )
 
 func TestUpdateTrigger(t *testing.T) {
@@ -156,14 +158,14 @@ func TestGetTrigger(t *testing.T) {
 	triggerID := uuid.NewV4().String()
 	triggerModel := dto.TriggerModel{ID: triggerID}
 	trigger := *(triggerModel.ToMoiraTrigger())
-	begging := time.Unix(0, 0)
+	beginning := time.Unix(0, 0)
 	now := time.Now()
 	tomorrow := now.Add(time.Hour * 24)
 	yesterday := now.Add(-time.Hour * 24)
 
 	Convey("Has trigger no throttling", t, func() {
 		dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-		dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(begging, begging)
+		dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(beginning, beginning)
 		actual, err := GetTrigger(dataBase, triggerID)
 		So(err, ShouldBeNil)
 		So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})
@@ -171,7 +173,7 @@ func TestGetTrigger(t *testing.T) {
 
 	Convey("Has trigger has throttling", t, func() {
 		dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-		dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(tomorrow, begging)
+		dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(tomorrow, beginning)
 		actual, err := GetTrigger(dataBase, triggerID)
 		So(err, ShouldBeNil)
 		So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: tomorrow.Unix()})
@@ -179,7 +181,7 @@ func TestGetTrigger(t *testing.T) {
 
 	Convey("Has trigger has old throttling", t, func() {
 		dataBase.EXPECT().GetTrigger(triggerID).Return(trigger, nil)
-		dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(yesterday, begging)
+		dataBase.EXPECT().GetTriggerThrottling(triggerID).Return(yesterday, beginning)
 		actual, err := GetTrigger(dataBase, triggerID)
 		So(err, ShouldBeNil)
 		So(actual, ShouldResemble, &dto.Trigger{TriggerModel: triggerModel, Throttling: 0})

--- a/checker/check.go
+++ b/checker/check.go
@@ -147,8 +147,8 @@ func (triggerChecker *TriggerChecker) handleErrorCheck(checkData moira.CheckData
 		}
 	case ErrTriggerHasOnlyWildcards:
 		triggerChecker.Logger.Debugf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
-		if len(checkData.Metrics) == 0 && triggerChecker.ttlState != OK && triggerChecker.ttlState != DEL {
-			checkData.State = NODATA
+		if len(checkData.Metrics) == 0 {
+			checkData.State = toTriggerState(triggerChecker.ttlState)
 			checkData.Message = checkingError.Error()
 			if triggerChecker.ttl == 0 || triggerChecker.ttlState == DEL {
 				return checkData, nil

--- a/checker/check.go
+++ b/checker/check.go
@@ -147,10 +147,11 @@ func (triggerChecker *TriggerChecker) handleErrorCheck(checkData moira.CheckData
 		}
 	case ErrTriggerHasOnlyWildcards:
 		triggerChecker.Logger.Debugf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
-		if len(checkData.Metrics) == 0 {
-			checkData.State = ToTriggerState(triggerChecker.ttlState)
+		triggerState := ToTriggerState(triggerChecker.ttlState)
+		if len(checkData.Metrics) == 0 && triggerState != OK {
+			checkData.State = triggerState
 			checkData.Message = checkingError.Error()
-			if triggerChecker.ttl == 0 || triggerChecker.ttlState == DEL {
+			if triggerChecker.ttl == 0 {
 				return checkData, nil
 			}
 		}

--- a/checker/check.go
+++ b/checker/check.go
@@ -148,7 +148,7 @@ func (triggerChecker *TriggerChecker) handleErrorCheck(checkData moira.CheckData
 	case ErrTriggerHasOnlyWildcards:
 		triggerChecker.Logger.Debugf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
 		if len(checkData.Metrics) == 0 {
-			checkData.State = toTriggerState(triggerChecker.ttlState)
+			checkData.State = ToTriggerState(triggerChecker.ttlState)
 			checkData.Message = checkingError.Error()
 			if triggerChecker.ttl == 0 || triggerChecker.ttlState == DEL {
 				return checkData, nil

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -785,7 +785,7 @@ func TestHandleErrorCheck(t *testing.T) {
 		dataBase.EXPECT().PushNotificationEvent(gomock.Any(), true).Return(nil)
 		actual, err := triggerChecker.handleErrorCheck(checkData, ErrTriggerHasOnlyWildcards{})
 		expected := moira.CheckData{
-			State:          NODATA,
+			State:          ERROR,
 			Timestamp:      checkData.Timestamp,
 			EventTimestamp: checkData.Timestamp,
 			Message:        "Trigger never received metrics",

--- a/checker/state.go
+++ b/checker/state.go
@@ -16,3 +16,10 @@ func toMetricState(state string) string {
 	}
 	return state
 }
+
+func toTriggerState(state string) string {
+	if state == DEL {
+		return OK
+	}
+	return state
+}

--- a/checker/state.go
+++ b/checker/state.go
@@ -17,7 +17,8 @@ func toMetricState(state string) string {
 	return state
 }
 
-func toTriggerState(state string) string {
+// ToTriggerState is an auxiliary function to handle trigger state properly.
+func ToTriggerState(state string) string {
 	if state == DEL {
 		return OK
 	}

--- a/checker/trigger_test.go
+++ b/checker/trigger_test.go
@@ -2,13 +2,14 @@ package checker
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/database"
 	"github.com/moira-alert/moira/mock/moira-alert"
 	"github.com/op/go-logging"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestInitTriggerChecker(t *testing.T) {


### PR DESCRIPTION
When you create a new trigger, switch its state as `TTLState` looks like a great idea. `TTLState` is an option which defines which state to set on trigger when no data provided. So, if you want to treat `NODATA` as `OK` its quite obvious to create trigger in `OK` state.

The second part is checking trigger without any metric inside. I think, we should set `TTLState` in this case too.