### PR TITLE
Launch moira locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-# Moira 2.0  [![Documentation Status](https://readthedocs.org/projects/moira/badge/?version=latest)](http://moira.readthedocs.io/en/latest/?badge=latest) [![Telegram](https://img.shields.io/badge/telegram-join%20chat-3796cd.svg)](https://t.me/moira_alert) [![Go Report Card](https://goreportcard.com/badge/github.com/moira-alert/moira)](https://goreportcard.com/report/github.com/moira-alert/moira) 
+# Moira 2.0  [![Build Status](https://travis-ci.org/moira-alert/moira.svg?branch=master)](https://travis-ci.org/moira-alert/moira) [![Coverage Status](https://coveralls.io/repos/github/moira-alert/moira/badge.svg?branch=master)](https://coveralls.io/github/moira-alert/moira?branch=master) [![Documentation Status](https://readthedocs.org/projects/moira/badge/?version=latest)](http://moira.readthedocs.io/en/latest/?badge=latest) [![Telegram](https://img.shields.io/badge/telegram-join%20chat-3796cd.svg)](https://t.me/moira_alert) [![Go Report Card](https://goreportcard.com/badge/github.com/moira-alert/moira)](https://goreportcard.com/report/github.com/moira-alert/moira) 
 
 Moira is a real-time alerting tool, based on [Graphite](https://graphite.readthedocs.io) data.
-
-## Build status
-| branch | status |
-| ------ | ------ |
-| master | [![Build Status](https://travis-ci.org/moira-alert/moira.svg?branch=master)](https://travis-ci.org/moira-alert/moira) [![Coverage Status](https://coveralls.io/repos/github/moira-alert/moira/badge.svg?branch=master)](https://coveralls.io/github/moira-alert/moira?branch=master) |
-| develop | [![Build Status](https://travis-ci.org/moira-alert/moira.svg?branch=develop)](https://travis-ci.org/moira-alert/moira) [![Coverage Status](https://coveralls.io/repos/github/moira-alert/moira/badge.svg?branch=develop)](https://coveralls.io/github/moira-alert/moira?branch=develop) |
-
 
 ## Installation
 
@@ -30,6 +23,33 @@ Configure triggers at `localhost:8080` using your browser.
 
 Other installation methods are available, see [documentation](https://moira.readthedocs.io/en/latest/installation/index.html).
 
+## Development
+
+To build and run tests, first get all dependencies:
+
+```
+go get github.com/kardianos/govendor
+govendor sync
+```
+
+To run test use ``go test ./...`` or run [GoConvey](http://goconvey.co/):
+
+```
+go get github.com/smartystreets/goconvey
+goconvey
+```
+
+For full local deployment of all services, including web, graphite and metrics relay (may be slow on first launch) use:
+
+```
+docker-compose up
+```
+
+Before push your changes don't forget about linter:
+
+```
+make lint
+```
 
 ## Getting Started
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       dockerfile: Dockerfile.api
     volumes:
       - ./local/api.yml:/etc/moira/api.yml
+      - ./local/web.json:/etc/moira/web.json
     depends_on:
       - redis
       - checker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,83 @@
+version: "3.7"
+
+services:
+  redis:
+    image: redis:alpine
+
+  graphite:
+    image: graphiteapp/graphite-statsd
+    ports:
+      - "7080:80"
+
+  filter:
+    build:
+      context: .
+      dockerfile: Dockerfile.filter
+    volumes:
+      - ./local/filter.yml:/etc/moira/filter.yml
+    depends_on:
+      - redis
+
+  checker:
+    build:
+      context: .
+      dockerfile: Dockerfile.checker
+    volumes:
+      - ./local/checker.yml:/etc/moira/checker.yml
+    depends_on:
+      - redis
+      - filter
+      - graphite
+
+  notifier:
+    build:
+      context: .
+      dockerfile: Dockerfile.notifier
+    volumes:
+      - ./local/notifier.yml:/etc/moira/notifier.yml
+    depends_on:
+      - redis
+      - checker
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    volumes:
+      - ./local/api.yml:/etc/moira/api.yml
+    depends_on:
+      - redis
+      - checker
+    networks:
+      - default
+      - balancer
+
+  web:
+    image: moira/web2
+    networks:
+      - balancer
+
+  balancer:
+    image: nginx:alpine
+    ports:
+      - "8080:8083"
+    depends_on:
+      - web
+      - api
+    networks:
+      - balancer
+    volumes:
+      - ./local/nginx.conf:/etc/nginx/conf.d/moira.conf
+
+  relay:
+    image: bodsch/docker-carbon-c-relay
+    ports:
+      - "2003:2003"
+    depends_on:
+      - graphite
+      - filter
+    volumes:
+      - ./local/relay.conf:/home/relay/carbon-c-relay.conf
+    command: /usr/bin/relay -E -s -f /home/relay/carbon-c-relay.conf
+networks:
+  balancer:

--- a/local/api.yml
+++ b/local/api.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: Moira
+  prefix: moira
   interval: 60s
 remote:
   enabled: true

--- a/local/api.yml
+++ b/local/api.yml
@@ -11,6 +11,8 @@ graphite:
   interval: 60s
 remote:
   enabled: true
+  url: "http://graphite:80/render"
+  check_interval: 60s
   timeout: 60s
 api:
   listen: ":8081"

--- a/local/api.yml
+++ b/local/api.yml
@@ -1,0 +1,21 @@
+#See https://moira.readthedocs.io/en/latest/installation/configuration.html for config explanation
+redis:
+  host: redis
+  port: "6379"
+  dbid: 0
+graphite:
+  enabled: true
+  runtime_stats: true
+  uri: "relay:2003"
+  prefix: DevOps.Moira
+  interval: 60s
+remote:
+  enabled: true
+  timeout: 60s
+api:
+  listen: ":8081"
+  enable_cors: false
+  web_config_path: "/etc/moira/web.json"
+log:
+  log_file: stdout
+  log_level: info

--- a/local/api.yml
+++ b/local/api.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: DevOps.Moira
+  prefix: Moira
   interval: 60s
 remote:
   enabled: true
@@ -20,4 +20,4 @@ api:
   web_config_path: "/etc/moira/web.json"
 log:
   log_file: stdout
-  log_level: info
+  log_level: debug

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: Moira
+  prefix: moira
   interval: 60s
 remote:
   enabled: true

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -1,0 +1,24 @@
+#See https://moira.readthedocs.io/en/latest/installation/configuration.html for config explanation
+redis:
+  host: redis
+  port: "6379"
+  dbid: 0
+graphite:
+  enabled: true
+  runtime_stats: true
+  uri: "relay:2003"
+  prefix: DevOps.Moira
+  interval: 60s
+remote:
+  enabled: true
+  url: "http://graphite:80/render"
+  check_interval: 60s
+  timeout: 60s
+checker:
+  nodata_check_interval: 60s
+  check_interval: 10s
+  metrics_ttl: 3h
+  stop_checking_interval: 30s
+log:
+  log_file: stdout
+  log_level: info

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: DevOps.Moira
+  prefix: Moira
   interval: 60s
 remote:
   enabled: true
@@ -21,4 +21,4 @@ checker:
   stop_checking_interval: 30s
 log:
   log_file: stdout
-  log_level: info
+  log_level: debug

--- a/local/cli.yml
+++ b/local/cli.yml
@@ -3,5 +3,5 @@ redis:
   port: "6379"
   dbid: 0
 log_file: stdout
-log_level: info
+log_level: debug
 

--- a/local/cli.yml
+++ b/local/cli.yml
@@ -1,0 +1,7 @@
+redis:
+  host: redis
+  port: "6379"
+  dbid: 0
+log_file: stdout
+log_level: info
+

--- a/local/filter.yml
+++ b/local/filter.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: DevOps.Moira
+  prefix: Moira
   interval: 60s
 filter:
   listen: ":2003"
@@ -16,4 +16,4 @@ filter:
   max_parallel_matches: 0
 log:
   log_file: stdout
-  log_level: info
+  log_level: debug

--- a/local/filter.yml
+++ b/local/filter.yml
@@ -1,0 +1,19 @@
+#See https://moira.readthedocs.io/en/latest/installation/configuration.html for config explanation
+redis:
+  host: redis
+  port: "6379"
+  dbid: 0
+graphite:
+  enabled: true
+  runtime_stats: true
+  uri: "relay:2003"
+  prefix: DevOps.Moira
+  interval: 60s
+filter:
+  listen: ":2003"
+  retention_config: /etc/moira/storage-schemas.conf
+  cache_capacity: 10
+  max_parallel_matches: 0
+log:
+  log_file: stdout
+  log_level: info

--- a/local/filter.yml
+++ b/local/filter.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: Moira
+  prefix: moira
   interval: 60s
 filter:
   listen: ":2003"

--- a/local/nginx.conf
+++ b/local/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 0.0.0.0:8083 default;
+
+    location /api/ {
+        proxy_pass http://api:8081;
+    }
+
+    location / {
+        proxy_pass http://web:80;
+    }
+}

--- a/local/notifier.yml
+++ b/local/notifier.yml
@@ -1,0 +1,32 @@
+#See https://moira.readthedocs.io/en/latest/installation/configuration.html for config explanation
+redis:
+  host: redis
+  port: "6379"
+  dbid: 0
+graphite:
+  enabled: true
+  runtime_stats: true
+  uri: "relay:2003"
+  prefix: DevOps.Moira
+  interval: 60s
+remote:
+  enabled: true
+  timeout: 60s
+notifier:
+  sender_timeout: 10s
+  resending_timeout: "1:00"
+  senders: []
+  moira_selfstate:
+    enabled: false
+    remote_triggers_enabled: false
+    redis_disconect_delay: 60s
+    last_metric_received_delay: 120s
+    last_check_delay: 120s
+    last_remote_check_delay: 300s
+    notice_interval: 300s
+  front_uri: http://localhost
+  timezone: UTC
+  date_time_format: "15:04 02.01.2006"
+log:
+  log_file: stdout
+  log_level: info

--- a/local/notifier.yml
+++ b/local/notifier.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: Moira
+  prefix: moira
   interval: 60s
 remote:
   enabled: true

--- a/local/notifier.yml
+++ b/local/notifier.yml
@@ -7,7 +7,7 @@ graphite:
   enabled: true
   runtime_stats: true
   uri: "relay:2003"
-  prefix: DevOps.Moira
+  prefix: Moira
   interval: 60s
 remote:
   enabled: true

--- a/local/notifier.yml
+++ b/local/notifier.yml
@@ -11,6 +11,8 @@ graphite:
   interval: 60s
 remote:
   enabled: true
+  url: "http://graphite:80/render"
+  check_interval: 60s
   timeout: 60s
 notifier:
   sender_timeout: 10s

--- a/local/relay.conf
+++ b/local/relay.conf
@@ -1,0 +1,7 @@
+cluster local
+    forward
+        filter:2003
+        graphite:2003
+    ;
+
+match * send to local;

--- a/local/web.json
+++ b/local/web.json
@@ -1,0 +1,30 @@
+{
+  "contacts": [
+    {
+      "type": "mail",
+      "label": "E-mail"
+    },
+    {
+      "type": "pushover",
+      "label": "Pushover"
+    },
+    {
+      "type": "slack",
+      "label": "Slack"
+    },
+    {
+      "type": "telegram",
+      "label": "Telegram",
+      "help": "required to grant @MoiraBot admin privileges"
+    },
+    {
+      "type": "twilio sms",
+      "label": "Twilio SMS"
+    },
+    {
+      "type": "twilio voice",
+      "label": "Twilio voice"
+    }
+  ],
+  "remoteAllowed": true
+}


### PR DESCRIPTION
The goal of the PR is to run Moira(from source) and its environment locally:
1. Redis
2. Graphite
3. Relay

It will help to test locally a lot.

Also there is small minor fix of docker-compose: links are replaced by names of services(instead of localhost).

![image](https://user-images.githubusercontent.com/664889/59158014-76593f80-8acd-11e9-9e80-0c2c560143a7.png)
