### PR TITLE
Change contract for config contact

### DIFF
--- a/pkg/api/web.json
+++ b/pkg/api/web.json
@@ -1,11 +1,30 @@
 {
   "contacts": [
-    {"type": "mail"},
-    {"type": "pushover"},
-    {"type": "slack"},
-    {"type": "telegram", "help": "required to grant @MoiraBot admin privileges"},
-    {"type": "twilio sms"},
-    {"type": "twilio voice"}
+    {
+      "type": "mail",
+      "label": "E-mail"
+    },
+    {
+      "type": "pushover",
+      "label": "Pushover"
+    },
+    {
+      "type": "slack",
+      "label": "Slack"
+    },
+    {
+      "type": "telegram",
+      "label": "Telegram",
+      "help": "required to grant @MoiraBot admin privileges"
+    },
+    {
+      "type": "twilio sms",
+      "label": "Twilio SMS"
+    },
+    {
+      "type": "twilio voice",
+      "label": "Twilio voice"
+    }
   ],
   "remoteAllowed": false
 }


### PR DESCRIPTION
Изменит контракт описания контактов в конфиге, потому что теперь на его основе рисуется интерфейс в настройках веб-морды Мойры.