### PR TITLE
ErrWrongTriggerTarget -> ErrWrongTriggerTargets

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -159,7 +159,7 @@ func (triggerChecker *TriggerChecker) handleErrorCheck(checkData moira.CheckData
 		triggerChecker.Logger.Warningf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
 		checkData.State = EXCEPTION
 		checkData.Message = checkingError.Error()
-	case ErrWrongTriggerTarget, ErrTriggerHasSameTimeSeriesNames:
+	case ErrWrongTriggerTargets, ErrTriggerHasSameTimeSeriesNames:
 		checkData.State = EXCEPTION
 		checkData.Message = checkingError.Error()
 	default:

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -975,7 +975,7 @@ func TestHandleErrorCheck(t *testing.T) {
 
 		dataBase.EXPECT().PushNotificationEvent(gomock.Any(), true).Return(nil)
 
-		actual, err := triggerChecker.handleErrorCheck(checkData, ErrWrongTriggerTarget(2))
+		actual, err := triggerChecker.handleErrorCheck(checkData, ErrWrongTriggerTargets([]int{2}))
 		expected := moira.CheckData{
 			State:          EXCEPTION,
 			Timestamp:      checkData.Timestamp,

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -1108,7 +1108,7 @@ func TestHandleErrorCheck(t *testing.T) {
 
 		dataBase.EXPECT().PushNotificationEvent(gomock.Any(), true).Return(nil)
 
-		actual, err := triggerChecker.handleErrorCheck(checkData, ErrWrongTriggerTargets([]int{2}))
+		actual, err := triggerChecker.handleTriggerCheck(checkData, ErrWrongTriggerTargets([]int{2}))
 		expected := moira.CheckData{
 			State:          ERROR,
 			Timestamp:      checkData.Timestamp,

--- a/checker/timeseries.go
+++ b/checker/timeseries.go
@@ -49,13 +49,11 @@ func (triggerChecker *TriggerChecker) getTimeSeries(from, until int64) (*trigger
 
 	isSimpleTrigger := triggerChecker.trigger.IsSimple()
 
-EVALUATE:
 	for targetIndex, tar := range triggerChecker.trigger.Targets {
 		result, err := target.EvaluateTarget(triggerChecker.Database, tar, from, until, isSimpleTrigger)
 		if err != nil {
 			return nil, nil, err
 		}
-
 		if targetIndex == 0 {
 			triggerTimeSeries.Main = result.TimeSeries
 		} else {
@@ -69,11 +67,6 @@ EVALUATE:
 				}
 			case timeSeriesCount > 1:
 				wrongTriggerTargets = append(wrongTriggerTargets, targetIndex+1)
-				if targetIndex != len(triggerChecker.trigger.Targets)-1 {
-					continue
-				} else {
-					break EVALUATE
-				}
 			default:
 				triggerTimeSeries.Additional = append(triggerTimeSeries.Additional, result.TimeSeries[0])
 			}

--- a/checker/timeseries.go
+++ b/checker/timeseries.go
@@ -1,9 +1,9 @@
 package checker
 
 import (
+	"bytes"
 	"fmt"
 	"math"
-	"bytes"
 	"strconv"
 
 	"github.com/moira-alert/moira/expression"
@@ -30,7 +30,7 @@ func (err ErrWrongTriggerTargets) Error() string {
 	for tarInd, tar := range err {
 		wrongTargets.WriteString("t")
 		wrongTargets.WriteString(strconv.Itoa(tar))
-		if tarInd != len(err) - 1 {
+		if tarInd != len(err)-1 {
 			wrongTargets.WriteString(", ")
 		}
 	}
@@ -47,6 +47,8 @@ func (triggerChecker *TriggerChecker) getTimeSeries(from, until int64) (*trigger
 	metricsArr := make([]string, 0)
 
 	isSimpleTrigger := triggerChecker.trigger.IsSimple()
+
+EVALUATE:
 	for targetIndex, tar := range triggerChecker.trigger.Targets {
 		result, err := target.EvaluateTarget(triggerChecker.Database, tar, from, until, isSimpleTrigger)
 		if err != nil {
@@ -66,10 +68,10 @@ func (triggerChecker *TriggerChecker) getTimeSeries(from, until int64) (*trigger
 				}
 			case timeSeriesCount > 1:
 				wrongTriggerTargets = append(wrongTriggerTargets, targetIndex+1)
-				if targetIndex != len(triggerChecker.trigger.Targets) {
+				if targetIndex != len(triggerChecker.trigger.Targets)-1 {
 					continue
 				} else {
-					break
+					break EVALUATE
 				}
 			default:
 				triggerTimeSeries.Additional = append(triggerTimeSeries.Additional, result.TimeSeries[0])

--- a/checker/timeseries.go
+++ b/checker/timeseries.go
@@ -34,7 +34,8 @@ func (err ErrWrongTriggerTargets) Error() string {
 			wrongTargets.WriteString(", ")
 		}
 	}
-	return fmt.Sprintf("%s has more than one timeseries", wrongTargets.String())
+	wrongTargets.WriteString(" has more than one timeseries")
+	return wrongTargets.String()
 }
 
 func (triggerChecker *TriggerChecker) getTimeSeries(from, until int64) (*triggerTimeSeries, []string, error) {

--- a/checker/timeseries.go
+++ b/checker/timeseries.go
@@ -15,10 +15,10 @@ type triggerTimeSeries struct {
 	Additional []*target.TimeSeries
 }
 
-// ErrWrongTriggerTargets represents inconsistent number of timeseries
+// ErrWrongTriggerTargets represents targets with inconsistent number of timeseries
 type ErrWrongTriggerTargets []int
 
-// ErrWrongTriggerTarget implementation for given number of found timeseries
+// ErrWrongTriggerTarget implementation for list of invalid targets found
 func (err ErrWrongTriggerTargets) Error() string {
 	var countType []byte
 	if len(err) > 1 {

--- a/checker/timeseries_test.go
+++ b/checker/timeseries_test.go
@@ -199,14 +199,12 @@ func TestGetTimeSeries(t *testing.T) {
 			So(metrics, ShouldBeNil)
 		})
 
-		Convey("Three targets with many metrics in additional targets", func() {
-
+		Convey("Four targets with many metrics in additional targets", func() {
 			triggerChecker.trigger.Targets = []string{pattern, addPattern, pattern2, oneMorePattern}
 			triggerChecker.trigger.Patterns = []string{pattern, addPattern, pattern2, oneMorePattern}
 
 			dataList[addMetric2] = metricValues
 			dataList[metric2] = metricValues
-
 			dataList[oneMoreMetric1] = metricValues
 			dataList[oneMoreMetric2] = metricValues
 


### PR DESCRIPTION
Improvements for ErrWrongTriggerTarget and checker.getTimeSeries show all invalid targets

Master behavior:
![current_behavior](https://user-images.githubusercontent.com/5269320/42321258-bd931d9c-8071-11e8-8b45-8e9c7173f3e2.png)

Branch-specific behavior:
![branch-specific_behavior](https://user-images.githubusercontent.com/5269320/42321333-0077cd7e-8072-11e8-97c0-b62870078082.png)
