### PR TITLE
make filter cache capacity configurable

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -13,9 +13,12 @@ type config struct {
 }
 
 type apiConfig struct {
-	Listen        string `yaml:"listen"`          // Api local network address. Default is ':8081' so api will be available at http://moira.company.com:8081/api
-	EnableCORS    bool   `yaml:"enable_cors"`     // If true, CORS for cross-domain requests will be enabled. This option can be used only for debugging purposes.
-	WebConfigPath string `yaml:"web_config_path"` // Web_UI config file path. If file not found, api will return 404 in response to "api/config"
+	// Api local network address. Default is ':8081' so api will be available at http://moira.company.com:8081/api
+	Listen string `yaml:"listen"`
+	// If true, CORS for cross-domain requests will be enabled. This option can be used only for debugging purposes.
+	EnableCORS bool `yaml:"enable_cors"`
+	// Web_UI config file path. If file not found, api will return 404 in response to "api/config"
+	WebConfigPath string `yaml:"web_config_path"`
 }
 
 func (config *apiConfig) getSettings() *api.Config {

--- a/cmd/checker/config.go
+++ b/cmd/checker/config.go
@@ -17,11 +17,16 @@ type config struct {
 }
 
 type checkerConfig struct {
-	NoDataCheckInterval  string `yaml:"nodata_check_interval"`  // Period for every trigger to perform forced check on
-	StopCheckingInterval string `yaml:"stop_checking_interval"` // Period for every trigger to cancel forced check (earlier than 'NoDataCheckInterval') if no metrics were received
-	CheckInterval        string `yaml:"check_interval"`         // Min period to perform triggers re-check. Note: Reducing of this value leads to increasing of CPU and memory usage values
-	MetricsTTL           string `yaml:"metrics_ttl"`            // Time interval to store metrics. Note: Increasing of this value leads to increasing of Redis memory consumption value
-	MaxParallelChecks    int    `yaml:"max_parallel_checks"`    // Max concurrent checkers to run. Equals to the number of processor cores found on Moira host by default or when variable is defined as 0.
+	// Period for every trigger to perform forced check on
+	NoDataCheckInterval string `yaml:"nodata_check_interval"`
+	// Period for every trigger to cancel forced check (earlier than 'NoDataCheckInterval') if no metrics were received
+	StopCheckingInterval string `yaml:"stop_checking_interval"`
+	// Min period to perform triggers re-check. Note: Reducing of this value leads to increasing of CPU and memory usage values
+	CheckInterval string `yaml:"check_interval"`
+	// Time interval to store metrics. Note: Increasing of this value leads to increasing of Redis memory consumption value
+	MetricsTTL string `yaml:"metrics_ttl"`
+	// Max concurrent checkers to run. Equals to the number of processor cores found on Moira host by default or when variable is defined as 0.
+	MaxParallelChecks int `yaml:"max_parallel_checks"`
 }
 
 func (config *checkerConfig) getSettings() *checker.Config {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -41,7 +41,7 @@ func (config *RedisConfig) GetSettings() redis.Config {
 
 // GraphiteConfig is graphite metrics config structure that initialises at the start of moira
 type GraphiteConfig struct {
-	// If true, graphite logger will be enabled.
+	// If true, graphite sender will be enabled.
 	Enabled bool `yaml:"enabled"`
 	// If true, runtime stats will be captured and sent to graphite. Note: It takes to call stoptheworld() with configured "graphite.interval" to capture runtime stats (https://golang.org/src/runtime/mstats.go)
 	RuntimeStats bool `yaml:"runtime_stats"`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -43,8 +43,8 @@ func (config *RedisConfig) GetSettings() redis.Config {
 type GraphiteConfig struct {
 	// If true, graphite logger will be enabled.
 	Enabled bool `yaml:"enabled"`
-  // If true, runtime stats will be captured and sent to graphite. Note: It takes to call stoptheworld() with configured "graphite.interval" to capture runtime stats (https://golang.org/src/runtime/mstats.go)
-  RuntimeStats bool `yaml:"runtime_stats"`
+	// If true, runtime stats will be captured and sent to graphite. Note: It takes to call stoptheworld() with configured "graphite.interval" to capture runtime stats (https://golang.org/src/runtime/mstats.go)
+	RuntimeStats bool `yaml:"runtime_stats"`
 	// Graphite relay URI, format: ip:port
 	URI string `yaml:"uri"`
 	// Moira metrics prefix. Use 'prefix: {hostname}' to use hostname autoresolver.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,11 +16,16 @@ import (
 // Use fields MasterName and SentinelAddrs to enable Redis Sentinel support,
 // use Host and Port fields otherwise.
 type RedisConfig struct {
-	MasterName    string `yaml:"master_name"`    // Redis Sentinel cluster name
-	SentinelAddrs string `yaml:"sentinel_addrs"` // Redis Sentinel address list, format: {host1_name:port};{ip:port}
-	Host          string `yaml:"host"`           // Redis node ip-address or host name
-	Port          string `yaml:"port"`           // Redis node port
-	DBID          int    `yaml:"dbid"`           // Redis database id
+	// Redis Sentinel cluster name
+	MasterName string `yaml:"master_name"`
+	// Redis Sentinel address list, format: {host1_name:port};{ip:port}
+	SentinelAddrs string `yaml:"sentinel_addrs"`
+	// Redis node ip-address or host name
+	Host string `yaml:"host"`
+	// Redis node port
+	Port string `yaml:"port"`
+	// Redis database id
+	DBID int `yaml:"dbid"`
 }
 
 // GetSettings returns redis config parsed from moira config files
@@ -36,10 +41,14 @@ func (config *RedisConfig) GetSettings() redis.Config {
 
 // GraphiteConfig is graphite metrics config structure that initialises at the start of moira
 type GraphiteConfig struct {
-	Enabled  bool   `yaml:"enabled"`  // If true, graphite logger will be enabled.
-	URI      string `yaml:"uri"`      // Graphite relay URI, format: ip:port
-	Prefix   string `yaml:"prefix"`   // Moira metrics prefix. Use 'prefix: {hostname}' to use hostname autoresolver.
-	Interval string `yaml:"interval"` // Metrics sending interval
+	// If true, graphite logger will be enabled.
+	Enabled bool `yaml:"enabled"`
+	// Graphite relay URI, format: ip:port
+	URI string `yaml:"uri"`
+	// Moira metrics prefix. Use 'prefix: {hostname}' to use hostname autoresolver.
+	Prefix string `yaml:"prefix"`
+	// Metrics sending interval
+	Interval string `yaml:"interval"`
 }
 
 // GetSettings returns graphite metrics config parsed from moira config files
@@ -60,7 +69,8 @@ type LoggerConfig struct {
 
 // ProfilerConfig is pprof settings structure that initialises at the start of moira
 type ProfilerConfig struct {
-	Listen string `yaml:"listen"` // Define variable as valid non-empty string to enable pprof server. For example ':10000' will enable server available at http://moira.company.com:10000/debug/pprof/
+	// Define variable as valid non-empty string to enable pprof server. For example ':10000' will enable server available at http://moira.company.com:10000/debug/pprof/
+	Listen string `yaml:"listen"`
 }
 
 // ReadConfig parses config file by the given path into Moira-used type

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -15,7 +15,7 @@ type config struct {
 type filterConfig struct {
 	Listen          string `yaml:"listen"`           // Metrics listener uri
 	RetentionConfig string `yaml:"retention_config"` // Retentions config file path. Simply use your original storage-schemas.conf or create new if you're using Moira without existing Graphite installation.
-	CacheCapacity   int    `yaml:"cache_capacity"`   // Metrics cache capacity. Note: Increasing of this value leads to decreasing Redis CPU usage.
+	CacheCapacity   int    `yaml:"cache_capacity"`   // Number of metrics to cache before sending them to Redis. Note: As this value increases, Redis CPU usage decreases. Normally, this must be value of the same order of graphite.prefix.filter.recevied.matching.count | nonNegativeDerivative() | scaleToSeconds(1)
 }
 
 func getDefault() config {

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -13,9 +13,16 @@ type config struct {
 }
 
 type filterConfig struct {
-	Listen          string `yaml:"listen"`           // Metrics listener uri
-	RetentionConfig string `yaml:"retention_config"` // Retentions config file path. Simply use your original storage-schemas.conf or create new if you're using Moira without existing Graphite installation.
-	CacheCapacity   int    `yaml:"cache_capacity"`   // Number of metrics to cache before sending them to Redis. Note: As this value increases, Redis CPU usage decreases. Normally, this must be value of the same order of graphite.prefix.filter.recevied.matching.count | nonNegativeDerivative() | scaleToSeconds(1)
+	// Metrics listener uri
+	Listen string `yaml:"listen"`
+	// Retentions config file path.
+	// Simply use your original storage-schemas.conf or create new if you're using Moira without existing Graphite installation.
+	RetentionConfig string `yaml:"retention_config"`
+	// Number of metrics to cache before checking them.
+	// Note: As this value increases, Redis CPU usage decreases.
+	// Normally, this value must be an order of magnitude less than graphite.prefix.filter.recevied.matching.count | nonNegativeDerivative() | scaleToSeconds(1)
+	// For example: with 100 matching metrics, set cache_capacity to 10. With 1000 matching metrics, increase cache_capacity up to 100.
+	CacheCapacity int `yaml:"cache_capacity"`
 }
 
 func getDefault() config {
@@ -32,7 +39,7 @@ func getDefault() config {
 		Filter: filterConfig{
 			Listen:          ":2003",
 			RetentionConfig: "/etc/moira/storage-schemas.conf",
-			CacheCapacity:   100,
+			CacheCapacity:   10,
 		},
 		Graphite: cmd.GraphiteConfig{
 			URI:      "localhost:2003",

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -14,7 +14,8 @@ type config struct {
 
 type filterConfig struct {
 	Listen          string `yaml:"listen"`           // Metrics listener uri
-	RetentionConfig string `yaml:"retention-config"` // Retentions config file path. Simply use your original storage-schemas.conf or create new if you're using Moira without existing Graphite installation.
+	RetentionConfig string `yaml:"retention_config"` // Retentions config file path. Simply use your original storage-schemas.conf or create new if you're using Moira without existing Graphite installation.
+	CacheCapacity   int    `yaml:"cache_capacity"`   // Metrics cache capacity. Note: Increasing of this value leads to decreasing Redis CPU usage.
 }
 
 func getDefault() config {
@@ -31,6 +32,7 @@ func getDefault() config {
 		Filter: filterConfig{
 			Listen:          ":2003",
 			RetentionConfig: "/etc/moira/storage-schemas.conf",
+			CacheCapacity:   100,
 		},
 		Graphite: cmd.GraphiteConfig{
 			URI:      "localhost:2003",

--- a/cmd/filter/main.go
+++ b/cmd/filter/main.go
@@ -114,7 +114,8 @@ func main() {
 	metricsChan := listener.Listen()
 
 	// Start metrics matcher
-	metricsMatcher := matchedmetrics.NewMetricsMatcher(cacheMetrics, logger, database, cacheStorage)
+	cacheCapacity := config.Filter.CacheCapacity
+	metricsMatcher := matchedmetrics.NewMetricsMatcher(cacheMetrics, logger, database, cacheStorage, cacheCapacity)
 	metricsMatcher.Start(metricsChan)
 	defer metricsMatcher.Wait()  // First stop listener
 	defer stopListener(listener) // Then waiting for metrics matcher handle all received events

--- a/cmd/notifier/config.go
+++ b/cmd/notifier/config.go
@@ -21,22 +21,35 @@ type config struct {
 }
 
 type notifierConfig struct {
-	SenderTimeout    string              `yaml:"sender_timeout"`    // Soft timeout to start retrying to send notification after single failed attempt
-	ResendingTimeout string              `yaml:"resending_timeout"` // Hard timeout to stop retrying to send notification after multiple failed attempts
-	Senders          []map[string]string `yaml:"senders"`           // Senders configuration section. See https://moira.readthedocs.io/en/latest/installation/configuration.html for more explanation
-	SelfState        selfStateConfig     `yaml:"moira_selfstate"`   // Self state monitor configuration section. Note: No inner subscriptions is required. It's own notification mechanism will be used.
-	FrontURI         string              `yaml:"front_uri"`         // Web-UI uri prefix for trigger links in notifications. For example: with 'http://localhost' every notification will contain link like 'http://localhost/trigger/triggerId'
-	Timezone         string              `yaml:"timezone"`          // Timezone to use to convert ticks. Default is UTC. See https://golang.org/pkg/time/#LoadLocation for more details.
-	DateTimeFormat   string              `yaml:"date_time_format"`  // Format for email sender. Default is "15:04 02.01.2006". See https://golang.org/pkg/time/#Time.Format for more details about golang time formatting.
+	// Soft timeout to start retrying to send notification after single failed attempt
+	SenderTimeout string `yaml:"sender_timeout"`
+	// Hard timeout to stop retrying to send notification after multiple failed attempts
+	ResendingTimeout string `yaml:"resending_timeout"`
+	// Senders configuration section. See https://moira.readthedocs.io/en/latest/installation/configuration.html for more explanation
+	Senders []map[string]string `yaml:"senders"`
+	// Self state monitor configuration section. Note: No inner subscriptions is required. It's own notification mechanism will be used.
+	SelfState selfStateConfig `yaml:"moira_selfstate"`
+	// Web-UI uri prefix for trigger links in notifications. For example: with 'http://localhost' every notification will contain link like 'http://localhost/trigger/triggerId'
+	FrontURI string `yaml:"front_uri"`
+	// Timezone to use to convert ticks. Default is UTC. See https://golang.org/pkg/time/#LoadLocation for more details.
+	Timezone string `yaml:"timezone"`
+	// Format for email sender. Default is "15:04 02.01.2006". See https://golang.org/pkg/time/#Time.Format for more details about golang time formatting.
+	DateTimeFormat string `yaml:"date_time_format"`
 }
 
 type selfStateConfig struct {
-	Enabled                 bool                `yaml:"enabled"`                    // If true, Self state monitor will be enabled.
-	RedisDisconnectDelay    string              `yaml:"redis_disconect_delay"`      // Max Redis disconnect delay to send alert when reached
-	LastMetricReceivedDelay string              `yaml:"last_metric_received_delay"` // Max Filter metrics receive delay to send alert when reached
-	LastCheckDelay          string              `yaml:"last_check_delay"`           // Max Checker checks perform delay to send alert when reached
-	Contacts                []map[string]string `yaml:"contacts"`                   // Contact list for Self state monitor alerts
-	NoticeInterval          string              `yaml:"notice_interval"`            // Self state monitor alerting interval
+	// If true, Self state monitor will be enabled.
+	Enabled bool `yaml:"enabled"`
+	// Max Redis disconnect delay to send alert when reached
+	RedisDisconnectDelay string `yaml:"redis_disconect_delay"`
+	// Max Filter metrics receive delay to send alert when reached
+	LastMetricReceivedDelay string `yaml:"last_metric_received_delay"`
+	// Max Checker checks perform delay to send alert when reached
+	LastCheckDelay string `yaml:"last_check_delay"`
+	// Contact list for Self state monitor alerts
+	Contacts []map[string]string `yaml:"contacts"`
+	// Self state monitor alerting interval
+	NoticeInterval string `yaml:"notice_interval"`
 }
 
 func getDefault() config {

--- a/filter/matched_metrics/metrics.go
+++ b/filter/matched_metrics/metrics.go
@@ -60,7 +60,7 @@ func (matcher *MetricsMatcher) Start(channel chan *moira.MatchedMetric) {
 			buffer = make(map[string]*moira.MatchedMetric)
 		}
 	}()
-	matcher.logger.Info("Moira Filter Metrics Matcher started to save %d cached metrics every %s")
+	matcher.logger.Info("Moira Filter Metrics Matcher started to save %d cached metrics every %s", matcher.cacheCapacity, flushInterval.String())
 }
 
 // Wait waits for metric matcher instance will stop

--- a/filter/matched_metrics/metrics.go
+++ b/filter/matched_metrics/metrics.go
@@ -60,7 +60,7 @@ func (matcher *MetricsMatcher) Start(channel chan *moira.MatchedMetric) {
 			buffer = make(map[string]*moira.MatchedMetric)
 		}
 	}()
-	matcher.logger.Info("Moira Filter Metrics Matcher started to save %d cached metrics every %s", matcher.cacheCapacity, flushInterval.String())
+	matcher.logger.Infof("Moira Filter Metrics Matcher started to save %d cached metrics every %s", matcher.cacheCapacity, flushInterval.String())
 }
 
 // Wait waits for metric matcher instance will stop

--- a/filter/matched_metrics/metrics.go
+++ b/filter/matched_metrics/metrics.go
@@ -11,21 +11,23 @@ import (
 
 // MetricsMatcher make buffer of metrics and save it
 type MetricsMatcher struct {
-	logger       moira.Logger
-	metrics      *graphite.FilterMetrics
-	database     moira.Database
-	cacheStorage *filter.Storage
-	waitGroup    *sync.WaitGroup
+	logger        moira.Logger
+	metrics       *graphite.FilterMetrics
+	database      moira.Database
+	cacheStorage  *filter.Storage
+	cacheCapacity *int
+	waitGroup     *sync.WaitGroup
 }
 
 // NewMetricsMatcher creates new MetricsMatcher
-func NewMetricsMatcher(metrics *graphite.FilterMetrics, logger moira.Logger, database moira.Database, cacheStorage *filter.Storage) *MetricsMatcher {
+func NewMetricsMatcher(metrics *graphite.FilterMetrics, logger moira.Logger, database moira.Database, cacheStorage *filter.Storage, cacheCapacity int) *MetricsMatcher {
 	return &MetricsMatcher{
-		metrics:      metrics,
-		logger:       logger,
-		database:     database,
-		cacheStorage: cacheStorage,
-		waitGroup:    &sync.WaitGroup{},
+		metrics:       metrics,
+		logger:        logger,
+		database:      database,
+		cacheStorage:  cacheStorage,
+		cacheCapacity: &cacheCapacity,
+		waitGroup:     &sync.WaitGroup{},
 	}
 }
 
@@ -43,7 +45,7 @@ func (matcher *MetricsMatcher) Start(channel chan *moira.MatchedMetric) {
 					return
 				}
 				matcher.cacheStorage.EnrichMatchedMetric(buffer, metric)
-				if len(buffer) < 1000 {
+				if len(buffer) < *matcher.cacheCapacity {
 					continue
 				}
 			case <-time.After(time.Second):

--- a/pkg/filter/filter.yml
+++ b/pkg/filter/filter.yml
@@ -11,7 +11,7 @@ graphite:
 filter:
   listen: ":2003"
   retention_config: /etc/moira/storage-schemas.conf
-  cache_capacity: 100
+  cache_capacity: 10
 log:
   log_file: stdout
   log_level: info

--- a/pkg/filter/filter.yml
+++ b/pkg/filter/filter.yml
@@ -10,7 +10,8 @@ graphite:
   interval: 60s
 filter:
   listen: ":2003"
-  retention-config: /etc/moira/storage-schemas.conf
+  retention_config: /etc/moira/storage-schemas.conf
+  cache_capacity: 100
 log:
   log_file: stdout
   log_level: info


### PR DESCRIPTION
added field:
- cache_capacity to make it tunable for large production solutions
changed field:
- retention-config -> retention_config (to have common underscore style for config params)

doc pr: https://github.com/moira-alert/doc/pull/21