### PR TITLE
Limit message size in Slack sender

### DIFF
--- a/senders/slack/slack.go
+++ b/senders/slack/slack.go
@@ -19,7 +19,7 @@ const (
 	exceptionEmoji = ":moira-state-exception:"
 	testEmoji      = ":moira-state-test:"
 
-	messageMaxCharacters          = 4000
+	messageMaxCharacters          = 40000
 	additionalInfoCharactersCount = 400
 )
 

--- a/senders/slack/slack_test.go
+++ b/senders/slack/slack_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -133,6 +134,17 @@ func TestBuildMessage(t *testing.T) {
 		Convey("Print moira message with 6 events", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event, event, event, event, event, event}, trigger, false)
 			expected := "*NODATA* [tag1][tag2] <http://moira.url/trigger/TriggerID|Name>\n```\n02:40: Metric = 123 (OK to NODATA)\n02:40: Metric = 123 (OK to NODATA)\n02:40: Metric = 123 (OK to NODATA)\n02:40: Metric = 123 (OK to NODATA)\n02:40: Metric = 123 (OK to NODATA)\n02:40: Metric = 123 (OK to NODATA)```"
+			So(actual, ShouldResemble, expected)
+		})
+
+		events := make([]moira.NotificationEvent, 0)
+		Convey("Print moira message with 100 events and cutoff", func() {
+			for i := 0; i < 200; i++ {
+				events = append(events, event)
+			}
+			lines := strings.Repeat("\n02:40: Metric = 123 (OK to NODATA)", 100)
+			actual := sender.buildMessage(events, trigger, false)
+			expected := fmt.Sprintf("*NODATA* [tag1][tag2] <http://moira.url/trigger/TriggerID|Name>\n```%s```\n\n...and 100 more events.", lines)
 			So(actual, ShouldResemble, expected)
 		})
 

--- a/senders/slack/slack_test.go
+++ b/senders/slack/slack_test.go
@@ -138,13 +138,13 @@ func TestBuildMessage(t *testing.T) {
 		})
 
 		events := make([]moira.NotificationEvent, 0)
-		Convey("Print moira message with 100 events and cutoff", func() {
-			for i := 0; i < 200; i++ {
+		Convey("Print moira message with 1129 events and cutoff", func() {
+			for i := 0; i < 1200; i++ {
 				events = append(events, event)
 			}
-			lines := strings.Repeat("\n02:40: Metric = 123 (OK to NODATA)", 100)
+			lines := strings.Repeat("\n02:40: Metric = 123 (OK to NODATA)", 1129)
 			actual := sender.buildMessage(events, trigger, false)
-			expected := fmt.Sprintf("*NODATA* [tag1][tag2] <http://moira.url/trigger/TriggerID|Name>\n```%s```\n\n...and 100 more events.", lines)
+			expected := fmt.Sprintf("*NODATA* [tag1][tag2] <http://moira.url/trigger/TriggerID|Name>\n```%s```\n\n...and 71 more events.", lines)
 			So(actual, ShouldResemble, expected)
 		})
 


### PR DESCRIPTION
Fix #255
Solution is based on Telegram's sender.

Even though the original issue mentioned a 40k character limit, the current limit set by Slack seems to be at 4k.
