### PR TITLE
Never save patterns for remote triggers

### DIFF
--- a/api/controller/triggers_test.go
+++ b/api/controller/triggers_test.go
@@ -103,7 +103,7 @@ func TestGetAllTriggers(t *testing.T) {
 		So(list, ShouldResemble, &dto.TriggersList{List: make([]moira.TriggerCheck, 0)})
 	})
 
-	Convey("GetTriggerIDs error", t, func() {
+	Convey("GetLocalTriggerIDs error", t, func() {
 		expected := fmt.Errorf("getTriggerIDs error")
 		mockDatabase.EXPECT().GetAllTriggerIDs().Return(nil, expected)
 		list, err := GetAllTriggers(mockDatabase)

--- a/checker/worker/nodata.go
+++ b/checker/worker/nodata.go
@@ -27,7 +27,7 @@ func (worker *Checker) checkNoData() error {
 		worker.Logger.Infof("Checking NODATA disabled. No metrics for %v seconds", now-worker.lastData)
 	} else {
 		worker.Logger.Info("Checking NODATA")
-		triggerIds, err := worker.Database.GetTriggerIDs()
+		triggerIds, err := worker.Database.GetLocalTriggerIDs()
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -359,7 +359,7 @@ func ConvertSubscriptions(database moira.Database, logger moira.Logger, rollback
 // - update: Set trigger_type to one of the following options: "expression" (trigger has custom user expression) "rising" (error > warn > ok), "falling" (error < warn < ok)
 // - rollback: Set trigger_type to empty string and fill omitted warn/error values
 func ConvertTriggers(dataBase moira.Database, logger moira.Logger, rollback bool) error {
-	allTriggerIDs, err := dataBase.GetTriggerIDs()
+	allTriggerIDs, err := dataBase.GetLocalTriggerIDs()
 	if err != nil {
 		return err
 	}

--- a/database/redis/database_test.go
+++ b/database/redis/database_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// docker run -p 6379:6379 redis
 func TestInitialization(t *testing.T) {
 	Convey("Initialization methods", t, func() {
 		logger, _ := logging.ConfigureLog("stdout", "info", "test")

--- a/database/redis/trigger.go
+++ b/database/redis/trigger.go
@@ -133,7 +133,11 @@ func (connector *DbConnector) SaveTrigger(triggerID string, trigger *moira.Trigg
 	c.Send("MULTI")
 	cleanupPatterns := make([]string, 0)
 	if errGetTrigger != database.ErrNil {
-		for _, pattern := range moira.GetStringListsDiff(existing.Patterns, trigger.Patterns) {
+		triggerPatterns := trigger.Patterns
+		if trigger.IsRemote {
+			triggerPatterns = make([]string, 0)
+		}
+		for _, pattern := range moira.GetStringListsDiff(existing.Patterns, triggerPatterns) {
 			c.Send("SREM", patternTriggersKey(pattern), triggerID)
 			cleanupPatterns = append(cleanupPatterns, pattern)
 		}

--- a/database/redis/trigger.go
+++ b/database/redis/trigger.go
@@ -22,8 +22,8 @@ func (connector *DbConnector) GetAllTriggerIDs() ([]string, error) {
 	return triggerIds, nil
 }
 
-// GetTriggerIDs gets moira triggerIDs without remote
-func (connector *DbConnector) GetTriggerIDs() ([]string, error) {
+// GetLocalTriggerIDs gets moira local triggerIDs
+func (connector *DbConnector) GetLocalTriggerIDs() ([]string, error) {
 	c := connector.pool.Get()
 	defer c.Close()
 	triggerIds, err := redis.Strings(c.Do("SDIFF", triggersListKey, remoteTriggersListKey))

--- a/database/redis/trigger.go
+++ b/database/redis/trigger.go
@@ -124,6 +124,9 @@ func (connector *DbConnector) SaveTrigger(triggerID string, trigger *moira.Trigg
 	if errGetTrigger != nil && errGetTrigger != database.ErrNil {
 		return errGetTrigger
 	}
+	if trigger.IsRemote {
+		trigger.Patterns = make([]string, 0)
+	}
 	bytes, err := reply.GetTriggerBytes(triggerID, trigger)
 	if err != nil {
 		return err
@@ -133,11 +136,7 @@ func (connector *DbConnector) SaveTrigger(triggerID string, trigger *moira.Trigg
 	c.Send("MULTI")
 	cleanupPatterns := make([]string, 0)
 	if errGetTrigger != database.ErrNil {
-		triggerPatterns := trigger.Patterns
-		if trigger.IsRemote {
-			triggerPatterns = make([]string, 0)
-		}
-		for _, pattern := range moira.GetStringListsDiff(existing.Patterns, triggerPatterns) {
+		for _, pattern := range moira.GetStringListsDiff(existing.Patterns, trigger.Patterns) {
 			c.Send("SREM", patternTriggersKey(pattern), triggerID)
 			cleanupPatterns = append(cleanupPatterns, pattern)
 		}

--- a/database/redis/trigger_test.go
+++ b/database/redis/trigger_test.go
@@ -481,7 +481,7 @@ func TestRemoteTrigger(t *testing.T) {
 		})
 	})
 
-	Convey("Resaving remote trigger as non-remote", t, func() {
+	Convey("Update remote trigger as local", t, func() {
 		trigger.IsRemote = false
 		trigger.Patterns = []string{pattern}
 		Convey("Trigger should be saved correctly", func() {
@@ -506,7 +506,7 @@ func TestRemoteTrigger(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{})
 		})
-		Convey("Trigger shouldn't be returned as non-remote", func() {
+		Convey("Trigger shouldn't be returned as local", func() {
 			ids, err := dataBase.GetPatternTriggerIDs(pattern)
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})

--- a/database/redis/trigger_test.go
+++ b/database/redis/trigger_test.go
@@ -473,6 +473,11 @@ func TestRemoteTrigger(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{})
 		})
+		Convey("Trigger pattern shouldn't be in patterns collection", func() {
+			patterns, err := dataBase.GetPatterns()
+			So(err, ShouldBeNil)
+			So(patterns, ShouldResemble, []string{})
+		})
 	})
 
 	Convey("Resaving remote trigger as non-remote", t, func() {
@@ -508,6 +513,45 @@ func TestRemoteTrigger(t *testing.T) {
 			ids, err := dataBase.GetPatternTriggerIDs(trigger.Patterns[0])
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
+		})
+		Convey("Trigger pattern should be in patterns collection", func() {
+			patterns, err := dataBase.GetPatterns()
+			So(err, ShouldBeNil)
+			So(patterns, ShouldResemble, trigger.Patterns)
+		})
+
+		trigger.IsRemote = true
+		Convey("Update this trigger as remote", func() {
+			err := dataBase.SaveTrigger(trigger.ID, trigger)
+			So(err, ShouldBeNil)
+			actual, err := dataBase.GetTrigger(trigger.ID)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, *trigger)
+		})
+		Convey("Trigger should be deleted from local triggers collection", func() {
+			ids, err := dataBase.GetLocalTriggerIDs()
+			So(err, ShouldBeNil)
+			So(ids, ShouldResemble, []string{})
+		})
+		Convey("Trigger should still be in all triggers collection", func() {
+			ids, err := dataBase.GetAllTriggerIDs()
+			So(err, ShouldBeNil)
+			So(ids, ShouldResemble, []string{trigger.ID})
+		})
+		Convey("Trigger should be added to remote triggers collection", func() {
+			ids, err := dataBase.GetRemoteTriggerIDs()
+			So(err, ShouldBeNil)
+			So(ids, ShouldResemble, []string{trigger.ID})
+		})
+		Convey("Trigger should deleted from patterns collection", func() {
+			ids, err := dataBase.GetPatternTriggerIDs(trigger.Patterns[0])
+			So(err, ShouldBeNil)
+			So(ids, ShouldResemble, []string{})
+		})
+		Convey("Trigger pattern should not be in patterns collection", func() {
+			patterns, err := dataBase.GetPatterns()
+			So(err, ShouldBeNil)
+			So(patterns, ShouldResemble, []string{})
 		})
 	})
 }

--- a/database/redis/trigger_test.go
+++ b/database/redis/trigger_test.go
@@ -434,11 +434,12 @@ func TestTriggerStoring(t *testing.T) {
 func TestRemoteTrigger(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewDatabase(logger, config)
+	pattern := "test.pattern.remote1"
 	trigger := &moira.Trigger{
 		ID:          "triggerID-0000000000010",
 		Name:        "remote",
 		Targets:     []string{"test.target.remote1"},
-		Patterns:    []string{"test.pattern.remote1"},
+		Patterns:    []string{pattern},
 		IsRemote:    true,
 		TriggerType: moira.RisingTrigger,
 	}
@@ -469,7 +470,7 @@ func TestRemoteTrigger(t *testing.T) {
 			So(ids, ShouldResemble, []string{trigger.ID})
 		})
 		Convey("Trigger should not be added to patterns collection", func() {
-			ids, err := dataBase.GetPatternTriggerIDs(trigger.Patterns[0])
+			ids, err := dataBase.GetPatternTriggerIDs(pattern)
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{})
 		})
@@ -482,6 +483,7 @@ func TestRemoteTrigger(t *testing.T) {
 
 	Convey("Resaving remote trigger as non-remote", t, func() {
 		trigger.IsRemote = false
+		trigger.Patterns = []string{pattern}
 		Convey("Trigger should be saved correctly", func() {
 			err := dataBase.SaveTrigger(trigger.ID, trigger)
 			So(err, ShouldBeNil)
@@ -505,12 +507,12 @@ func TestRemoteTrigger(t *testing.T) {
 			So(ids, ShouldResemble, []string{})
 		})
 		Convey("Trigger shouldn't be returned as non-remote", func() {
-			ids, err := dataBase.GetPatternTriggerIDs(trigger.Patterns[0])
+			ids, err := dataBase.GetPatternTriggerIDs(pattern)
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
 		})
 		Convey("Trigger should be added to patterns collection", func() {
-			ids, err := dataBase.GetPatternTriggerIDs(trigger.Patterns[0])
+			ids, err := dataBase.GetPatternTriggerIDs(pattern)
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
 		})
@@ -544,7 +546,7 @@ func TestRemoteTrigger(t *testing.T) {
 			So(ids, ShouldResemble, []string{trigger.ID})
 		})
 		Convey("Trigger should deleted from patterns collection", func() {
-			ids, err := dataBase.GetPatternTriggerIDs(trigger.Patterns[0])
+			ids, err := dataBase.GetPatternTriggerIDs(pattern)
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{})
 		})

--- a/database/redis/trigger_test.go
+++ b/database/redis/trigger_test.go
@@ -38,7 +38,7 @@ func TestTriggerStoring(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, *trigger)
 
-			ids, err := dataBase.GetTriggerIDs()
+			ids, err := dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
 
@@ -159,7 +159,7 @@ func TestTriggerStoring(t *testing.T) {
 			So(err, ShouldResemble, database.ErrNil)
 			So(actual, ShouldResemble, moira.Trigger{})
 
-			ids, err = dataBase.GetTriggerIDs()
+			ids, err = dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldBeEmpty)
 
@@ -308,7 +308,7 @@ func TestTriggerStoring(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, *triggerVer1)
 
-			ids, err := dataBase.GetTriggerIDs()
+			ids, err := dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{triggerVer1.ID})
 
@@ -354,7 +354,7 @@ func TestTriggerStoring(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, *triggerVer2)
 
-			ids, err = dataBase.GetTriggerIDs()
+			ids, err = dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{triggerVer2.ID})
 
@@ -404,7 +404,7 @@ func TestTriggerStoring(t *testing.T) {
 			So(err, ShouldResemble, database.ErrNil)
 			So(actual, ShouldResemble, moira.Trigger{})
 
-			ids, err = dataBase.GetTriggerIDs()
+			ids, err = dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{})
 
@@ -458,8 +458,8 @@ func TestRemoteTrigger(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
 		})
-		Convey("Trigger should not be returned as non-remote trigger", func() { //TODO rewrite msg
-			ids, err := dataBase.GetTriggerIDs()
+		Convey("Trigger should not be added to local triggers collection", func() {
+			ids, err := dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{})
 		})
@@ -485,7 +485,7 @@ func TestRemoteTrigger(t *testing.T) {
 			So(actual, ShouldResemble, *trigger)
 		})
 		Convey("Trigger should be added to triggers collection", func() {
-			ids, err := dataBase.GetTriggerIDs()
+			ids, err := dataBase.GetLocalTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
 		})
@@ -518,7 +518,7 @@ func TestTriggerErrorConnection(t *testing.T) {
 	dataBase.flush()
 	defer dataBase.flush()
 	Convey("Should throw error when no connection", t, func() {
-		actual, err := dataBase.GetTriggerIDs()
+		actual, err := dataBase.GetLocalTriggerIDs()
 		So(err, ShouldNotBeNil)
 		So(actual, ShouldBeNil)
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -29,7 +29,7 @@ type Database interface {
 	SetTriggerCheckMetricsMaintenance(triggerID string, metrics map[string]int64) error
 
 	// Trigger storing
-	GetTriggerIDs() ([]string, error)
+	GetLocalTriggerIDs() ([]string, error)
 	GetAllTriggerIDs() ([]string, error)
 	GetRemoteTriggerIDs() ([]string, error)
 	GetTrigger(triggerID string) (Trigger, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -556,17 +556,17 @@ func (mr *MockDatabaseMockRecorder) GetTriggerChecks(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggerChecks", reflect.TypeOf((*MockDatabase)(nil).GetTriggerChecks), arg0)
 }
 
-// GetTriggerIDs mocks base method
+// GetLocalTriggerIDs mocks base method
 func (m *MockDatabase) GetTriggerIDs() ([]string, error) {
-	ret := m.ctrl.Call(m, "GetTriggerIDs")
+	ret := m.ctrl.Call(m, "GetLocalTriggerIDs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTriggerIDs indicates an expected call of GetTriggerIDs
+// GetLocalTriggerIDs indicates an expected call of GetLocalTriggerIDs
 func (mr *MockDatabaseMockRecorder) GetTriggerIDs() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetTriggerIDs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetTriggerIDs))
 }
 
 // GetTriggerLastCheck mocks base method

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -270,6 +270,19 @@ func (mr *MockDatabaseMockRecorder) GetIDByUsername(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDByUsername", reflect.TypeOf((*MockDatabase)(nil).GetIDByUsername), arg0, arg1)
 }
 
+// GetLocalTriggerIDs mocks base method
+func (m *MockDatabase) GetLocalTriggerIDs() ([]string, error) {
+	ret := m.ctrl.Call(m, "GetLocalTriggerIDs")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLocalTriggerIDs indicates an expected call of GetLocalTriggerIDs
+func (mr *MockDatabaseMockRecorder) GetLocalTriggerIDs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetLocalTriggerIDs))
+}
+
 // GetMetricRetention mocks base method
 func (m *MockDatabase) GetMetricRetention(arg0 string) (int64, error) {
 	ret := m.ctrl.Call(m, "GetMetricRetention", arg0)
@@ -554,19 +567,6 @@ func (m *MockDatabase) GetTriggerChecks(arg0 []string) ([]*moira.TriggerCheck, e
 // GetTriggerChecks indicates an expected call of GetTriggerChecks
 func (mr *MockDatabaseMockRecorder) GetTriggerChecks(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggerChecks", reflect.TypeOf((*MockDatabase)(nil).GetTriggerChecks), arg0)
-}
-
-// GetLocalTriggerIDs mocks base method
-func (m *MockDatabase) GetTriggerIDs() ([]string, error) {
-	ret := m.ctrl.Call(m, "GetLocalTriggerIDs")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLocalTriggerIDs indicates an expected call of GetLocalTriggerIDs
-func (mr *MockDatabaseMockRecorder) GetTriggerIDs() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetTriggerIDs))
 }
 
 // GetTriggerLastCheck mocks base method


### PR DESCRIPTION
Решил немного go вспомнить. Я тут спалил что в SaveTrigger нам никто не запрещает remote передавать триггеры с паттернами, если такое произойдет, то у нас добавятся паттерны в лист для построения дерева в фильтре. Хочется такого избежать. 
Сейчас единственное место сохранения триггера это апи, где мы по хардкору не заполняем паттерны если это не нужно, хочется уберечь себя от случайного выстрела в ногу, если мы где-то объебемся. Плюс немного переименования =)