### PR TITLE
Add smtp_hello parameter on mail sender

### DIFF
--- a/senders/mail/mail.go
+++ b/senders/mail/mail.go
@@ -15,6 +15,7 @@ import (
 // Sender implements moira sender interface via pushover
 type Sender struct {
 	From           string
+	SMTPHello			 string
 	SMTPHost       string
 	SMTPPort       int64
 	FrontURI       string
@@ -46,6 +47,7 @@ func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger
 func (sender *Sender) fillSettings(senderSettings map[string]string, logger moira.Logger, location *time.Location, dateTimeFormat string) error {
 	sender.logger = logger
 	sender.From = senderSettings["mail_from"]
+	sender.SMTPHello = senderSettings["smtp_hello"]
 	sender.SMTPHost = senderSettings["smtp_host"]
 	sender.SMTPPort, _ = strconv.ParseInt(senderSettings["smtp_port"], 10, 64)
 	sender.InsecureTLS, _ = strconv.ParseBool(senderSettings["insecure_tls"])

--- a/senders/mail/mail.go
+++ b/senders/mail/mail.go
@@ -87,6 +87,11 @@ func (sender *Sender) tryDial() error {
 		return err
 	}
 	defer t.Close()
+	if sender.SMTPHello != "" {
+		if err := t.Hello(sender.SMTPHello); err != nil {
+			return err
+		}
+	}
 	if sender.Password != "" {
 		tlsConfig := &tls.Config{
 			InsecureSkipVerify: sender.InsecureTLS,

--- a/senders/mail/send.go
+++ b/senders/mail/send.go
@@ -103,6 +103,7 @@ func (sender *Sender) dialAndSend(message *gomail.Message) error {
 	d := gomail.Dialer{
 		Host: sender.SMTPHost,
 		Port: int(sender.SMTPPort),
+		LocalName: sender.SMTPHello,
 		TLSConfig: &tls.Config{
 			InsecureSkipVerify: sender.InsecureTLS,
 			ServerName:         sender.SMTPHost,


### PR DESCRIPTION
Closes #289

The default LocalName (the hostname sent to the SMTP server with the HELO command) in the Dialer struct is "localhost". Therefore if the `smtp_hello` parameter is not provided, `sender.SMTPHello` is set to `""`, which then falls back to the default LocalName: https://github.com/go-gomail/gomail/blob/81ebce5c23dfd25c6c67194b37d3dd3f338c98b1/smtp.go#L75-L79