### PR TITLE
Improvements in plotting render calls

### DIFF
--- a/api/controller/trigger_metrics_test.go
+++ b/api/controller/trigger_metrics_test.go
@@ -308,7 +308,7 @@ func TestGetTriggerMetrics(t *testing.T) {
 		dataBase.EXPECT().GetMetricsValues([]string{metric}, from, until).Return(dataList, nil)
 		triggerMetrics, err := GetTriggerMetrics(dataBase, remoteCfg, from, until, triggerID)
 		So(err, ShouldBeNil)
-		So(*triggerMetrics, ShouldResemble, dto.TriggerMetrics{Main: map[string][]*moira.MetricValue{metric: {{Value: 0, Timestamp: 17}, {Value: 1, Timestamp: 27}, {Value: 2, Timestamp: 37}, {Value: 3, Timestamp: 47}, {Value: 4, Timestamp: 57}}}, Additional: make(map[string][]*moira.MetricValue)})
+		So(*triggerMetrics, ShouldResemble, dto.TriggerMetrics{Main: map[string][]*moira.MetricValue{metric: {{Value: 0, Timestamp: 17}, {Value: 1, Timestamp: 27}, {Value: 2, Timestamp: 37}, {Value: 3, Timestamp: 47}}}, Additional: make(map[string][]*moira.MetricValue)})
 	})
 
 	Convey("GetTrigger error", t, func() {

--- a/api/handler/trigger_render.go
+++ b/api/handler/trigger_render.go
@@ -3,8 +3,8 @@ package handler
 import (
 	"fmt"
 	"net/http"
-	"time"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/render"
 	"github.com/go-graphite/carbonapi/date"

--- a/datatypes.go
+++ b/datatypes.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	eventStates = [...]string{"OK", "WARN", "ERROR", "NODATA", "TEST"}
+	eventStates = [...]string{"OK", "WARN", "ERROR", "NODATA", "EXCEPTION", "TEST"}
 )
 
 var scores = map[string]int64{

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -37,8 +37,8 @@ func TestGetMetricNames(t *testing.T) {
 		So(actual, ShouldResemble, expected)
 	})
 	Convey("Test empty notification package", t, func() {
-		notificationsPackage = NotificationPackage{}
-		actual := notificationsPackage.GetMetricNames()
+		emptyNotificationPackage := NotificationPackage{}
+		actual := emptyNotificationPackage.GetMetricNames()
 		So(actual, ShouldResemble, make([]string, 0))
 	})
 }
@@ -51,8 +51,8 @@ func TestGetWindow(t *testing.T) {
 		So(to, ShouldEqual, 79)
 	})
 	Convey("Test empty notification package", t, func() {
-		notificationsPackage = NotificationPackage{}
-		_, _, err := notificationsPackage.GetWindow()
+		emptyNotificationPackage := NotificationPackage{}
+		_, _, err := emptyNotificationPackage.GetWindow()
 		So(err, ShouldResemble, fmt.Errorf("not enough data to resolve package window"))
 	})
 }

