### PR TITLE
Generate event bug fixes

### DIFF
--- a/checker/event_test.go
+++ b/checker/event_test.go
@@ -479,7 +479,7 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 					StartUser: &startMetricUser,
 					StartTime: &startMetricTime,
 				}
-				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user metric user at 05:15 01.01.1970.")
+				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user metric user at %v 01.01.1970.", time.Unix(startMetricTime, 0).Format(format))
 				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
 					TriggerID: triggerChecker.triggerID,
 					Timestamp: currentState.Timestamp,
@@ -511,7 +511,7 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 					StartUser: &startMetricUser,
 					StartTime: &startMetricTime,
 				}
-				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user trigger user at 05:16 01.01.1970.")
+				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user trigger user at %v 01.01.1970.", time.Unix(startTriggerTime, 0).Format(format))
 				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
 					TriggerID: triggerChecker.triggerID,
 					Timestamp: currentState.Timestamp,

--- a/checker/event_test.go
+++ b/checker/event_test.go
@@ -479,7 +479,7 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 					StartUser: &startMetricUser,
 					StartTime: &startMetricTime,
 				}
-				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user metric user at %v 01.01.1970.", time.Unix(startMetricTime, 0).Format(format))
+				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user metric user at %v.", time.Unix(startMetricTime, 0).Format(format))
 				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
 					TriggerID: triggerChecker.triggerID,
 					Timestamp: currentState.Timestamp,
@@ -511,7 +511,7 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 					StartUser: &startMetricUser,
 					StartTime: &startMetricTime,
 				}
-				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user trigger user at %v 01.01.1970.", time.Unix(startTriggerTime, 0).Format(format))
+				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user trigger user at %v.", time.Unix(startTriggerTime, 0).Format(format))
 				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
 					TriggerID: triggerChecker.triggerID,
 					Timestamp: currentState.Timestamp,

