### PR TITLE
The same logic as in #113, but reversed

### DIFF
--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -60,49 +60,49 @@ type TriggerModel struct {
 	Patterns []string `json:"patterns"`
 	// Shows if trigger is remote (graphite-backend) based or stored inside Moira-Redis DB
 	IsRemote bool `json:"is_remote"`
-	// If false, first event NODATA → OK will be omitted
-	NotifyAboutNewMetrics bool `json:"notify_about_new_metrics"`
+	// If true, first event NODATA → OK will be omitted
+	MuteNewMetrics bool `json:"mute_new_metrics"`
 }
 
 // ToMoiraTrigger transforms TriggerModel to moira.Trigger
 func (model *TriggerModel) ToMoiraTrigger() *moira.Trigger {
 	return &moira.Trigger{
-		ID:                    model.ID,
-		Name:                  model.Name,
-		Desc:                  model.Desc,
-		Targets:               model.Targets,
-		WarnValue:             model.WarnValue,
-		ErrorValue:            model.ErrorValue,
-		TriggerType:           model.TriggerType,
-		Tags:                  model.Tags,
-		TTLState:              model.TTLState,
-		TTL:                   model.TTL,
-		Schedule:              model.Schedule,
-		Expression:            &model.Expression,
-		Patterns:              model.Patterns,
-		IsRemote:              model.IsRemote,
-		NotifyAboutNewMetrics: model.NotifyAboutNewMetrics,
+		ID:             model.ID,
+		Name:           model.Name,
+		Desc:           model.Desc,
+		Targets:        model.Targets,
+		WarnValue:      model.WarnValue,
+		ErrorValue:     model.ErrorValue,
+		TriggerType:    model.TriggerType,
+		Tags:           model.Tags,
+		TTLState:       model.TTLState,
+		TTL:            model.TTL,
+		Schedule:       model.Schedule,
+		Expression:     &model.Expression,
+		Patterns:       model.Patterns,
+		IsRemote:       model.IsRemote,
+		MuteNewMetrics: model.MuteNewMetrics,
 	}
 }
 
 // CreateTriggerModel transforms moira.Trigger to TriggerModel
 func CreateTriggerModel(trigger *moira.Trigger) TriggerModel {
 	return TriggerModel{
-		ID:                    trigger.ID,
-		Name:                  trigger.Name,
-		Desc:                  trigger.Desc,
-		Targets:               trigger.Targets,
-		WarnValue:             trigger.WarnValue,
-		ErrorValue:            trigger.ErrorValue,
-		TriggerType:           trigger.TriggerType,
-		Tags:                  trigger.Tags,
-		TTLState:              trigger.TTLState,
-		TTL:                   trigger.TTL,
-		Schedule:              trigger.Schedule,
-		Expression:            moira.UseString(trigger.Expression),
-		Patterns:              trigger.Patterns,
-		IsRemote:              trigger.IsRemote,
-		NotifyAboutNewMetrics: trigger.NotifyAboutNewMetrics,
+		ID:             trigger.ID,
+		Name:           trigger.Name,
+		Desc:           trigger.Desc,
+		Targets:        trigger.Targets,
+		WarnValue:      trigger.WarnValue,
+		ErrorValue:     trigger.ErrorValue,
+		TriggerType:    trigger.TriggerType,
+		Tags:           trigger.Tags,
+		TTLState:       trigger.TTLState,
+		TTL:            trigger.TTL,
+		Schedule:       trigger.Schedule,
+		Expression:     moira.UseString(trigger.Expression),
+		Patterns:       trigger.Patterns,
+		IsRemote:       trigger.IsRemote,
+		MuteNewMetrics: trigger.MuteNewMetrics,
 	}
 }
 

