### PR TITLE
[feature] Better NODATA protection

### DIFF
--- a/api/controller/health.go
+++ b/api/controller/health.go
@@ -12,7 +12,13 @@ func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorRe
 	if err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}
-	return &dto.NotifierState{State: state}, nil
+
+	notifierState := dto.NotifierState{State: state}
+	if state == dto.ERROR {
+		notifierState.Message = dto.ErrorMessage
+	}
+
+	return &notifierState, nil
 }
 
 // UpdateNotifierState update current notifier state

--- a/api/controller/health.go
+++ b/api/controller/health.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moira-alert/moira/api/dto"
 )
 
+// GetNotifierState return current notifier state
 func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorResponse) {
 	state, err := database.GetNotifierState()
 	if err != nil {
@@ -14,6 +15,7 @@ func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorRe
 	return &dto.NotifierState{State: state}, nil
 }
 
+// GetNotifierState update current notifier state
 func UpdateNotifierState(database moira.Database, state *dto.NotifierState) *api.ErrorResponse {
 	err := database.SetNotifierState(state.State)
 	if err != nil {

--- a/api/controller/health.go
+++ b/api/controller/health.go
@@ -1,0 +1,23 @@
+package controller
+
+import (
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/dto"
+)
+
+func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorResponse) {
+	state, err := database.GetNotifierState()
+	if err != nil {
+		return nil, api.ErrorInternalServer(err)
+	}
+	return &dto.NotifierState{State: state}, nil
+}
+
+func UpdateNotifierState(database moira.Database, state *dto.NotifierState) *api.ErrorResponse {
+	err := database.SetNotifierState(state.State)
+	if err != nil {
+		return api.ErrorInternalServer(err)
+	}
+	return nil
+}

--- a/api/controller/health.go
+++ b/api/controller/health.go
@@ -15,7 +15,7 @@ func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorRe
 	return &dto.NotifierState{State: state}, nil
 }
 
-// GetNotifierState update current notifier state
+// UpdateNotifierState update current notifier state
 func UpdateNotifierState(database moira.Database, state *dto.NotifierState) *api.ErrorResponse {
 	err := database.SetNotifierState(state.State)
 	if err != nil {

--- a/api/controller/health_test.go
+++ b/api/controller/health_test.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/moira-alert/moira/api/dto"
+	"github.com/moira-alert/moira/mock/moira-alert"
+	"github.com/moira-alert/moira/notifier/selfstate"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetNotifierState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+	defer mockCtrl.Finish()
+
+	Convey("On startup should return OK", t, func() {
+		expectedState := dto.NotifierState{State: selfstate.OK}
+		dataBase.EXPECT().GetNotifierState().Return(selfstate.OK, nil)
+		actualState, err := GetNotifierState(dataBase)
+
+		So(*actualState, ShouldResemble, expectedState)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUpdateNotifierState(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+	defer mockCtrl.Finish()
+
+	Convey("Setting OK notifier state", t, func() {
+		expectedState := dto.NotifierState{State: selfstate.OK}
+		dataBase.EXPECT().SetNotifierState(selfstate.OK).Return(nil)
+		dataBase.EXPECT().GetNotifierState().Return(selfstate.OK, nil)
+
+		err := UpdateNotifierState(dataBase, &dto.NotifierState{State: selfstate.OK})
+		So(err, ShouldBeNil)
+
+		actualState, err := GetNotifierState(dataBase)
+
+		So(*actualState, ShouldResemble, expectedState)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Setting ERROR notifier state", t, func() {
+		expectedState := dto.NotifierState{State: selfstate.ERROR}
+		dataBase.EXPECT().SetNotifierState(selfstate.ERROR).Return(nil)
+		dataBase.EXPECT().GetNotifierState().Return(selfstate.ERROR, nil)
+
+		err := UpdateNotifierState(dataBase, &dto.NotifierState{State: selfstate.ERROR})
+		So(err, ShouldBeNil)
+
+		actualState, err := GetNotifierState(dataBase)
+
+		So(*actualState, ShouldResemble, expectedState)
+		So(err, ShouldBeNil)
+	})
+
+}

--- a/api/controller/health_test.go
+++ b/api/controller/health_test.go
@@ -45,7 +45,7 @@ func TestUpdateNotifierState(t *testing.T) {
 	})
 
 	Convey("Setting ERROR notifier state", t, func() {
-		expectedState := dto.NotifierState{State: selfstate.ERROR}
+		expectedState := dto.NotifierState{State: selfstate.ERROR, Message: dto.ErrorMessage}
 		dataBase.EXPECT().SetNotifierState(selfstate.ERROR).Return(nil)
 		dataBase.EXPECT().GetNotifierState().Return(selfstate.ERROR, nil)
 

--- a/api/dto/health.go
+++ b/api/dto/health.go
@@ -1,0 +1,30 @@
+// nolint
+package dto
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	OK    = "OK"
+	ERROR = "ERROR"
+)
+
+type NotifierState struct {
+	State string `json:"state"`
+}
+
+func (*NotifierState) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+func (contact *NotifierState) Bind(r *http.Request) error {
+	if contact.State == "" {
+		return fmt.Errorf("state can not be empty")
+	}
+	if contact.State != OK && contact.State != ERROR {
+		return fmt.Errorf("invalid state '%s'. State should be one of: <OK|ERROR>", contact.State)
+	}
+	return nil
+}

--- a/api/dto/health.go
+++ b/api/dto/health.go
@@ -7,12 +7,14 @@ import (
 )
 
 const (
-	OK    = "OK"
-	ERROR = "ERROR"
+	OK           = "OK"
+	ERROR        = "ERROR"
+	ErrorMessage = "Something unexpected happened with Moira, so we temporarily turned off the notification mailing. We are already working on the problem and will fix it in the near future."
 )
 
 type NotifierState struct {
-	State string `json:"state"`
+	State   string `json:"state"`
+	Message string `json:"message,omitempty"`
 }
 
 func (*NotifierState) Render(w http.ResponseWriter, r *http.Request) error {

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -42,6 +42,7 @@ func NewHandler(db moira.Database, log moira.Logger, config *api.Config, configF
 		router.Route("/contact", contact)
 		router.Route("/subscription", subscription)
 		router.Route("/notification", notification)
+		router.Route("/health", health)
 	})
 	if config.EnableCORS {
 		return cors.AllowAll().Handler(router)

--- a/api/handler/health.go
+++ b/api/handler/health.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/controller"
+	"github.com/moira-alert/moira/api/dto"
+)
+
+func health(router chi.Router) {
+	router.Get("/notifier", getNotifierState)
+	router.Put("/notifier", setNotifierState)
+}
+
+func getNotifierState(writer http.ResponseWriter, request *http.Request) {
+	state, err := controller.GetNotifierState(database)
+	if err != nil {
+		render.Render(writer, request, err)
+		return
+	}
+
+	if err := render.Render(writer, request, state); err != nil {
+		render.Render(writer, request, api.ErrorRender(err))
+		return
+	}
+}
+
+func setNotifierState(writer http.ResponseWriter, request *http.Request) {
+	state := &dto.NotifierState{}
+	if err := render.Bind(request, state); err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err))
+		return
+	}
+
+	if err := controller.UpdateNotifierState(database, state); err != nil {
+		render.Render(writer, request, err)
+		return
+	}
+
+	if err := render.Render(writer, request, state); err != nil {
+		render.Render(writer, request, api.ErrorRender(err))
+		return
+	}
+
+}

--- a/database/redis/selfstate.go
+++ b/database/redis/selfstate.go
@@ -43,6 +43,8 @@ func (connector *DbConnector) GetNotifierState() (string, error) {
 	if err == redis.ErrNil {
 		ts = selfstate.OK
 		err = connector.SetNotifierState(ts)
+	} else if err != nil {
+		ts = selfstate.ERROR
 	}
 	return ts, err
 }

--- a/database/redis/selfstate.go
+++ b/database/redis/selfstate.go
@@ -1,6 +1,9 @@
 package redis
 
-import "github.com/garyburd/redigo/redis"
+import (
+	"github.com/garyburd/redigo/redis"
+	"github.com/moira-alert/moira/notifier/selfstate"
+)
 
 // UpdateMetricsHeartbeat increments redis counter
 func (connector *DbConnector) UpdateMetricsHeartbeat() error {
@@ -32,5 +35,24 @@ func (connector *DbConnector) GetChecksUpdatesCount() (int64, error) {
 	return ts, err
 }
 
+func (connector *DbConnector) GetNotifierState() (string, error) {
+	c := connector.pool.Get()
+	defer c.Close()
+	ts, err := redis.String(c.Do("GET", selfStateNotifierHealth))
+	if err == redis.ErrNil {
+		ts = selfstate.OK
+		err = connector.SetNotifierState(ts)
+	}
+	return ts, err
+}
+
+func (connector *DbConnector) SetNotifierState(health string) error {
+	c := connector.pool.Get()
+	defer c.Close()
+
+	return c.Send("SET", selfStateNotifierHealth, health)
+}
+
 var selfStateMetricsHeartbeatKey = "moira-selfstate:metrics-heartbeat"
 var selfStateChecksCounterKey = "moira-selfstate:checks-counter"
+var selfStateNotifierHealth = "moira-selfstate:notifier-health"

--- a/database/redis/selfstate.go
+++ b/database/redis/selfstate.go
@@ -35,6 +35,7 @@ func (connector *DbConnector) GetChecksUpdatesCount() (int64, error) {
 	return ts, err
 }
 
+// GetNotifierState return current notifier state: <OK|ERROR>
 func (connector *DbConnector) GetNotifierState() (string, error) {
 	c := connector.pool.Get()
 	defer c.Close()
@@ -46,6 +47,7 @@ func (connector *DbConnector) GetNotifierState() (string, error) {
 	return ts, err
 }
 
+// SetNotifierState update current notifier state: <OK|ERROR>
 func (connector *DbConnector) SetNotifierState(health string) error {
 	c := connector.pool.Get()
 	defer c.Close()

--- a/interfaces.go
+++ b/interfaces.go
@@ -12,6 +12,8 @@ type Database interface {
 	UpdateMetricsHeartbeat() error
 	GetMetricsUpdatesCount() (int64, error)
 	GetChecksUpdatesCount() (int64, error)
+	GetNotifierState() (string, error)
+	SetNotifierState(string) error
 
 	// Tag storing
 	GetTagNames() ([]string, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -299,6 +299,19 @@ func (mr *MockDatabaseMockRecorder) GetNotifications(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifications", reflect.TypeOf((*MockDatabase)(nil).GetNotifications), arg0, arg1)
 }
 
+// GetNotifierState mocks base method
+func (m *MockDatabase) GetNotifierState() (string, error) {
+	ret := m.ctrl.Call(m, "GetNotifierState")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNotifierState indicates an expected call of GetNotifierState
+func (mr *MockDatabaseMockRecorder) GetNotifierState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifierState", reflect.TypeOf((*MockDatabase)(nil).GetNotifierState))
+}
+
 // GetPatternMetrics mocks base method
 func (m *MockDatabase) GetPatternMetrics(arg0 string) ([]string, error) {
 	ret := m.ctrl.Call(m, "GetPatternMetrics", arg0)
@@ -795,6 +808,18 @@ func (m *MockDatabase) SaveTrigger(arg0 string, arg1 *moira.Trigger) error {
 // SaveTrigger indicates an expected call of SaveTrigger
 func (mr *MockDatabaseMockRecorder) SaveTrigger(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTrigger", reflect.TypeOf((*MockDatabase)(nil).SaveTrigger), arg0, arg1)
+}
+
+// SetNotifierState mocks base method
+func (m *MockDatabase) SetNotifierState(arg0 string) error {
+	ret := m.ctrl.Call(m, "SetNotifierState", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetNotifierState indicates an expected call of SetNotifierState
+func (mr *MockDatabaseMockRecorder) SetNotifierState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNotifierState", reflect.TypeOf((*MockDatabase)(nil).SetNotifierState), arg0)
 }
 
 // SetTriggerCheckLock mocks base method

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -52,11 +52,9 @@ func (worker *FetchNotificationsWorker) processScheduledNotifications() error {
 	}
 	state, err := worker.Database.GetNotifierState()
 	if err != nil {
-		worker.Logger.Error("can't get current notifier state")
 		return fmt.Errorf("can't get current notifier state")
 	}
 	if state != "OK" {
-		worker.Logger.Errorf("Stop sending notifications. Current notifier state: %v", state)
 		return fmt.Errorf("stop sending notifications. Current notifier state: %v", state)
 	}
 

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -50,6 +50,16 @@ func (worker *FetchNotificationsWorker) processScheduledNotifications() error {
 	if err != nil {
 		return err
 	}
+	state, err := worker.Database.GetNotifierState()
+	if err != nil {
+		worker.Logger.Error("can't get current notifier state")
+		return fmt.Errorf("can't get current notifier state")
+	}
+	if state != "OK" {
+		worker.Logger.Errorf("Stop sending notifications. Current notifier state: %v", state)
+		return fmt.Errorf("stop sending notifications. Current notifier state: %v", state)
+	}
+
 	notificationPackages := make(map[string]*notifier.NotificationPackage)
 	for _, notification := range notifications {
 		packageKey := fmt.Sprintf("%s:%s:%s", notification.Contact.Type, notification.Contact.Value, notification.Event.TriggerID)

--- a/notifier/notifications/notifications_test.go
+++ b/notifier/notifications/notifications_test.go
@@ -89,6 +89,7 @@ func TestProcessScheduledEvent(t *testing.T) {
 		}
 		notifier.EXPECT().Send(&pkg1, gomock.Any())
 		notifier.EXPECT().Send(&pkg2, gomock.Any())
+		dataBase.EXPECT().GetNotifierState().Return("OK", nil)
 		err := worker.processScheduledNotifications()
 		So(err, ShouldBeEmpty)
 		mockCtrl.Finish()
@@ -113,6 +114,7 @@ func TestProcessScheduledEvent(t *testing.T) {
 		}
 
 		notifier.EXPECT().Send(&pkg, gomock.Any())
+		dataBase.EXPECT().GetNotifierState().Return("OK", nil)
 		err := worker.processScheduledNotifications()
 		So(err, ShouldBeEmpty)
 		mockCtrl.Finish()
@@ -158,6 +160,7 @@ func TestGoRoutine(t *testing.T) {
 	dataBase.EXPECT().FetchNotifications(gomock.Any()).Return([]*moira.ScheduledNotification{&notification1}, nil)
 	notifier.EXPECT().Send(&pkg, gomock.Any()).Do(func(f ...interface{}) { close(shutdown) })
 	notifier.EXPECT().StopSenders()
+	dataBase.EXPECT().GetNotifierState().Return("OK", nil)
 
 	worker.Start()
 	waitTestEnd(shutdown, worker)

--- a/notifier/selfstate/health.go
+++ b/notifier/selfstate/health.go
@@ -1,6 +1,7 @@
 package selfstate
 
+// Notifier states
 const (
-	OK    = "OK"
-	ERROR = "ERROR"
+	OK    = "OK"    // OK means notifier is healthy
+	ERROR = "ERROR" // ERROR means notifier is stopped, admin intervention is required
 )

--- a/notifier/selfstate/health.go
+++ b/notifier/selfstate/health.go
@@ -1,0 +1,6 @@
+package selfstate
+
+const (
+	OK    = "OK"
+	ERROR = "ERROR"
+)

--- a/notifier/selfstate/selfstate.go
+++ b/notifier/selfstate/selfstate.go
@@ -93,7 +93,7 @@ func (selfCheck *SelfCheckWorker) check(nowTS int64, lastMetricReceivedTS, redis
 			return
 		}
 
-		if notifierState != OK && err2 == nil {
+		if notifierState != OK {
 			selfCheck.Log.Errorf("Notifier state: %v. Send message.", notifierState)
 			message := fmt.Sprintf("Notifier state: %v. Please, check Moira services.", notifierState)
 			selfCheck.sendErrorMessages(message, 0, 0)
@@ -135,7 +135,6 @@ func (selfCheck *SelfCheckWorker) sendErrorMessages(message string, currentValue
 			Events: []moira.NotificationEvent{
 				{
 					Timestamp: time.Now().Unix(),
-					OldState:  "NODATA",
 					State:     "ERROR",
 					Metric:    message,
 					Value:     &val,

--- a/notifier/selfstate/selfstate.go
+++ b/notifier/selfstate/selfstate.go
@@ -111,8 +111,8 @@ func (selfCheck *SelfCheckWorker) check(nowTS int64, lastMetricReceivedTS, redis
 		}
 
 		if len(events) > 0 {
-			eventsJson, _ := json.Marshal(events)
-			selfCheck.Log.Errorf("Selfstate check. Send package of %v notification events: %s", len(events), eventsJson)
+			eventsJSON, _ := json.Marshal(events)
+			selfCheck.Log.Errorf("Selfstate check. Send package of %v notification events: %s", len(events), eventsJSON)
 			selfCheck.sendErrorMessages(&events)
 			*nextSendErrorMessage = nowTS + selfCheck.Config.NoticeIntervalSeconds
 		}

--- a/notifier/selfstate/selfstate.go
+++ b/notifier/selfstate/selfstate.go
@@ -81,7 +81,7 @@ func (selfCheck *SelfCheckWorker) check(nowTS int64, lastMetricReceivedTS, redis
 	}
 	notifierState, err2 := selfCheck.DB.GetNotifierState()
 	if err2 != nil {
-		selfCheck.Log.Errorf("can't check notifier state: %v", err2)
+		selfCheck.Log.Errorf("Can't check notifier state: %v", err2)
 	}
 
 	if *nextSendErrorMessage < nowTS {
@@ -135,6 +135,7 @@ func (selfCheck *SelfCheckWorker) sendErrorMessages(message string, currentValue
 			Events: []moira.NotificationEvent{
 				{
 					Timestamp: time.Now().Unix(),
+					OldState:  "NODATA",
 					State:     "ERROR",
 					Metric:    message,
 					Value:     &val,
@@ -150,6 +151,6 @@ func (selfCheck *SelfCheckWorker) sendErrorMessages(message string, currentValue
 func (selfCheck *SelfCheckWorker) setNotifierState(state string) {
 	err := selfCheck.DB.SetNotifierState(state)
 	if err != nil {
-		selfCheck.Log.Errorf("can't set notifier state: %v", err)
+		selfCheck.Log.Errorf("Can't set notifier state: %v", err)
 	}
 }

--- a/notifier/selfstate/selfstate.go
+++ b/notifier/selfstate/selfstate.go
@@ -79,10 +79,7 @@ func (selfCheck *SelfCheckWorker) check(nowTS int64, lastMetricReceivedTS, redis
 			*lastCheckTS = nowTS
 		}
 	}
-	notifierState, err2 := selfCheck.DB.GetNotifierState()
-	if err2 != nil {
-		selfCheck.Log.Errorf("Can't check notifier state: %v", err2)
-	}
+	notifierState, _ := selfCheck.DB.GetNotifierState()
 
 	if *nextSendErrorMessage < nowTS {
 		if *redisLastCheckTS < nowTS-selfCheck.Config.RedisDisconnectDelaySeconds {

--- a/notifier/selfstate/selfstate_test.go
+++ b/notifier/selfstate/selfstate_test.go
@@ -43,6 +43,7 @@ func TestDatabaseDisconnected(t *testing.T) {
 	mock.selfCheckWorker.Start()
 	Convey("Database disconnected", t, func() {
 		Convey("Should notify admin", func() {
+			var events []moira.NotificationEvent
 			var sendingWG sync.WaitGroup
 			err := fmt.Errorf("DataBase doesn't work")
 			mock.database.EXPECT().GetMetricsUpdatesCount().Return(int64(1), nil)
@@ -54,7 +55,9 @@ func TestDatabaseDisconnected(t *testing.T) {
 			lastCheckTS = now.Unix()
 			nextSendErrorMessage = now.Add(-time.Second * 5).Unix()
 			lastMetricReceivedTS = now.Unix()
-			expectedPackage := configureNotificationPackage(adminContact, mock.conf.RedisDisconnectDelaySeconds, now.Unix()-redisLastCheckTS, "Redis disconnected")
+			appendNotificationEvents(&events, "Redis disconnected", now.Unix()-redisLastCheckTS)
+			appendNotificationEvents(&events, "Notifier state: ERROR. Events are not sending to recipients", 0)
+			expectedPackage := configureNotificationPackage(adminContact, &events)
 
 			mock.notif.EXPECT().Send(&expectedPackage, &sendingWG)
 			mock.selfCheckWorker.check(now.Unix(), &lastMetricReceivedTS, &redisLastCheckTS, &lastCheckTS, &nextSendErrorMessage, &metricsCount, &checksCount)
@@ -87,6 +90,7 @@ func TestMoiraCacheDoesNotReceivedNewMetrics(t *testing.T) {
 	mock := configureWorker(t)
 	mock.selfCheckWorker.Start()
 	Convey("Should notify admin", t, func() {
+		var events []moira.NotificationEvent
 		var sendingWG sync.WaitGroup
 		mock.database.EXPECT().GetMetricsUpdatesCount().Return(int64(1), nil)
 		mock.database.EXPECT().GetChecksUpdatesCount().Return(int64(1), nil)
@@ -99,10 +103,12 @@ func TestMoiraCacheDoesNotReceivedNewMetrics(t *testing.T) {
 		metricsCount = 1
 
 		callingNow := now.Add(time.Second * 2)
-		expectedPackage := configureNotificationPackage(adminContact, mock.conf.LastMetricReceivedDelaySeconds, callingNow.Unix()-lastMetricReceivedTS, "Moira-Filter does not received new metrics")
+		appendNotificationEvents(&events, "Moira-Filter does not received new metrics", callingNow.Unix()-lastMetricReceivedTS)
+		appendNotificationEvents(&events, "Notifier state: ERROR. Events are not sending to recipients", 0)
+		expectedPackage := configureNotificationPackage(adminContact, &events)
 
-		mock.database.EXPECT().GetNotifierState().Return("OK", nil)
 		mock.database.EXPECT().SetNotifierState("ERROR").Return(nil)
+		mock.database.EXPECT().GetNotifierState().Return("ERROR", nil)
 		mock.notif.EXPECT().Send(&expectedPackage, &sendingWG)
 		mock.selfCheckWorker.check(callingNow.Unix(), &lastMetricReceivedTS, &redisLastCheckTS, &lastCheckTS, &nextSendErrorMessage, &metricsCount, &checksCount)
 
@@ -133,6 +139,7 @@ func TestMoiraCheckerDoesNotChecksTriggers(t *testing.T) {
 	mock := configureWorker(t)
 	mock.selfCheckWorker.Start()
 	Convey("Should notify admin", t, func() {
+		var events []moira.NotificationEvent
 		var sendingWG sync.WaitGroup
 		mock.database.EXPECT().GetMetricsUpdatesCount().Return(int64(1), nil)
 		mock.database.EXPECT().GetChecksUpdatesCount().Return(int64(1), nil)
@@ -145,10 +152,13 @@ func TestMoiraCheckerDoesNotChecksTriggers(t *testing.T) {
 		checksCount = 1
 
 		callingNow := now.Add(time.Second * 2)
-		expectedPackage := configureNotificationPackage(adminContact, mock.conf.LastCheckDelaySeconds, callingNow.Unix()-lastCheckTS, "Moira-Checker does not checks triggers")
+		//expectedPackage := configureNotificationPackage(adminContact, mock.conf.LastCheckDelaySeconds, callingNow.Unix()-lastCheckTS, "Moira-Checker does not checks triggers")
+		appendNotificationEvents(&events, "Moira-Checker does not checks triggers", callingNow.Unix()-lastCheckTS)
+		appendNotificationEvents(&events, "Notifier state: ERROR. Events are not sending to recipients", 0)
+		expectedPackage := configureNotificationPackage(adminContact, &events)
 
-		mock.database.EXPECT().GetNotifierState().Return("OK", nil)
 		mock.database.EXPECT().SetNotifierState("ERROR").Return(nil)
+		mock.database.EXPECT().GetNotifierState().Return("ERROR", nil)
 		mock.notif.EXPECT().Send(&expectedPackage, &sendingWG)
 		mock.selfCheckWorker.check(callingNow.Unix(), &lastMetricReceivedTS, &redisLastCheckTS, &lastCheckTS, &nextSendErrorMessage, &metricsCount, &checksCount)
 
@@ -200,7 +210,7 @@ func TestRunGoRoutine(t *testing.T) {
 		err := fmt.Errorf("DataBase doesn't work")
 		database.EXPECT().GetMetricsUpdatesCount().Return(int64(1), nil).Times(11)
 		database.EXPECT().GetChecksUpdatesCount().Return(int64(1), err).Times(11)
-		database.EXPECT().GetNotifierState().Return("ERROR", err).Times(11)
+		database.EXPECT().GetNotifierState().Return("ERROR", err).Times(3)
 		notif.EXPECT().Send(gomock.Any(), gomock.Any()).Times(3)
 		selfStateWorker.Start()
 		time.Sleep(time.Second*11 + time.Millisecond*500)
@@ -248,25 +258,17 @@ func configureWorker(t *testing.T) *selfCheckWorkerMock {
 	}
 }
 
-func configureNotificationPackage(adminContact map[string]string, errorValue int64, currentValue int64, message string) notifier.NotificationPackage {
-	val := float64(currentValue)
+func configureNotificationPackage(adminContact map[string]string, events *[]moira.NotificationEvent) notifier.NotificationPackage {
 	return notifier.NotificationPackage{
 		Contact: moira.ContactData{
 			Type:  adminContact["type"],
 			Value: adminContact["value"],
 		},
 		Trigger: moira.TriggerData{
-			Name:       message,
-			ErrorValue: float64(errorValue),
+			Name:       "Moira health check",
+			ErrorValue: float64(0),
 		},
-		Events: []moira.NotificationEvent{
-			{
-				Timestamp: time.Now().Unix(),
-				State:     "ERROR",
-				Metric:    message,
-				Value:     &val,
-			},
-		},
+		Events:     *events,
 		DontResend: true,
 	}
 }

--- a/notifier/selfstate/selfstate_test.go
+++ b/notifier/selfstate/selfstate_test.go
@@ -47,7 +47,7 @@ func TestDatabaseDisconnected(t *testing.T) {
 			err := fmt.Errorf("DataBase doesn't work")
 			mock.database.EXPECT().GetMetricsUpdatesCount().Return(int64(1), nil)
 			mock.database.EXPECT().GetChecksUpdatesCount().Return(int64(1), err)
-			mock.database.EXPECT().GetNotifierState().Return("OK", err)
+			mock.database.EXPECT().GetNotifierState().Return("ERROR", err)
 
 			now := time.Now()
 			redisLastCheckTS = now.Add(-time.Second * 11).Unix()
@@ -173,9 +173,10 @@ func TestRunGoRoutine(t *testing.T) {
 		Contacts: []map[string]string{
 			adminContact,
 		},
-		RedisDisconnectDelaySeconds:    10,
+		RedisDisconnectDelaySeconds:    5,
 		LastMetricReceivedDelaySeconds: 60,
 		LastCheckDelaySeconds:          120,
+		NoticeIntervalSeconds:          3,
 	}
 
 	mockCtrl := gomock.NewController(t)
@@ -200,7 +201,7 @@ func TestRunGoRoutine(t *testing.T) {
 		database.EXPECT().GetMetricsUpdatesCount().Return(int64(1), nil).Times(11)
 		database.EXPECT().GetChecksUpdatesCount().Return(int64(1), err).Times(11)
 		database.EXPECT().GetNotifierState().Return("ERROR", err).Times(11)
-		notif.EXPECT().Send(gomock.Any(), gomock.Any()).Times(11)
+		notif.EXPECT().Send(gomock.Any(), gomock.Any()).Times(3)
 		selfStateWorker.Start()
 		time.Sleep(time.Second*11 + time.Millisecond*500)
 		selfStateWorker.Stop()


### PR DESCRIPTION
Сделал MVP.

Логика такая:
- Если фильтр не принимает новых метрик или чекер ничего не проверяет, то выставляем флаг в редисе
- Флаг можно поменять через API.
- Обратно флаг выставляется только вручную через API.