### PR TITLE
Few fixes of checking exceptions

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -147,7 +147,7 @@ func (triggerChecker *TriggerChecker) handleTriggerCheck(checkData moira.CheckDa
 	case ErrTriggerHasNoTimeSeries, ErrTriggerHasOnlyWildcards:
 		triggerChecker.Logger.Debugf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
 		triggerState := ToTriggerState(triggerChecker.ttlState)
-		if len(checkData.Metrics) == 0 && triggerState != OK {
+		if len(checkData.Metrics) == 0 {
 			checkData.State = triggerState
 			checkData.Message = checkingError.Error()
 			if triggerChecker.ttl == 0 {

--- a/checker/check.go
+++ b/checker/check.go
@@ -144,14 +144,7 @@ func (triggerChecker *TriggerChecker) handleTriggerCheck(checkData moira.CheckDa
 	}
 
 	switch checkingError.(type) {
-	case ErrTriggerHasNoTimeSeries:
-		triggerChecker.Logger.Debugf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
-		checkData.State = NODATA
-		checkData.Message = checkingError.Error()
-		if triggerChecker.ttl == 0 {
-			return checkData, nil
-		}
-	case ErrTriggerHasOnlyWildcards:
+	case ErrTriggerHasNoTimeSeries, ErrTriggerHasOnlyWildcards:
 		triggerChecker.Logger.Debugf("Trigger %s: %s", triggerChecker.TriggerID, checkingError.Error())
 		triggerState := ToTriggerState(triggerChecker.ttlState)
 		if len(checkData.Metrics) == 0 && triggerState != OK {
@@ -171,7 +164,6 @@ func (triggerChecker *TriggerChecker) handleTriggerCheck(checkData moira.CheckDa
 	default:
 		triggerChecker.Metrics.CheckError.Mark(1)
 		triggerChecker.Logger.Errorf("Trigger %s check failed: %s", triggerChecker.TriggerID, checkingError.Error())
-		checkData.State = EXCEPTION
 	}
 	return triggerChecker.compareTriggerStates(checkData)
 }

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -451,30 +451,18 @@ func TestCheckErrors(t *testing.T) {
 	}
 
 	Convey("GetTimeSeries error", t, func() {
-		ms := ""
-		event := moira.NotificationEvent{
-			IsTriggerEvent: true,
-			TriggerID:      triggerChecker.TriggerID,
-			State:          EXCEPTION,
-			OldState:       OK,
-			Timestamp:      67,
-			Metric:         triggerChecker.trigger.Name,
-			Message:        &ms,
-		}
-
 		lastCheck := moira.CheckData{
 			Metrics:        triggerChecker.lastCheck.Metrics,
-			State:          EXCEPTION,
+			State:          OK,
 			Timestamp:      triggerChecker.Until,
 			EventTimestamp: triggerChecker.Until,
-			Score:          100000,
-			Message:        ms,
+			Score:          0,
+			Message:        "",
 		}
 
 		dataBase.EXPECT().GetPatternMetrics(pattern).Return([]string{metric}, nil)
 		dataBase.EXPECT().GetMetricRetention(metric).Return(retention, nil)
 		dataBase.EXPECT().GetMetricsValues([]string{metric}, triggerChecker.From, triggerChecker.Until).Return(nil, metricErr)
-		dataBase.EXPECT().PushNotificationEvent(&event, true).Return(nil)
 		dataBase.EXPECT().SetTriggerLastCheck(triggerChecker.TriggerID, &lastCheck).Return(nil)
 		err := triggerChecker.Check()
 		So(err, ShouldBeNil)
@@ -833,6 +821,7 @@ func TestHandleErrorCheck(t *testing.T) {
 	defer mockCtrl.Finish()
 	logger, _ := logging.GetLogger("Test")
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+	ttlState := NODATA
 
 	Convey("Handle error no metrics", t, func() {
 		Convey("TTL is 0", func() {
@@ -841,7 +830,8 @@ func TestHandleErrorCheck(t *testing.T) {
 				Database:  dataBase,
 				Logger:    logger,
 				ttl:       0,
-				trigger:   &moira.Trigger{TriggerType: moira.RisingTrigger},
+				ttlState:  ttlState,
+				trigger:   &moira.Trigger{TriggerType: moira.RisingTrigger, TTLState: &ttlState},
 				lastCheck: &moira.CheckData{
 					Timestamp: 0,
 					State:     NODATA,

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -976,6 +976,7 @@ func TestHandleErrorCheck(t *testing.T) {
 			State:          OK,
 			Timestamp:      checkData.Timestamp,
 			EventTimestamp: checkData.Timestamp,
+			Message:        "Trigger never received metrics",
 		}
 		So(err, ShouldBeNil)
 		So(actual, ShouldResemble, expected)
@@ -1008,6 +1009,7 @@ func TestHandleErrorCheck(t *testing.T) {
 			State:          OK,
 			Timestamp:      now,
 			EventTimestamp: now - 3600,
+			Message:        "Trigger never received metrics",
 		}
 		So(err, ShouldBeNil)
 		So(actual, ShouldResemble, expected)


### PR DESCRIPTION
- since now we don't want to notify user if something goes wrong. So, I remove checkData.State = EXCEPTION
- if there are 0 metrics in trigger, we want to switch trigger in TTLState instead of NODATA