--- a/checker/event_test.go
+++ b/checker/event_test.go
@@ -151,13 +151,28 @@ func TestCompareMetricStates(t *testing.T) {
 		})
 
 		Convey("Test different states", func() {
-			Convey("Trigger maintenance", func() {
+			Convey("Metric maintenance", func() {
 				lastState := lastStateExample
 				currentState := currentStateExample
 				lastState.State = moira.StateEXCEPTION
 				currentState.State = moira.StateOK
 				currentState.SuppressedState = lastState.State
 				currentState.Maintenance = 1502719222
+
+				actual, err := triggerChecker.compareMetricStates("m1", currentState, lastState)
+				So(err, ShouldBeNil)
+				currentState.EventTimestamp = currentState.Timestamp
+				currentState.Suppressed = true
+				So(actual, ShouldResemble, currentState)
+			})
+
+			Convey("Trigger maintenance", func() {
+				lastState := lastStateExample
+				currentState := currentStateExample
+				lastState.State = moira.StateEXCEPTION
+				currentState.State = moira.StateOK
+				currentState.SuppressedState = lastState.State
+				triggerChecker.lastCheck.Maintenance = 1502719222
 
 				actual, err := triggerChecker.compareMetricStates("m1", currentState, lastState)
 				So(err, ShouldBeNil)
@@ -262,20 +277,8 @@ func TestCompareTriggerStates(t *testing.T) {
 }
 
 func TestCheckMetricStateWithLastStateSuppressed(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	logger, _ := logging.GetLogger("Test")
-	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
-
 	triggerChecker := TriggerChecker{
-		logger:   logger,
-		until:    67,
-		from:     17,
-		database: dataBase,
-		trigger: &moira.Trigger{
-			ID:      "superId",
-			Targets: []string{"aliasByNode(super.*.metric, 0)"},
-		},
+		trigger:   &moira.Trigger{},
 		lastCheck: &moira.CheckData{},
 	}
 
@@ -286,58 +289,46 @@ func TestCheckMetricStateWithLastStateSuppressed(t *testing.T) {
 		Maintenance:    1100,
 		State:          moira.StateWARN,
 	}
-	currentState := moira.MetricState{
-		Suppressed: false,
-		Timestamp:  1200,
-		State:      moira.StateWARN,
-	}
-
+	currentState := newMetricState(lastState, moira.StateWARN, 1200, nil)
 	states := []moira.State{moira.StateOK, moira.StateWARN, moira.StateERROR, moira.StateNODATA, moira.StateEXCEPTION}
 
 	for _, state := range states {
+		lastState.State = state
+		currentState.State = state
 		Convey(fmt.Sprintf("Test Same Status %s after maintenance. No need to send message.", state), t, func() {
-			lastState.State = state
-			currentState.State = state
-			currentState.SuppressedState = lastState.State
-			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
+			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", *currentState, lastState)
 			So(err, ShouldBeNil)
 			currentState.EventTimestamp = lastState.EventTimestamp
-			So(actual, ShouldResemble, currentState)
+			currentState.Suppressed = false
+			So(actual, ShouldResemble, *currentState)
 		})
 	}
 }
 
 func TestCheckMetricStateSuppressedState(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	logger, _ := logging.GetLogger("Test")
-	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
-
-	triggerChecker := TriggerChecker{
-		logger:   logger,
-		until:    67,
-		from:     17,
-		database: dataBase,
-		trigger: &moira.Trigger{
-			ID:      "superId",
-			Targets: []string{"aliasByNode(super.*.metric, 0)"},
-		},
-		lastCheck: &moira.CheckData{},
-	}
-
-	lastState := moira.MetricState{
-		Timestamp:      100,
-		EventTimestamp: 10,
-		State:          moira.StateOK,
-	}
-	currentState := moira.MetricState{
-		Timestamp:   1000,
-		Maintenance: 1500,
-		State:       moira.StateWARN,
-	}
-
 	Convey("Test SuppressedState remembered properly", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		triggerChecker := TriggerChecker{
+			database:  dataBase,
+			trigger:   &moira.Trigger{},
+			lastCheck: &moira.CheckData{},
+		}
+
 		Convey("Test switch to maintenance. State changes OK => WARN", func() {
+			lastState := moira.MetricState{
+				Timestamp:      100,
+				EventTimestamp: 10,
+				State:          moira.StateOK,
+			}
+			currentState := moira.MetricState{
+				Timestamp:   1000,
+				Maintenance: 1500,
+				State:       moira.StateWARN,
+			}
+
 			currentState.SuppressedState = lastState.State
 			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
 			So(err, ShouldBeNil)
@@ -347,64 +338,196 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 		})
 
 		Convey("Test still in maintenance. State changes WARN => OK", func() {
-			lastState = currentState
-			currentState.Timestamp = 1100
-			currentState.State = moira.StateOK
+			lastState := moira.MetricState{
+				Timestamp:       1000,
+				EventTimestamp:  1000,
+				Maintenance:     1500,
+				State:           moira.StateWARN,
+				Suppressed:      true,
+				SuppressedState: moira.StateOK,
+			}
+
+			currentState := moira.MetricState{
+				Timestamp:   1100,
+				Maintenance: 1500,
+				State:       moira.StateOK,
+				Suppressed:  true,
+			}
 			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
 			So(err, ShouldBeNil)
-			currentState.EventTimestamp = lastState.EventTimestamp
+			currentState.SuppressedState = lastState.SuppressedState
+			currentState.EventTimestamp = lastState.Timestamp
 			So(actual, ShouldResemble, currentState)
 		})
 
 		Convey("Test still in maintenance. State changes OK => ERROR", func() {
-			lastState = currentState
-			currentState.Timestamp = 1200
-			currentState.State = moira.StateERROR
+			lastState := moira.MetricState{
+				Timestamp:       1100,
+				EventTimestamp:  1000,
+				Maintenance:     1500,
+				State:           moira.StateOK,
+				Suppressed:      true,
+				SuppressedState: moira.StateOK,
+			}
+
+			currentState := moira.MetricState{
+				Timestamp:   1200,
+				Maintenance: 1500,
+				State:       moira.StateERROR,
+				Suppressed:  true,
+			}
+
 			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
 			So(err, ShouldBeNil)
+			currentState.SuppressedState = lastState.SuppressedState
 			currentState.EventTimestamp = currentState.Timestamp
 			So(actual, ShouldResemble, currentState)
 		})
 
 		Convey("Test switch out of maintenance. State didn't change", func() {
-			lastState = currentState
-			currentState.Timestamp = 1600
-			currentState.State = moira.StateOK
-			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
+			firstState := moira.MetricState{
+				Timestamp:       1200,
+				EventTimestamp:  1200,
+				Maintenance:     1500,
+				State:           moira.StateERROR,
+				Suppressed:      true,
+				SuppressedState: moira.StateOK,
+			}
+
+			secondState := moira.MetricState{
+				Timestamp:   1600,
+				Maintenance: 1500,
+				State:       moira.StateOK,
+			}
+
+			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", secondState, firstState)
 			So(err, ShouldBeNil)
-			currentState.EventTimestamp = lastState.EventTimestamp
-			So(actual, ShouldResemble, currentState)
+			secondState.EventTimestamp = firstState.EventTimestamp
+			//secondState.SuppressedState = firstState.SuppressedState
+			So(actual, ShouldResemble, secondState)
+
+			Convey("Test state change state after suppressed", func() {
+				thirdState := moira.MetricState{
+					Timestamp:   1800,
+					Maintenance: 1500,
+					State:       moira.StateERROR,
+				}
+
+				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
+					TriggerID: triggerChecker.triggerID,
+					Timestamp: thirdState.Timestamp,
+					State:     thirdState.State,
+					OldState:  secondState.State,
+					Metric:    "super.awesome.metric",
+					Value:     thirdState.Value,
+				}, true).Return(nil)
+				actual, err = triggerChecker.compareMetricStates("super.awesome.metric", thirdState, secondState)
+				So(err, ShouldBeNil)
+				thirdState.EventTimestamp = thirdState.Timestamp
+				thirdState.Suppressed = false
+				So(actual, ShouldResemble, thirdState)
+			})
 		})
 
 		Convey("Test switch out of maintenance. State changed during suppression", func() {
-			lastState = moira.MetricState{
-				EventTimestamp:  1300,
-				Timestamp:       1300,
+			startMetricUser := "metric user"
+			startMetricTime := int64(900)
+			startTriggerUser := "trigger user"
+			startTriggerTime := int64(1000)
+
+			lastState := moira.MetricState{
+				Timestamp:       1200,
+				EventTimestamp:  1200,
 				Maintenance:     1500,
+				State:           moira.StateOK,
 				Suppressed:      true,
 				SuppressedState: moira.StateOK,
-				State:           moira.StateERROR,
 			}
-			currentState.Timestamp = 1600
-			currentState.State = moira.StateERROR
 
-			message := fmt.Sprintf("This metric changed its state during maintenance interval.")
-			dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
-				TriggerID: triggerChecker.triggerID,
-				Timestamp: currentState.Timestamp,
-				State:     currentState.State,
-				OldState:  currentState.SuppressedState,
-				Metric:    "super.awesome.metric",
-				Value:     currentState.Value,
-				Message:   &message,
-			}, true).Return(nil)
+			currentState := moira.MetricState{
+				Timestamp:   1600,
+				Maintenance: 1500,
+				State:       moira.StateERROR,
+				Suppressed:  true,
+			}
 
-			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
-			So(err, ShouldBeNil)
-			currentState.Suppressed = false
-			currentState.SuppressedState = ""
-			currentState.EventTimestamp = currentState.Timestamp
-			So(actual, ShouldResemble, currentState)
+			Convey("No maintenance info", func() {
+				message := fmt.Sprintf("This metric changed its state during maintenance interval.")
+				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
+					TriggerID: triggerChecker.triggerID,
+					Timestamp: currentState.Timestamp,
+					State:     currentState.State,
+					OldState:  lastState.SuppressedState,
+					Metric:    "super.awesome.metric",
+					Value:     currentState.Value,
+					Message:   &message,
+				}, true).Return(nil)
+				actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
+				So(err, ShouldBeNil)
+				currentState.Suppressed = false
+				currentState.SuppressedState = ""
+				currentState.EventTimestamp = currentState.Timestamp
+				So(actual, ShouldResemble, currentState)
+			})
+
+			Convey("Maintenance info in metric state", func() {
+				lastState.MaintenanceInfo = moira.MaintenanceInfo{
+					StartUser: &startMetricUser,
+					StartTime: &startMetricTime,
+				}
+				currentState.MaintenanceInfo = moira.MaintenanceInfo{
+					StartUser: &startMetricUser,
+					StartTime: &startMetricTime,
+				}
+				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user metric user at 05:15 01.01.1970.")
+				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
+					TriggerID: triggerChecker.triggerID,
+					Timestamp: currentState.Timestamp,
+					State:     currentState.State,
+					OldState:  lastState.SuppressedState,
+					Metric:    "super.awesome.metric",
+					Value:     currentState.Value,
+					Message:   &message,
+				}, true).Return(nil)
+				actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
+				So(err, ShouldBeNil)
+				currentState.Suppressed = false
+				currentState.SuppressedState = ""
+				currentState.EventTimestamp = currentState.Timestamp
+				So(actual, ShouldResemble, currentState)
+			})
+
+			Convey("Maintenance info in metric state and trigger state, but in trigger state maintenance timestamp are more", func() {
+				triggerChecker.lastCheck.Maintenance = 1550
+				triggerChecker.lastCheck.MaintenanceInfo = moira.MaintenanceInfo{
+					StartUser: &startTriggerUser,
+					StartTime: &startTriggerTime,
+				}
+				lastState.MaintenanceInfo = moira.MaintenanceInfo{
+					StartUser: &startMetricUser,
+					StartTime: &startMetricTime,
+				}
+				currentState.MaintenanceInfo = moira.MaintenanceInfo{
+					StartUser: &startMetricUser,
+					StartTime: &startMetricTime,
+				}
+				message := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user trigger user at 05:16 01.01.1970.")
+				dataBase.EXPECT().PushNotificationEvent(&moira.NotificationEvent{
+					TriggerID: triggerChecker.triggerID,
+					Timestamp: currentState.Timestamp,
+					State:     currentState.State,
+					OldState:  lastState.SuppressedState,
+					Metric:    "super.awesome.metric",
+					Value:     currentState.Value,
+					Message:   &message,
+				}, true).Return(nil)
+				actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
+				So(err, ShouldBeNil)
+				currentState.Suppressed = false
+				currentState.SuppressedState = ""
+				currentState.EventTimestamp = currentState.Timestamp
+				So(actual, ShouldResemble, currentState)
+			})
 		})
 	})
 }