--- a/checker/check.go
+++ b/checker/check.go
@@ -131,7 +131,7 @@ func (triggerChecker *TriggerChecker) handleMetricsCheck() (moira.CheckData, err
 }
 
 func (triggerChecker *TriggerChecker) checkTimeSeries(timeSeries *target.TimeSeries, triggerTimeSeries *triggerTimeSeries) (lastState moira.MetricState, needToDeleteMetric bool, err error) {
-	lastState = triggerChecker.lastCheck.GetOrCreateMetricState(timeSeries.Name, timeSeries.StartTime-3600, triggerChecker.trigger.NotifyAboutNewMetrics)
+	lastState = triggerChecker.lastCheck.GetOrCreateMetricState(timeSeries.Name, timeSeries.StartTime-3600, triggerChecker.trigger.MuteNewMetrics)
 	metricStates, err := triggerChecker.getTimeSeriesStepsStates(triggerTimeSeries, timeSeries, lastState)
 	if err != nil {
 		return

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -616,7 +616,7 @@ func TestIgnoreNodataToOk(t *testing.T) {
 	}
 
 	Convey("First Event, NODATA - OK is ignored", t, func() {
-		triggerChecker.trigger.NotifyAboutNewMetrics = false
+		triggerChecker.trigger.MuteNewMetrics = true
 		dataBase.EXPECT().GetPatternMetrics(pattern).Return([]string{metric}, nil)
 		dataBase.EXPECT().GetMetricRetention(metric).Return(retention, nil)
 		dataBase.EXPECT().GetMetricsValues([]string{metric}, triggerChecker.From, triggerChecker.Until).Return(dataList, nil)
@@ -700,12 +700,11 @@ func TestHandleTrigger(t *testing.T) {
 		ttl:      ttl,
 		ttlState: NODATA,
 		trigger: &moira.Trigger{
-			ErrorValue:            &errValue,
-			WarnValue:             &warnValue,
-			TriggerType:           moira.RisingTrigger,
-			NotifyAboutNewMetrics: true,
-			Targets:               []string{pattern},
-			Patterns:              []string{pattern},
+			ErrorValue:  &errValue,
+			WarnValue:   &warnValue,
+			TriggerType: moira.RisingTrigger,
+			Targets:     []string{pattern},
+			Patterns:    []string{pattern},
 		},
 		lastCheck: &lastCheck,
 	}
@@ -852,12 +851,11 @@ func TestHandleTrigger(t *testing.T) {
 			ttl:      ttl,
 			ttlState: NODATA,
 			trigger: &moira.Trigger{
-				ErrorValue:            &errValue,
-				WarnValue:             &warnValue,
-				TriggerType:           moira.RisingTrigger,
-				NotifyAboutNewMetrics: true,
-				Targets:               []string{"aliasByNode(super.*.metric, 0)"},
-				Patterns:              []string{pattern1},
+				ErrorValue:  &errValue,
+				WarnValue:   &warnValue,
+				TriggerType: moira.RisingTrigger,
+				Targets:     []string{"aliasByNode(super.*.metric, 0)"},
+				Patterns:    []string{pattern1},
 			},
 			lastCheck: &moira.CheckData{
 				Metrics:   make(map[string]moira.MetricState),
@@ -1030,7 +1028,7 @@ func TestHandleErrorCheck(t *testing.T) {
 			Database:  dataBase,
 			Logger:    logger,
 			ttl:       60,
-			trigger:   &moira.Trigger{TriggerType: moira.RisingTrigger, NotifyAboutNewMetrics: true},
+			trigger:   &moira.Trigger{TriggerType: moira.RisingTrigger},
 			ttlState:  NODATA,
 			lastCheck: &moira.CheckData{
 				Timestamp: time.Now().Unix(),
@@ -1065,7 +1063,7 @@ func TestHandleErrorCheck(t *testing.T) {
 			Database:  dataBase,
 			Logger:    logger,
 			ttl:       60,
-			trigger:   &moira.Trigger{TriggerType: moira.RisingTrigger, NotifyAboutNewMetrics: true},
+			trigger:   &moira.Trigger{TriggerType: moira.RisingTrigger},
 			ttlState:  OK,
 			lastCheck: &moira.CheckData{
 				Timestamp: time.Now().Unix(),

--- a/checker/trigger_test.go
+++ b/checker/trigger_test.go
@@ -57,17 +57,16 @@ func TestInitTriggerChecker(t *testing.T) {
 	ttlStateNoData := NODATA
 
 	trigger := moira.Trigger{
-		ID:                    "d39b8510-b2f4-448c-b881-824658c58128",
-		Name:                  "Time",
-		Targets:               []string{"aliasByNode(Metric.*.time, 1)"},
-		WarnValue:             &warnWalue,
-		ErrorValue:            &errorWalue,
-		TriggerType:           moira.RisingTrigger,
-		NotifyAboutNewMetrics: true,
-		Tags:     []string{"tag1", "tag2"},
-		TTLState: &ttlStateOk,
-		Patterns: []string{"Egais.elasticsearch.*.*.jvm.gc.collection.time"},
-		TTL:      ttl,
+		ID:          "d39b8510-b2f4-448c-b881-824658c58128",
+		Name:        "Time",
+		Targets:     []string{"aliasByNode(Metric.*.time, 1)"},
+		WarnValue:   &warnWalue,
+		ErrorValue:  &errorWalue,
+		TriggerType: moira.RisingTrigger,
+		Tags:        []string{"tag1", "tag2"},
+		TTLState:    &ttlStateOk,
+		Patterns:    []string{"Egais.elasticsearch.*.*.jvm.gc.collection.time"},
+		TTL:         ttl,
 	}
 
 	lastCheck := moira.CheckData{

--- a/database/redis/reply/trigger.go
+++ b/database/redis/reply/trigger.go
@@ -12,63 +12,63 @@ import (
 
 // Duty hack for moira.Trigger TTL int64 and stored trigger TTL string compatibility
 type triggerStorageElement struct {
-	ID                    string              `json:"id"`
-	Name                  string              `json:"name"`
-	Desc                  *string             `json:"desc,omitempty"`
-	Targets               []string            `json:"targets"`
-	WarnValue             *float64            `json:"warn_value"`
-	ErrorValue            *float64            `json:"error_value"`
-	TriggerType           string              `json:"trigger_type,omitempty"`
-	Tags                  []string            `json:"tags"`
-	TTLState              *string             `json:"ttl_state,omitempty"`
-	Schedule              *moira.ScheduleData `json:"sched,omitempty"`
-	Expression            *string             `json:"expr,omitempty"`
-	PythonExpression      *string             `json:"expression,omitempty"`
-	Patterns              []string            `json:"patterns"`
-	TTL                   string              `json:"ttl,omitempty"`
-	IsRemote              bool                `json:"is_remote"`
-	NotifyAboutNewMetrics bool                `json:"notify_about_new_metrics,omitempty"`
+	ID               string              `json:"id"`
+	Name             string              `json:"name"`
+	Desc             *string             `json:"desc,omitempty"`
+	Targets          []string            `json:"targets"`
+	WarnValue        *float64            `json:"warn_value"`
+	ErrorValue       *float64            `json:"error_value"`
+	TriggerType      string              `json:"trigger_type,omitempty"`
+	Tags             []string            `json:"tags"`
+	TTLState         *string             `json:"ttl_state,omitempty"`
+	Schedule         *moira.ScheduleData `json:"sched,omitempty"`
+	Expression       *string             `json:"expr,omitempty"`
+	PythonExpression *string             `json:"expression,omitempty"`
+	Patterns         []string            `json:"patterns"`
+	TTL              string              `json:"ttl,omitempty"`
+	IsRemote         bool                `json:"is_remote"`
+	MuteNewMetrics   bool                `json:"mute_new_metrics,omitempty"`
 }
 
 func (storageElement *triggerStorageElement) toTrigger() moira.Trigger {
 	return moira.Trigger{
-		ID:                    storageElement.ID,
-		Name:                  storageElement.Name,
-		Desc:                  storageElement.Desc,
-		Targets:               storageElement.Targets,
-		WarnValue:             storageElement.WarnValue,
-		ErrorValue:            storageElement.ErrorValue,
-		TriggerType:           storageElement.TriggerType,
-		Tags:                  storageElement.Tags,
-		TTLState:              storageElement.TTLState,
-		Schedule:              storageElement.Schedule,
-		Expression:            storageElement.Expression,
-		PythonExpression:      storageElement.PythonExpression,
-		Patterns:              storageElement.Patterns,
-		TTL:                   getTriggerTTL(storageElement.TTL),
-		IsRemote:              storageElement.IsRemote,
-		NotifyAboutNewMetrics: storageElement.NotifyAboutNewMetrics,
+		ID:               storageElement.ID,
+		Name:             storageElement.Name,
+		Desc:             storageElement.Desc,
+		Targets:          storageElement.Targets,
+		WarnValue:        storageElement.WarnValue,
+		ErrorValue:       storageElement.ErrorValue,
+		TriggerType:      storageElement.TriggerType,
+		Tags:             storageElement.Tags,
+		TTLState:         storageElement.TTLState,
+		Schedule:         storageElement.Schedule,
+		Expression:       storageElement.Expression,
+		PythonExpression: storageElement.PythonExpression,
+		Patterns:         storageElement.Patterns,
+		TTL:              getTriggerTTL(storageElement.TTL),
+		IsRemote:         storageElement.IsRemote,
+		MuteNewMetrics:   storageElement.MuteNewMetrics,
 	}
 }
 
 func toTriggerStorageElement(trigger *moira.Trigger, triggerID string) *triggerStorageElement {
 	return &triggerStorageElement{
-		ID:                    triggerID,
-		Name:                  trigger.Name,
-		Desc:                  trigger.Desc,
-		Targets:               trigger.Targets,
-		WarnValue:             trigger.WarnValue,
-		ErrorValue:            trigger.ErrorValue,
-		TriggerType:           trigger.TriggerType,
-		Tags:                  trigger.Tags,
-		TTLState:              trigger.TTLState,
-		Schedule:              trigger.Schedule,
-		Expression:            trigger.Expression,
-		PythonExpression:      trigger.PythonExpression,
-		Patterns:              trigger.Patterns,
-		TTL:                   getTriggerTTLString(trigger.TTL),
-		IsRemote:              trigger.IsRemote,
-		NotifyAboutNewMetrics: trigger.NotifyAboutNewMetrics,
+		ID:               triggerID,
+		Name:             trigger.Name,
+		Desc:             trigger.Desc,
+		Targets:          trigger.Targets,
+		WarnValue:        trigger.WarnValue,
+		ErrorValue:       trigger.ErrorValue,
+		TriggerType:      trigger.TriggerType,
+		Tags:             trigger.Tags,
+		TTLState:         trigger.TTLState,
+		Schedule:         trigger.Schedule,
+		Expression:       trigger.Expression,
+		PythonExpression: trigger.PythonExpression,
+		Patterns:         trigger.Patterns,
+		TTL:              getTriggerTTLString(trigger.TTL),
+		IsRemote:         trigger.IsRemote,
+		MuteNewMetrics:   trigger.MuteNewMetrics,
 	}
 }
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -129,22 +129,22 @@ const (
 
 // Trigger represents trigger data object
 type Trigger struct {
-	ID                    string        `json:"id"`
-	Name                  string        `json:"name"`
-	Desc                  *string       `json:"desc,omitempty"`
-	Targets               []string      `json:"targets"`
-	WarnValue             *float64      `json:"warn_value"`
-	ErrorValue            *float64      `json:"error_value"`
-	TriggerType           string        `json:"trigger_type"`
-	Tags                  []string      `json:"tags"`
-	TTLState              *string       `json:"ttl_state,omitempty"`
-	TTL                   int64         `json:"ttl,omitempty"`
-	Schedule              *ScheduleData `json:"sched,omitempty"`
-	Expression            *string       `json:"expression,omitempty"`
-	PythonExpression      *string       `json:"python_expression,omitempty"`
-	Patterns              []string      `json:"patterns"`
-	IsRemote              bool          `json:"is_remote"`
-	NotifyAboutNewMetrics bool          `json:"notify_about_new_metrics"`
+	ID               string        `json:"id"`
+	Name             string        `json:"name"`
+	Desc             *string       `json:"desc,omitempty"`
+	Targets          []string      `json:"targets"`
+	WarnValue        *float64      `json:"warn_value"`
+	ErrorValue       *float64      `json:"error_value"`
+	TriggerType      string        `json:"trigger_type"`
+	Tags             []string      `json:"tags"`
+	TTLState         *string       `json:"ttl_state,omitempty"`
+	TTL              int64         `json:"ttl,omitempty"`
+	Schedule         *ScheduleData `json:"sched,omitempty"`
+	Expression       *string       `json:"expression,omitempty"`
+	PythonExpression *string       `json:"python_expression,omitempty"`
+	Patterns         []string      `json:"patterns"`
+	IsRemote         bool          `json:"is_remote"`
+	MuteNewMetrics   bool          `json:"mute_new_metrics"`
 }
 
 // TriggerCheck represent trigger data with last check data and check timestamp
@@ -255,10 +255,10 @@ func (eventData NotificationEvent) String() string {
 }
 
 // GetOrCreateMetricState gets metric state from check data or create new if CheckData has no state for given metric
-func (checkData *CheckData) GetOrCreateMetricState(metric string, emptyTimestampValue int64, notifyAboutNewMetrics bool) MetricState {
+func (checkData *CheckData) GetOrCreateMetricState(metric string, emptyTimestampValue int64, muteNewMetric bool) MetricState {
 	_, ok := checkData.Metrics[metric]
 	if !ok {
-		checkData.Metrics[metric] = createEmptyMetricState(emptyTimestampValue, notifyAboutNewMetrics)
+		checkData.Metrics[metric] = createEmptyMetricState(emptyTimestampValue, !muteNewMetric)
 	}
 	return checkData.Metrics[metric]
 }

--- a/datatypes_test.go
+++ b/datatypes_test.go
@@ -144,13 +144,13 @@ func TestCheckData_GetOrCreateMetricState(t *testing.T) {
 		checkData := CheckData{
 			Metrics: make(map[string]MetricState),
 		}
-		So(checkData.GetOrCreateMetricState("my.metric", 12343, true), ShouldResemble, MetricState{State: "NODATA", Timestamp: 12343})
+		So(checkData.GetOrCreateMetricState("my.metric", 12343, false), ShouldResemble, MetricState{State: "NODATA", Timestamp: 12343})
 	})
 	Convey("Test no metric, notifyAboutNew = false", t, func() {
 		checkData := CheckData{
 			Metrics: make(map[string]MetricState),
 		}
-		So(checkData.GetOrCreateMetricState("my.metric", 12343, false), ShouldResemble, MetricState{State: "OK", Timestamp: time.Now().Unix(), EventTimestamp: time.Now().Unix()})
+		So(checkData.GetOrCreateMetricState("my.metric", 12343, true), ShouldResemble, MetricState{State: "OK", Timestamp: time.Now().Unix(), EventTimestamp: time.Now().Unix()})
 	})
 	Convey("Test has metric", t, func() {
 		metricState := MetricState{Timestamp: 11211}
@@ -159,7 +159,7 @@ func TestCheckData_GetOrCreateMetricState(t *testing.T) {
 				"my.metric": metricState,
 			},
 		}
-		So(checkData.GetOrCreateMetricState("my.metric", 12343, true), ShouldResemble, metricState)
+		So(checkData.GetOrCreateMetricState("my.metric", 12343, false), ShouldResemble, metricState)
 	})
 }
 


### PR DESCRIPTION
This PR reverse default behavior of Moira when new metrics are received. It is almost the same as #113 but by default Moira will send `NODATA - OK` events.