### PR TITLE
Add pattern matching workers

### DIFF
--- a/checker/worker/worker.go
+++ b/checker/worker/worker.go
@@ -28,7 +28,7 @@ type Checker struct {
 // Start start schedule new MetricEvents and check for NODATA triggers
 func (worker *Checker) Start() error {
 	if worker.Config.MaxParallelChecks == 0 {
-		return fmt.Errorf("MaxParallelChecks is not configured, checker doesn't start")
+		return fmt.Errorf("MaxParallelChecks is not configured, checker does not start")
 	}
 
 	worker.lastData = time.Now().UTC().Unix()

--- a/checker/worker/worker.go
+++ b/checker/worker/worker.go
@@ -28,7 +28,7 @@ type Checker struct {
 // Start start schedule new MetricEvents and check for NODATA triggers
 func (worker *Checker) Start() error {
 	if worker.Config.MaxParallelChecks == 0 {
-		return fmt.Errorf("MaxParallelChecks does not configure, checker does not started")
+		return fmt.Errorf("MaxParallelChecks is not configured, checker doesn't start")
 	}
 
 	worker.lastData = time.Now().UTC().Unix()

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -24,8 +24,9 @@ type filterConfig struct {
 	// Note: As this value increases, Redis CPU usage decreases.
 	// Normally, this value must be an order of magnitude less than graphite.prefix.filter.recevied.matching.count | nonNegativeDerivative() | scaleToSeconds(1)
 	// For example: with 100 matching metrics, set cache_capacity to 10. With 1000 matching metrics, increase cache_capacity up to 100.
-	CacheCapacity     int `yaml:"cache_capacity"`
-	MaxParallelChecks int `yaml:"max_parallel_checks"`
+	CacheCapacity int `yaml:"cache_capacity"`
+	// Max concurrent metric matchers to run. Equals to the number of processor cores found on Moira host by default or when variable is defined as 0.
+	MaxParallelMatches int `yaml:"max_parallel_matches"`
 }
 
 func getDefault() config {
@@ -40,10 +41,10 @@ func getDefault() config {
 			LogLevel: "info",
 		},
 		Filter: filterConfig{
-			Listen:            ":2003",
-			RetentionConfig:   "/etc/moira/storage-schemas.conf",
-			CacheCapacity:     10,
-			MaxParallelChecks: runtime.NumCPU(),
+			Listen:             ":2003",
+			RetentionConfig:    "/etc/moira/storage-schemas.conf",
+			CacheCapacity:      10,
+			MaxParallelMatches: runtime.NumCPU(),
 		},
 		Graphite: cmd.GraphiteConfig{
 			RuntimeStats: false,

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"runtime"
+
 	"github.com/moira-alert/moira/cmd"
 )
 
@@ -22,7 +24,8 @@ type filterConfig struct {
 	// Note: As this value increases, Redis CPU usage decreases.
 	// Normally, this value must be an order of magnitude less than graphite.prefix.filter.recevied.matching.count | nonNegativeDerivative() | scaleToSeconds(1)
 	// For example: with 100 matching metrics, set cache_capacity to 10. With 1000 matching metrics, increase cache_capacity up to 100.
-	CacheCapacity int `yaml:"cache_capacity"`
+	CacheCapacity     int `yaml:"cache_capacity"`
+	MaxParallelChecks int `yaml:"max_parallel_checks"`
 }
 
 func getDefault() config {
@@ -37,9 +40,10 @@ func getDefault() config {
 			LogLevel: "info",
 		},
 		Filter: filterConfig{
-			Listen:          ":2003",
-			RetentionConfig: "/etc/moira/storage-schemas.conf",
-			CacheCapacity:   10,
+			Listen:            ":2003",
+			RetentionConfig:   "/etc/moira/storage-schemas.conf",
+			CacheCapacity:     10,
+			MaxParallelChecks: runtime.NumCPU(),
 		},
 		Graphite: cmd.GraphiteConfig{
 			RuntimeStats: false,

--- a/cmd/filter/main.go
+++ b/cmd/filter/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	if config.Filter.MaxParallelChecks == 0 {
-		fmt.Fprint(os.Stderr, "MaxParallelChecks does not configured, filter does not started")
+		fmt.Fprint(os.Stderr, "MaxParallelChecks is not configured, filter does not start")
 	}
 
 	logger, err = logging.ConfigureLog(config.Logger.LogFile, config.Logger.LogLevel, serviceName)

--- a/cmd/filter/main.go
+++ b/cmd/filter/main.go
@@ -57,8 +57,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if config.Filter.MaxParallelChecks == 0 {
-		fmt.Fprint(os.Stderr, "MaxParallelChecks is not configured, filter does not start")
+	if config.Filter.MaxParallelMatches == 0 {
+		fmt.Fprint(os.Stderr, "MaxParallelMatches is not configured, filter does not start")
 	}
 
 	logger, err = logging.ConfigureLog(config.Logger.LogFile, config.Logger.LogLevel, serviceName)
@@ -120,7 +120,7 @@ func main() {
 	lineChan := listener.Listen()
 
 	patternMatcher := patterns.NewMatcher(logger, cacheMetrics, patternStorage)
-	metricsChan := patternMatcher.Start(config.Filter.MaxParallelChecks, lineChan)
+	metricsChan := patternMatcher.Start(config.Filter.MaxParallelMatches, lineChan)
 
 	// Start metrics matcher
 	cacheCapacity := config.Filter.CacheCapacity

--- a/cmd/filter/main.go
+++ b/cmd/filter/main.go
@@ -57,6 +57,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if config.Filter.MaxParallelChecks == 0 {
+		fmt.Fprint(os.Stderr, "MaxParallelChecks does not configured, filter does not started")
+	}
+
 	logger, err = logging.ConfigureLog(config.Logger.LogFile, config.Logger.LogLevel, serviceName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can not configure log: %s\n", err.Error())
@@ -109,11 +113,14 @@ func main() {
 	defer stopHeartbeatWorker(heartbeatWorker)
 
 	// Start metrics listener
-	listener, err := connection.NewListener(config.Filter.Listen, logger, cacheMetrics, patternStorage)
+	listener, err := connection.NewListener(config.Filter.Listen, logger, cacheMetrics)
 	if err != nil {
 		logger.Fatalf("Failed to start listen: %s", err.Error())
 	}
-	metricsChan := listener.Listen()
+	lineChan := listener.Listen()
+
+	patternMatcher := patterns.NewMatcher(logger, cacheMetrics, patternStorage)
+	metricsChan := patternMatcher.Start(config.Filter.MaxParallelChecks, lineChan)
 
 	// Start metrics matcher
 	cacheCapacity := config.Filter.CacheCapacity

--- a/filter/connection/handler.go
+++ b/filter/connection/handler.go
@@ -55,7 +55,7 @@ func (handler *Handler) handle(connection net.Conn, lineChan chan<- []byte) {
 	}
 }
 
-// StopHandlingConnections closes all open connections and wait for handling ramaining metrics
+// StopHandlingConnections closes all open connections and wait for handling remaining metrics
 func (handler *Handler) StopHandlingConnections() {
 	close(handler.terminate)
 	handler.wg.Wait()

--- a/filter/connection/listening.go
+++ b/filter/connection/listening.go
@@ -24,11 +24,11 @@ type MetricsListener struct {
 func NewListener(port string, logger moira.Logger, metrics *graphite.FilterMetrics) (*MetricsListener, error) {
 	address, err := net.ResolveTCPAddr("tcp", port)
 	if nil != err {
-		return nil, fmt.Errorf("Failed to resolve tcp address [%s]: %s", port, err.Error())
+		return nil, fmt.Errorf("failed to resolve tcp address [%s]: %s", port, err.Error())
 	}
 	newListener, err := net.ListenTCP("tcp", address)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to listen on [%s]: %s", port, err.Error())
+		return nil, fmt.Errorf("failed to listen on [%s]: %s", port, err.Error())
 	}
 	listener := MetricsListener{
 		listener: newListener,

--- a/filter/connection/listening.go
+++ b/filter/connection/listening.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/moira-alert/moira"
-	"github.com/moira-alert/moira/filter"
 	"github.com/moira-alert/moira/metrics/graphite"
 )
 
@@ -22,7 +21,7 @@ type MetricsListener struct {
 }
 
 // NewListener creates new listener
-func NewListener(port string, logger moira.Logger, metrics *graphite.FilterMetrics, patternStorage *filter.PatternStorage) (*MetricsListener, error) {
+func NewListener(port string, logger moira.Logger, metrics *graphite.FilterMetrics) (*MetricsListener, error) {
 	address, err := net.ResolveTCPAddr("tcp", port)
 	if nil != err {
 		return nil, fmt.Errorf("Failed to resolve tcp address [%s]: %s", port, err.Error())
@@ -34,16 +33,16 @@ func NewListener(port string, logger moira.Logger, metrics *graphite.FilterMetri
 	listener := MetricsListener{
 		listener: newListener,
 		logger:   logger,
-		handler:  NewConnectionsHandler(logger, patternStorage),
-		metrics: 	metrics,
+		handler:  NewConnectionsHandler(logger),
+		metrics:  metrics,
 	}
 	return &listener, nil
 }
 
 // Listen waits for new data in connection and handles it in ConnectionHandler
-// All handled data sets to metricsChan
-func (listener *MetricsListener) Listen() chan *moira.MatchedMetric {
-	metricsChan := make(chan *moira.MatchedMetric, 16384)
+// All handled data sets to lineChan
+func (listener *MetricsListener) Listen() chan []byte {
+	lineChan := make(chan []byte, 16384)
 	listener.tomb.Go(func() error {
 		for {
 			select {
@@ -52,7 +51,7 @@ func (listener *MetricsListener) Listen() chan *moira.MatchedMetric {
 					listener.logger.Info("Stopping listener...")
 					listener.listener.Close()
 					listener.handler.StopHandlingConnections()
-					close(metricsChan)
+					close(lineChan)
 					listener.logger.Info("Moira Filter Listener stopped")
 					return nil
 				}
@@ -68,23 +67,22 @@ func (listener *MetricsListener) Listen() chan *moira.MatchedMetric {
 				continue
 			}
 			listener.logger.Infof("%s connected", conn.RemoteAddr())
-			listener.handler.HandleConnection(conn, metricsChan)
+			listener.handler.HandleConnection(conn, lineChan)
 		}
 	})
-
-	listener.tomb.Go(func() error { return listener.checkNewMetricsChannelLen(metricsChan) })
+	listener.tomb.Go(func() error { return listener.checkNewLinesChannelLen(lineChan) })
 	listener.logger.Info("Moira Filter Listener Started")
-	return metricsChan
+	return lineChan
 }
 
-func (listener *MetricsListener) checkNewMetricsChannelLen(channel <-chan *moira.MatchedMetric) error {
+func (listener *MetricsListener) checkNewLinesChannelLen(channel <-chan []byte) error {
 	checkTicker := time.NewTicker(time.Millisecond * 100)
 	for {
 		select {
 		case <-listener.tomb.Dying():
 			return nil
 		case <-checkTicker.C:
-			listener.metrics.MetricChannelLen.Update(int64(len(channel)))
+			listener.metrics.LineChannelLen.Update(int64(len(channel)))
 		}
 	}
 }

--- a/filter/matched_metrics/metrics.go
+++ b/filter/matched_metrics/metrics.go
@@ -32,7 +32,7 @@ func NewMetricsMatcher(metrics *graphite.FilterMetrics, logger moira.Logger, dat
 }
 
 // Start process matched metrics from channel and save it in cache storage
-func (matcher *MetricsMatcher) Start(channel chan *moira.MatchedMetric) {
+func (matcher *MetricsMatcher) Start(matchedMetricsChan chan *moira.MatchedMetric) {
 	flushInterval := time.Second
 	matcher.waitGroup.Add(1)
 	go func() {
@@ -40,7 +40,7 @@ func (matcher *MetricsMatcher) Start(channel chan *moira.MatchedMetric) {
 		buffer := make(map[string]*moira.MatchedMetric)
 		for {
 			select {
-			case metric, ok := <-channel:
+			case metric, ok := <-matchedMetricsChan:
 				if !ok {
 					matcher.logger.Info("Moira Filter Metrics Matcher stopped")
 					return

--- a/filter/patterns/matcher.go
+++ b/filter/patterns/matcher.go
@@ -1,0 +1,66 @@
+package patterns
+
+import (
+	"time"
+
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/filter"
+	"github.com/moira-alert/moira/metrics/graphite"
+	"gopkg.in/tomb.v2"
+)
+
+type Matcher struct {
+	logger         moira.Logger
+	tomb           tomb.Tomb
+	metrics        *graphite.FilterMetrics
+	patternStorage *filter.PatternStorage
+}
+
+// NewMatcher creates pattern matcher
+func NewMatcher(logger moira.Logger, metrics *graphite.FilterMetrics, patternsStorage *filter.PatternStorage) *Matcher {
+	return &Matcher{
+		logger:         logger,
+		metrics:        metrics,
+		patternStorage: patternsStorage,
+	}
+}
+
+// Start spawns pattern matcher workers
+func (m *Matcher) Start(workerCnt int, lineChan <-chan []byte) chan *moira.MatchedMetric {
+	metricsChan := make(chan *moira.MatchedMetric, 16384)
+	m.logger.Infof("starting %d pattern matcher workers", workerCnt)
+	for i := 0; i < workerCnt; i++ {
+		m.tomb.Go(func() error {
+			return m.worker(lineChan, metricsChan)
+		})
+	}
+	go func() {
+		<-m.tomb.Dying()
+		m.logger.Info("Stopping pattern matcher...")
+		close(metricsChan)
+		m.logger.Info("Moira pattern matcher stopped")
+	}()
+
+	return metricsChan
+}
+
+func (m *Matcher) worker(in <-chan []byte, out chan<- *moira.MatchedMetric) error {
+	for line := range in {
+		if m := m.patternStorage.ProcessIncomingMetric(line); m != nil {
+			out <- m
+		}
+	}
+	return nil
+}
+
+func (m *Matcher) checkNewMetricsChannelLen(channel <-chan *moira.MatchedMetric) error {
+	checkTicker := time.NewTicker(time.Millisecond * 100)
+	for {
+		select {
+		case <-m.tomb.Dying():
+			return nil
+		case <-checkTicker.C:
+			m.metrics.MetricChannelLen.Update(int64(len(channel)))
+		}
+	}
+}

--- a/filter/patterns/matcher.go
+++ b/filter/patterns/matcher.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
+// Matcher checks metrics against known patterns
 type Matcher struct {
 	logger         moira.Logger
 	tomb           tomb.Tomb

--- a/filter/patterns/matcher.go
+++ b/filter/patterns/matcher.go
@@ -41,6 +41,7 @@ func (m *Matcher) Start(workerCnt int, lineChan <-chan []byte) chan *moira.Match
 		m.logger.Info("Moira pattern matcher stopped")
 	}()
 
+	m.tomb.Go(func() error { return m.checkNewMetricsChannelLen(metricsChan) })
 	return metricsChan
 }
 

--- a/filter/patterns/matcher.go
+++ b/filter/patterns/matcher.go
@@ -29,7 +29,7 @@ func NewMatcher(logger moira.Logger, metrics *graphite.FilterMetrics, patternsSt
 // Start spawns pattern matcher workers
 func (m *Matcher) Start(matchersCount int, lineChan <-chan []byte) chan *moira.MatchedMetric {
 	matchedMetricsChan := make(chan *moira.MatchedMetric, 16384)
-	m.logger.Infof("starting %d pattern matcher workers", matchersCount)
+	m.logger.Infof("Start %d pattern matcher workers", matchersCount)
 	for i := 0; i < matchersCount; i++ {
 		m.tomb.Go(func() error {
 			return m.worker(lineChan, matchedMetricsChan)

--- a/metrics/graphite/filter.go
+++ b/metrics/graphite/filter.go
@@ -9,4 +9,5 @@ type FilterMetrics struct {
 	SavingTimer             Timer
 	BuildTreeTimer          Timer
 	MetricChannelLen        Histogram
+	LineChannelLen          Histogram
 }

--- a/metrics/graphite/go-metrics/configuration.go
+++ b/metrics/graphite/go-metrics/configuration.go
@@ -16,6 +16,7 @@ func ConfigureFilterMetrics(prefix string) *graphite.FilterMetrics {
 		SavingTimer:             registerTimer(metricNameWithPrefix(prefix, "time.save")),
 		BuildTreeTimer:          registerTimer(metricNameWithPrefix(prefix, "time.buildtree")),
 		MetricChannelLen:        registerHistogram(metricNameWithPrefix(prefix, "metricsToSave")),
+		LineChannelLen:          registerHistogram(metricNameWithPrefix(prefix, "linesToMatch")),
 	}
 }
 


### PR DESCRIPTION
We have encountered a performance issues with moira-filter (slow metrics ingestion which resulted in false-positive NODATA alerts)

The problem is that we have a large number of incoming metrics from a single host (carbon-c-relay in our case).
Current implementation assigns single goroutine per connections for a relatively slow process of pattern matching.

By introducing separate pool of pattern matching workers we completely solved our problem with slow ingestion