@@ -455,7 +578,6 @@ func TestTriggerMaintenance(t *testing.T) {
 
 	Convey("Test trigger maintenance work properly and we don't create events", t, func() {
 		Convey("Compare metric state", func() {
-
 			Convey("No need to send", func() {
 				actual, err := triggerChecker.compareMetricStates("m1", currentMetricState, lastMetricState)
 				currentMetricState.EventTimestamp = 1000
@@ -522,98 +644,100 @@ func TestTriggerMaintenance(t *testing.T) {
 	})
 }
 
-func TestNeedSendEvent(t *testing.T) {
+func TestIsStateChanged(t *testing.T) {
 	startMaintenanceUser := "testStartMtUser"
 	startMaintenanceTime := int64(123)
 	stopMaintenanceUser := "testStopMtUser"
 	stopMaintenanceTime := int64(1230)
 
-	Convey("Test needSendEvents for trigger", t, func() {
-		Convey("Start Maintenance not start user and time", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval.")
-			needSend, message := needSendEvent(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
+	Convey("isStateChanged tests", t, func() {
+		var lastCheckTest = moira.CheckData{
+			Score:           6000,
+			State:           moira.StateOK,
+			Suppressed:      true,
+			SuppressedState: moira.StateERROR,
+			Timestamp:       1504509981,
+			Maintenance:     1000,
+		}
+
+		var currentCheckTest = moira.CheckData{
+			State:     moira.StateWARN,
+			Timestamp: 1504509981,
+		}
+
+		var currentMetricTest = moira.MetricState{
+			EventTimestamp: 1504449789,
+			State:          moira.StateWARN,
+			Suppressed:     true,
+			Timestamp:      1504509380,
+		}
+
+		var lastMetricsTest = moira.MetricState{
+			EventTimestamp: 1504449789,
+			State:          moira.StateNODATA,
+			Suppressed:     true,
+			Timestamp:      1504509380,
+			Maintenance:    1552723340,
+		}
+
+		Convey("Test needSendEvents for trigger", func() {
+			Convey("Start Maintenance not start user and time", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval.")
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
+			Convey("Start Maintenance", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"))
+				lastCheckTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, nil, nil)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
+			Convey("Stop Maintenance", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v. Maintenance removed by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"), stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
+				lastCheckTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, &stopMaintenanceUser, &stopMaintenanceTime)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
+			Convey("Stop Maintenance not start user and time", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance removed by user %v at %v.", stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
+				lastCheckTest.MaintenanceInfo.Set(nil, nil, &stopMaintenanceUser, &stopMaintenanceTime)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
 		})
-		Convey("Start Maintenance", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"))
-			lastCheckTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, nil, nil)
-			needSend, message := needSendEvent(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
-		})
-		Convey("Stop Maintenance", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v. Maintenance removed by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"), stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
-			lastCheckTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, &stopMaintenanceUser, &stopMaintenanceTime)
-			needSend, message := needSendEvent(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
-		})
-		Convey("Stop Maintenance not start user and time", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance removed by user %v at %v.", stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
-			lastCheckTest.MaintenanceInfo.Set(nil, nil, &stopMaintenanceUser, &stopMaintenanceTime)
-			needSend, message := needSendEvent(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
+
+		Convey("Test needSendEvents for metric", func() {
+			Convey("Start Maintenance not start user and time", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval.")
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
+			Convey("Start Maintenance", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"))
+				currentMetricTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, nil, nil)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
+			Convey("Stop Maintenance", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance removed by user %v at %v.", stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
+				currentMetricTest.MaintenanceInfo.Set(nil, nil, &stopMaintenanceUser, &stopMaintenanceTime)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
+			Convey("Stop Maintenance not start user and time", func() {
+				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v. Maintenance removed by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"), stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
+				currentMetricTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, &stopMaintenanceUser, &stopMaintenanceTime)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				So(needSend, ShouldBeTrue)
+				So(*message, ShouldResemble, actual)
+			})
 		})
 	})
-
-	Convey("Test needSendEvents for metric", t, func() {
-		Convey("Start Maintenance not start user and time", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval.")
-			needSend, message := needSendEvent(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
-		})
-		Convey("Start Maintenance", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"))
-			currentMetricTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, nil, nil)
-			needSend, message := needSendEvent(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
-		})
-		Convey("Stop Maintenance", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance removed by user %v at %v.", stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
-			currentMetricTest.MaintenanceInfo.Set(nil, nil, &stopMaintenanceUser, &stopMaintenanceTime)
-			needSend, message := needSendEvent(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
-		})
-		Convey("Stop Maintenance not start user and time", func() {
-			actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v. Maintenance removed by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"), stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
-			currentMetricTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, &stopMaintenanceUser, &stopMaintenanceTime)
-			needSend, message := needSendEvent(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
-			So(needSend, ShouldBeTrue)
-			So(*message, ShouldResemble, actual)
-		})
-	})
-}
-
-var lastCheckTest = moira.CheckData{
-	Score:           6000,
-	State:           moira.StateOK,
-	Suppressed:      true,
-	SuppressedState: moira.StateERROR,
-	Timestamp:       1504509981,
-	Maintenance:     1000,
-}
-
-var currentCheckTest = moira.CheckData{
-	State:     moira.StateWARN,
-	Timestamp: 1504509981,
-}
-
-var currentMetricTest = moira.MetricState{
-	EventTimestamp: 1504449789,
-	State:          moira.StateWARN,
-	Suppressed:     true,
-	Timestamp:      1504509380,
-}
-
-var lastMetricsTest = moira.MetricState{
-	EventTimestamp: 1504449789,
-	State:          moira.StateNODATA,
-	Suppressed:     true,
-	Timestamp:      1504509380,
-	Maintenance:    1552723340,
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -68,6 +68,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Can not configure log: %s\n", err.Error())
 		os.Exit(1)
 	}
+	logger.Infof("Moira API stopped. Version: %s", MoiraVersion)
 
 	configFile, err := getWebConfigBytes(config.API.WebConfigPath)
 	if err != nil {
@@ -149,5 +150,4 @@ func Stop(logger moira.Logger, server *http.Server) {
 	if err := server.Shutdown(ctx); err != nil {
 		logger.Errorf("Can't stop Moira API correctly: %v", err)
 	}
-	logger.Infof("Moira API Stopped. Version: %s", MoiraVersion)
 }

--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -65,7 +65,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Can not configure log: %s\n", err.Error())
 		os.Exit(1)
 	}
-	defer logger.Infof("Moira Notifier Stopped. Version: %s", MoiraVersion)
+	defer logger.Infof("Moira Notifier stopped. Version: %s", MoiraVersion)
 
 	if config.Pprof.Listen != "" {
 		logger.Infof("Starting pprof server at: [%s]", config.Pprof.Listen)


### PR DESCRIPTION
Don't remove maintenance info after every check process. Make logic more transparent.
Use maximal maintenance for calculating is metric in maintenance while processing new state.
Don't send "This metric changed its state" message if a state does not change during maintenance interval. Fix #328