--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -151,7 +151,7 @@ func fetchAvailableSeries(database moira.Database, remoteCfg *remote.Config, isR
 	}
 	result, realtimeErr := target.EvaluateTarget(database, tar, from, to, true)
 	switch realtimeErr.(type) {
-	case target.ErrEvalExprFailedWithPanic:
+	case target.ErrEvaluateTargetFailedWithPanic:
 		result, err = target.EvaluateTarget(database, tar, from, to, false)
 		if err != nil {
 			return nil, errFetchAvailableSeriesFailed{realtimeErr:realtimeErr.Error(), storedErr:err.Error()}

--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/moira-alert/moira/plotting"
 	"github.com/moira-alert/moira/remote"
 	"github.com/moira-alert/moira/target"
-	"fmt"
 )
 
 var (

--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moira-alert/moira/plotting"
 	"github.com/moira-alert/moira/remote"
 	"github.com/moira-alert/moira/target"
+	"fmt"
 )
 
 var (
@@ -21,6 +22,17 @@ var (
 	// defaultTimeRange is default time range to fetch timeseries
 	defaultTimeRange = 30 * time.Minute
 )
+
+// ErrFetchAvailableSeriesFailed is used in cases when fetchAvailableSeries failed after retry
+type ErrFetchAvailableSeriesFailed struct {
+	realtimeErr string
+	storedErr   string
+}
+
+// Error is implementation of golang error interface for ErrFetchAvailableSeriesFailed struct
+func (err ErrFetchAvailableSeriesFailed) Error() string {
+	return fmt.Sprintf("Failed to fetch both realtime and stored data: [realtime]: %s, [stored]: %s", err.realtimeErr, err.storedErr)
+}
 
 // buildNotificationPackagePlot returns bytes slice containing package plot
 func (notifier *StandardNotifier) buildNotificationPackagePlot(pkg NotificationPackage) ([]byte, error) {
@@ -106,7 +118,6 @@ func evaluateTriggerMetrics(database moira.Database, remoteCfg *remote.Config, f
 
 // getTriggerEvaluationResult returns trigger metrics from chosen data source
 func getTriggerEvaluationResult(dataBase moira.Database, remoteConfig *remote.Config, from, to int64, triggerID string) (*checker.TriggerTimeSeries, *moira.Trigger, error) {
-	allowRealtimeAlerting := true
 	trigger, err := dataBase.GetTrigger(triggerID)
 	if err != nil {
 		return nil, nil, err
@@ -119,18 +130,9 @@ func getTriggerEvaluationResult(dataBase moira.Database, remoteConfig *remote.Co
 		return nil, &trigger, remote.ErrRemoteStorageDisabled
 	}
 	for i, tar := range trigger.Targets {
-		var timeSeries []*target.TimeSeries
-		if trigger.IsRemote {
-			timeSeries, err = remote.Fetch(remoteConfig, tar, from, to, allowRealtimeAlerting)
-			if err != nil {
-				return nil, &trigger, err
-			}
-		} else {
-			result, err := target.EvaluateTarget(dataBase, tar, from, to, allowRealtimeAlerting)
-			if err != nil {
-				return nil, &trigger, err
-			}
-			timeSeries = result.TimeSeries
+		timeSeries, err := fetchAvailableSeries(dataBase, remoteConfig, trigger.IsRemote, tar, from, to)
+		if err != nil {
+			return nil, &trigger, err
 		}
 		if i == 0 {
 			triggerMetrics.Main = timeSeries
@@ -139,4 +141,30 @@ func getTriggerEvaluationResult(dataBase moira.Database, remoteConfig *remote.Co
 		}
 	}
 	return triggerMetrics, &trigger, nil
+}
+
+// fetchAvailableSeries calls fetch function with realtime alerting and retries on fail without
+func fetchAvailableSeries(database moira.Database, remoteCfg *remote.Config, isRemote bool, tar string, from, to int64) ([]*target.TimeSeries, error) {
+	var err error
+	allowRealtimeAlerting := true
+	if isRemote {
+		timeSeries, realtimeErr := remote.Fetch(remoteCfg, tar, from, to, allowRealtimeAlerting)
+		if realtimeErr != nil {
+			allowRealtimeAlerting = false
+			timeSeries, err = remote.Fetch(remoteCfg, tar, from, to, allowRealtimeAlerting)
+			if err != nil {
+				return nil, ErrFetchAvailableSeriesFailed{realtimeErr:realtimeErr.Error(), storedErr:err.Error()}
+			}
+		}
+		return timeSeries, nil
+	}
+	result, realtimeErr := target.EvaluateTarget(database, tar, from, to, allowRealtimeAlerting)
+	if realtimeErr != nil {
+		allowRealtimeAlerting = false
+		result, err = target.EvaluateTarget(database, tar, from, to, allowRealtimeAlerting)
+		if err != nil {
+			return nil, ErrFetchAvailableSeriesFailed{realtimeErr:realtimeErr.Error(), storedErr:err.Error()}
+		}
+	}
+	return result.TimeSeries, nil
 }

--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -157,5 +157,5 @@ func fetchAvailableSeries(database moira.Database, remoteCfg *remote.Config, isR
 			return nil, errFetchAvailableSeriesFailed{realtimeErr:realtimeErr.Error(), storedErr:err.Error()}
 		}
 	}
-	return result.TimeSeries, err
+	return result.TimeSeries, realtimeErr
 }

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -76,7 +76,7 @@ func (sender *Sender) talk(username, message string, plot []byte) error {
 		photo := telebot.Photo{File: telebot.FromReader(bytes.NewReader(plot))}
 		_, err = photo.Send(sender.bot, chat, &telebot.SendOptions{ReplyTo: postedMessage})
 		if err != nil {
-			return fmt.Errorf("can't send event plot to %s: %s", uid, err.Error())
+			sender.logger.Errorf("can't send event plot to %s: %s", uid, err.Error())
 		}
 	}
 	return nil

--- a/target/target.go
+++ b/target/target.go
@@ -11,15 +11,15 @@ import (
 	"github.com/moira-alert/moira"
 )
 
-// ErrEvalExprFailedWithPanic used to identify occurred error as a result of recover from panic
-type ErrEvalExprFailedWithPanic struct {
+// ErrEvaluateTargetFailedWithPanic used to identify occurred error as a result of recover from panic
+type ErrEvaluateTargetFailedWithPanic struct {
 	target         string
 	recoverMessage interface{}
 	stackRecord    []byte
 }
 
-// Error is implementation of golang error interface for ErrEvalExprFailedWithPanic struct
-func(err ErrEvalExprFailedWithPanic) Error() string {
+// Error is implementation of golang error interface for ErrEvaluateTargetFailedWithPanic struct
+func(err ErrEvaluateTargetFailedWithPanic) Error() string {
 	return fmt.Sprintf("panic while evaluate target %s: message: '%s' stack: %s", err.target, err.recoverMessage, err.stackRecord)
 }
 
@@ -65,7 +65,7 @@ func EvaluateTarget(database moira.Database, target string, from int64, until in
 				defer func() {
 					if r := recover(); r != nil {
 						result = nil
-						err = ErrEvalExprFailedWithPanic{target: target, recoverMessage: r, stackRecord: debug.Stack()}
+						err = ErrEvaluateTargetFailedWithPanic{target: target, recoverMessage: r, stackRecord: debug.Stack()}
 					}
 				}()
 				result, err = expr.EvalExpr(expr2, from, until, metricsMap)


### PR DESCRIPTION
- Retry to render plots in notifications without realtime, return ErrFetchAvailableSeriesFailed if failed again
- Added boolean ```realtime``` param to api/trigger/triggerId/render requests handler, defaults to false
- Rendering /api/trigger/triggerId/metrics allways usese AllowRealtimeAlerting set to false
- Added some more tests