### PR TITLE
Metrics parsing optimization

### DIFF
--- a/filter/patterns_storage_test.go
+++ b/filter/patterns_storage_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/moira-alert/moira/metrics/graphite/go-metrics"
-	"github.com/moira-alert/moira/mock/moira-alert"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
 	"github.com/op/go-logging"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -45,7 +45,7 @@ func TestParseMetricFromString(t *testing.T) {
 		}
 
 		for _, invalidMetric := range invalidMetrics {
-			_, _, _, err := storage.parseMetricFromString([]byte(invalidMetric))
+			_, _, _, err := storage.parseMetric([]byte(invalidMetric))
 			So(err, ShouldBeError)
 		}
 	})
@@ -62,7 +62,7 @@ func TestParseMetricFromString(t *testing.T) {
 		}
 
 		for _, validMetric := range validMetrics {
-			metric, value, timestamp, err := storage.parseMetricFromString([]byte(validMetric.raw))
+			metric, value, timestamp, err := storage.parseMetric([]byte(validMetric.raw))
 			So(err, ShouldBeEmpty)
 			So(metric, ShouldResemble, []byte(validMetric.metric))
 			So(value, ShouldResemble, validMetric.value)
@@ -88,7 +88,7 @@ func TestParseMetricFromString(t *testing.T) {
 			rawTimestamp := strconv.FormatFloat(float64(testTimestamp)+rand.Float64(), 'f', i, 64)
 			rawMetric := "One.two.three 123 " + rawTimestamp
 			validMetric := ValidMetricCase{rawMetric, "One.two.three", 123, testTimestamp}
-			metric, value, timestamp, err := storage.parseMetricFromString([]byte(validMetric.raw))
+			metric, value, timestamp, err := storage.parseMetric([]byte(validMetric.raw))
 			So(err, ShouldBeEmpty)
 			So(metric, ShouldResemble, []byte(validMetric.metric))
 			So(value, ShouldResemble, validMetric.value)


### PR DESCRIPTION
```
package main

import (
	"bytes"
	"fmt"
	"math"
	"strconv"
	"unicode"
	"unsafe"
)

func ParseMetricBase(input []byte) ([]byte, float64, int64, error) {
	var parts [3][]byte
	partIndex := 0
	partOffset := 0
	for i, b := range input {
		r := rune(b)
		if r > unicode.MaxASCII || !strconv.IsPrint(r) {
			return nil, 0, 0, fmt.Errorf("non-ascii or non-printable chars in metric name: '%s'", input)
		}
		if b == ' ' {
			parts[partIndex] = input[partOffset:i]
			partOffset = i + 1
			partIndex++
		}
		if partIndex > 2 {
			return nil, 0, 0, fmt.Errorf("too many space-separated items: '%s'", input)
		}
	}

	if partIndex < 2 {
		return nil, 0, 0, fmt.Errorf("too few space-separated items: '%s'", input)
	}

	parts[partIndex] = input[partOffset:]

	metric := parts[0]
	if len(metric) < 1 {
		return nil, 0, 0, fmt.Errorf("metric name is empty: '%s'", input)
	}

	value, err := strconv.ParseFloat(string(parts[1]), 64)
	if err != nil {
		return nil, 0, 0, fmt.Errorf("cannot parse value: '%s' (%s)", input, err)
	}

	timestamp, err := parseTimestamp(string(parts[2]))
	if err != nil || timestamp == 0 {
		return nil, 0, 0, fmt.Errorf("cannot parse timestamp: '%s' (%s)", input, err)
	}

	return metric, value, timestamp, nil
}

func parseTimestamp(unixTimestamp string) (int64, error) {
	timestamp, err := strconv.ParseFloat(unixTimestamp, 64)
	return int64(timestamp), err
}

// https://github.com/golang/go/issues/2632#issuecomment-66061057
func unsafeString(b []byte) string {
	return *(*string)(unsafe.Pointer(&b))
}

func isPrintableASCII(b []byte) bool {
	for i := 0; i < len(b); i++ {
		if b[i] <= 0x20 || b[i] > 0x7E {
			return false
		}
	}

	return true
}


func ParseMetric(p []byte) ([]byte, float64, int64, error) {
	i1 := bytes.IndexByte(p, ' ')
	if i1 < 1 {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	i2 := bytes.IndexByte(p[i1+1:], ' ')
	if i2 < 1 {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}
	i2 += i1 + 1

	name := p[:i1]
	if !isPrintableASCII(name) {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	value, err := strconv.ParseFloat(unsafeString(p[i1+1:i2]), 64)
	if err != nil || math.IsNaN(value) {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	tsf, err := strconv.ParseFloat(unsafeString(p[i2+1:]), 64)
	if err != nil || math.IsNaN(tsf) {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	return name, value, int64(tsf), nil
}

func ParseMetricCarbon(p []byte) ([]byte, float64, int64, error) {
	i1 := bytes.IndexByte(p, ' ')
	if i1 < 1 {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	i2 := bytes.IndexByte(p[i1+1:], ' ')
	if i2 < 1 {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}
	i2 += i1 + 1

	value, err := strconv.ParseFloat(unsafeString(p[i1+1:i2]), 64)
	if err != nil || math.IsNaN(value) {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	tsf, err := strconv.ParseFloat(unsafeString(p[i2+1:]), 64)
	if err != nil || math.IsNaN(tsf) {
		return nil, 0, 0, fmt.Errorf("bad message: %#v", string(p))
	}

	return p[:i1], value, int64(tsf), nil
}
```

```
package main

import "testing"

var validMetrics = []string{
	"One.two.three 123 1234567890",
	"One.two.three 1.23e2 1234567890",
	"One.two.three -123 1234567890",
	"One.two.three +123 1234567890",
	"One.two.three 123. 1234567890",
	"One.two.three 123.0 1234567890",
	"One.two.three .123 1234567890",
}

func BenchmarkParseMetricBase(b *testing.B) {
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		for _, metric := range validMetrics {
			ParseMetricBase([]byte(metric))
		}
	}
}

func BenchmarkParseMetric(b *testing.B) {
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		for _, metric := range validMetrics {
			ParseMetric([]byte(metric))
		}
	}
}

func BenchmarkParseMetricCarbon(b *testing.B) {
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		for _, metric := range validMetrics {
			ParseMetricCarbon([]byte(metric))
		}
	}
}
```

```
BenchmarkParseMetricBase-4     	  200000	      6396 ns/op	     336 B/op	      21 allocs/op
BenchmarkParseMetric-4         	 1000000	      1929 ns/op	     224 B/op	       7 allocs/op
BenchmarkParseMetricCarbon-4   	 1000000	      1055 ns/op	     224 B/op	       7 allocs/op
```
