### PR TITLE
Fix update event timestamp on maintenance metric in changed suppressed state on every trigger check

### DIFF
--- a/checker/event.go
+++ b/checker/event.go
@@ -41,7 +41,7 @@ func (triggerChecker *TriggerChecker) compareTriggerStates(currentCheck moira.Ch
 	currentCheck.SuppressedState = lastStateSuppressedValue
 
 	maintenanceInfo, maintenanceTimestamp := getMaintenanceInfo(lastCheck, nil)
-	needSend, message := isStateChanged(currentStateValue, lastStateValue, currentCheckTimestamp, lastCheck.GetEventTimestamp(), lastStateSuppressed, lastStateSuppressedValue, maintenanceInfo)
+	needSend, message := isStateChanged(currentStateValue, lastStateValue, currentCheckTimestamp, lastCheck.GetEventTimestamp(), lastStateSuppressed, lastStateSuppressedValue, maintenanceTimestamp, maintenanceInfo)
 	if !needSend {
 		if maintenanceTimestamp < currentCheckTimestamp {
 			currentCheck.Suppressed = false
@@ -95,7 +95,7 @@ func (triggerChecker *TriggerChecker) compareMetricStates(metric string, current
 	currentState.SuppressedState = lastState.SuppressedState
 
 	maintenanceInfo, maintenanceTimestamp := getMaintenanceInfo(triggerChecker.lastCheck, &currentState)
-	needSend, message := isStateChanged(currentState.State, lastState.State, currentState.Timestamp, lastState.GetEventTimestamp(), lastState.Suppressed, lastState.SuppressedState, maintenanceInfo)
+	needSend, message := isStateChanged(currentState.State, lastState.State, currentState.Timestamp, lastState.GetEventTimestamp(), lastState.Suppressed, lastState.SuppressedState, maintenanceTimestamp, maintenanceInfo)
 	if !needSend {
 		if maintenanceTimestamp < currentState.Timestamp {
 			currentState.Suppressed = false
@@ -152,14 +152,16 @@ func (triggerChecker *TriggerChecker) isTriggerSuppressed(timestamp int64, maint
 	return !triggerChecker.trigger.Schedule.IsScheduleAllows(timestamp) || maintenanceTimestamp >= timestamp
 }
 
-func isStateChanged(currentStateValue moira.State, lastStateValue moira.State, currentStateTimestamp int64, lastStateEventTimestamp int64, isLastCheckSuppressed bool, lastStateSuppressedValue moira.State, maintenanceInfo moira.MaintenanceInfo) (needSend bool, message *string) {
+func isStateChanged(currentStateValue moira.State, lastStateValue moira.State, currentStateTimestamp int64, lastStateEventTimestamp int64, isLastCheckSuppressed bool, lastStateSuppressedValue moira.State, maintenance int64, maintenanceInfo moira.MaintenanceInfo) (needSend bool, message *string) {
 	if !isLastCheckSuppressed && currentStateValue != lastStateValue {
 		return true, nil
 	}
 
 	if isLastCheckSuppressed && currentStateValue != lastStateSuppressedValue {
-		message := getMaintenanceCreateMessage(maintenanceInfo)
-		return true, &message
+		if currentStateTimestamp > maintenance || currentStateValue != lastStateValue {
+			message := getMaintenanceCreateMessage(maintenanceInfo)
+			return true, &message
+		}
 	}
 	remindInterval, ok := badStateReminder[currentStateValue]
 	if ok && needRemindAgain(currentStateTimestamp, lastStateEventTimestamp, remindInterval) {

--- a/checker/event_test.go
+++ b/checker/event_test.go
@@ -360,6 +360,30 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 			So(actual, ShouldResemble, currentState)
 		})
 
+		Convey("Test still in maintenance. State changes WARN => WARN", func() {
+			lastState := moira.MetricState{
+				Timestamp:       1000,
+				EventTimestamp:  1000,
+				Maintenance:     1500,
+				State:           moira.StateWARN,
+				Suppressed:      true,
+				SuppressedState: moira.StateOK,
+			}
+
+			currentState := moira.MetricState{
+				Timestamp:   1100,
+				Maintenance: 1500,
+				State:       moira.StateWARN,
+				Suppressed:  true,
+			}
+
+			actual, err := triggerChecker.compareMetricStates("super.awesome.metric", currentState, lastState)
+			So(err, ShouldBeNil)
+			currentState.SuppressedState = lastState.SuppressedState
+			currentState.EventTimestamp = lastState.EventTimestamp
+			So(actual, ShouldResemble, currentState)
+		})
+
 		Convey("Test still in maintenance. State changes OK => ERROR", func() {
 			lastState := moira.MetricState{
 				Timestamp:       1100,
@@ -439,7 +463,7 @@ func TestCheckMetricStateSuppressedState(t *testing.T) {
 				Timestamp:       1200,
 				EventTimestamp:  1200,
 				Maintenance:     1500,
-				State:           moira.StateOK,
+				State:           moira.StateERROR,
 				Suppressed:      true,
 				SuppressedState: moira.StateOK,
 			}
@@ -683,28 +707,28 @@ func TestIsStateChanged(t *testing.T) {
 		Convey("Test needSendEvents for trigger", func() {
 			Convey("Start Maintenance not start user and time", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval.")
-				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, 0, lastCheckTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
 			Convey("Start Maintenance", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"))
 				lastCheckTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, nil, nil)
-				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, 0, lastCheckTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
 			Convey("Stop Maintenance", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v. Maintenance removed by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"), stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
 				lastCheckTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, &stopMaintenanceUser, &stopMaintenanceTime)
-				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, 0, lastCheckTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
 			Convey("Stop Maintenance not start user and time", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance removed by user %v at %v.", stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
 				lastCheckTest.MaintenanceInfo.Set(nil, nil, &stopMaintenanceUser, &stopMaintenanceTime)
-				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, lastCheckTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentCheckTest.State, lastCheckTest.State, currentCheckTest.Timestamp, lastCheckTest.GetEventTimestamp(), lastCheckTest.Suppressed, lastCheckTest.SuppressedState, 0, lastCheckTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
@@ -713,28 +737,28 @@ func TestIsStateChanged(t *testing.T) {
 		Convey("Test needSendEvents for metric", func() {
 			Convey("Start Maintenance not start user and time", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval.")
-				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, 0, currentMetricTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
 			Convey("Start Maintenance", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"))
 				currentMetricTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, nil, nil)
-				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, 0, currentMetricTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
 			Convey("Stop Maintenance", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance removed by user %v at %v.", stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
 				currentMetricTest.MaintenanceInfo.Set(nil, nil, &stopMaintenanceUser, &stopMaintenanceTime)
-				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, 0, currentMetricTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})
 			Convey("Stop Maintenance not start user and time", func() {
 				actual := fmt.Sprintf("This metric changed its state during maintenance interval. Maintenance was set by user %v at %v. Maintenance removed by user %v at %v.", startMaintenanceUser, time.Unix(startMaintenanceTime, 0).Format("15:04 02.01.2006"), stopMaintenanceUser, time.Unix(stopMaintenanceTime, 0).Format("15:04 02.01.2006"))
 				currentMetricTest.MaintenanceInfo.Set(&startMaintenanceUser, &startMaintenanceTime, &stopMaintenanceUser, &stopMaintenanceTime)
-				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, currentMetricTest.MaintenanceInfo)
+				needSend, message := isStateChanged(currentMetricTest.State, lastMetricsTest.State, currentMetricTest.Timestamp, lastMetricsTest.GetEventTimestamp(), lastMetricsTest.Suppressed, lastMetricsTest.SuppressedState, 0, currentMetricTest.MaintenanceInfo)
 				So(needSend, ShouldBeTrue)
 				So(*message, ShouldResemble, actual)
 			})


### PR DESCRIPTION
If metric in maintenance and change its state from initial suppress state, then event timestamp will change in every trigger check. Example:

*12:50* - Metric OK							-> In web, last Event is 10:00. **Good**
*12:51* - Set maintenance to metric
*12:53* - Trigger check with this metric.   -> In web, last Event is 10:00. **Good**
*12:55* - Metric change his state to ERROR. -> In web, last Event is 12:55. **Good**
*12:56* - Trigger check with this metric.   -> In web, last Event is 12:56. **BUG**
*12:57* - Trigger check with this metric.   -> In web, last Event is 12:57. **BUG**
*12:58* - Trigger check with this metric.   -> In web, last Event is 12:57. **BUG**
