### PR TITLE
Fix ref error of MinAndMaxOfTime from package go-chart

### DIFF
--- a/plotting/limits.go
+++ b/plotting/limits.go
@@ -42,7 +42,7 @@ func resolveLimits(metricsData []*metricSource.MetricData) plotLimits {
 		allTimes = append(allTimes, moira.Int64ToTime(metricData.StartTime))
 		allTimes = append(allTimes, moira.Int64ToTime(metricData.StopTime))
 	}
-	from, to := util.Math.MinAndMaxOfTime(allTimes...)
+	from, to := util.Time.StartAndEnd(allTimes...)
 	lowest, highest := util.Math.MinAndMax(allValues...)
 	if highest == lowest {
 		highest = highest + (defaultRangeDelta / 2)


### PR DESCRIPTION
File `plotting/limits.go` referencing to [https://github.com/wcharczuk/go-chart/blob/master/util/math.go](url) , and in newer version of go-chart, the function _MinAndMaxOfTime_ renamed to _StartAndEnd_ in different file.

Error output:
```
# github.com/moira-alert/moira/plotting
../../plotting/limits.go:45:23: util.Math.MinAndMaxOfTime undefined (type *util.mathUtil has no field or method MinAndMaxOfTime)
```
