### PR TITLE
Log notifier state every 30 seconds, not every 1 second

### DIFF
--- a/notifier/notifications/error.go
+++ b/notifier/notifications/error.go
@@ -1,0 +1,11 @@
+package notifications
+
+// notifierInBadStateError is used for ERROR state of notifier service
+type notifierInBadStateError struct {
+	message string
+}
+
+// notifierInBadStateError implementation with constant error message
+func (err notifierInBadStateError) Error() string {
+	return err.message
+}

--- a/notifier/notifications/error.go
+++ b/notifier/notifications/error.go
@@ -1,11 +1,9 @@
 package notifications
 
 // notifierInBadStateError is used for ERROR state of notifier service
-type notifierInBadStateError struct {
-	message string
-}
+type notifierInBadStateError string
 
 // notifierInBadStateError implementation with constant error message
 func (err notifierInBadStateError) Error() string {
-	return err.message
+	return string(err)
 }

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -11,7 +11,7 @@ import (
 	"github.com/moira-alert/moira/notifier"
 )
 
-const sleepAfterNotifierBadState = time.Second * 30
+const sleepAfterNotifierBadState = time.Second * 10
 
 // FetchNotificationsWorker - check for new notifications and send it using notifier
 type FetchNotificationsWorker struct {
@@ -60,10 +60,10 @@ func (worker *FetchNotificationsWorker) processScheduledNotifications() error {
 	}
 	state, err := worker.Database.GetNotifierState()
 	if err != nil {
-		return notifierInBadStateError{"can't get current notifier state"}
+		return notifierInBadStateError("can't get current notifier state")
 	}
 	if state != "OK" {
-		return notifierInBadStateError{fmt.Sprintf("notifier in a bad state: %v", state)}
+		return notifierInBadStateError(fmt.Sprintf("notifier in a bad state: %v", state))
 	}
 
 	notificationPackages := make(map[string]*notifier.NotificationPackage)

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -11,6 +11,8 @@ import (
 	"github.com/moira-alert/moira/notifier"
 )
 
+const sleepAfterNotifierBadState = time.Second * 30
+
 // FetchNotificationsWorker - check for new notifications and send it using notifier
 type FetchNotificationsWorker struct {
 	Logger   moira.Logger
@@ -31,7 +33,13 @@ func (worker *FetchNotificationsWorker) Start() {
 				return nil
 			case <-checkTicker.C:
 				if err := worker.processScheduledNotifications(); err != nil {
-					worker.Logger.Warningf("Failed to fetch scheduled notifications: %s", err.Error())
+					switch err.(type) {
+					case notifierInBadStateError:
+						worker.Logger.Warningf("Stop sending notifications for %v: %s", sleepAfterNotifierBadState, err.Error())
+						<-time.After(sleepAfterNotifierBadState)
+					default:
+						worker.Logger.Warningf("Failed to fetch scheduled notifications: %s", err.Error())
+					}
 				}
 			}
 		}
@@ -52,10 +60,10 @@ func (worker *FetchNotificationsWorker) processScheduledNotifications() error {
 	}
 	state, err := worker.Database.GetNotifierState()
 	if err != nil {
-		return fmt.Errorf("can't get current notifier state")
+		return notifierInBadStateError{"can't get current notifier state"}
 	}
 	if state != "OK" {
-		return fmt.Errorf("stop sending notifications. Current notifier state: %v", state)
+		return notifierInBadStateError{fmt.Sprintf("notifier in a bad state: %v", state)}
 	}
 
 	notificationPackages := make(map[string]*notifier.NotificationPackage)


### PR DESCRIPTION
При отключении нотифаера, мы логгируем его состояние по тикеру каждую секунду. Это бессмысленно. Сделал так, чтобы при отключении нотифаера, писалось меньше логов.