### PR TITLE
Create separate layer for installed govendor and run govendor sync only if vendors.json has changed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+vendor
+!vendor/vendor.json

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,9 +1,13 @@
 FROM golang:1.12.5 as builder
 
-WORKDIR /go/src/github.com/moira-alert/moira
-COPY . /go/src/github.com/moira-alert/moira/
 RUN go get github.com/kardianos/govendor
+
+COPY ./vendor/vendor.json /go/src/github.com/moira-alert/moira/vendor/vendor.json
+WORKDIR /go/src/github.com/moira-alert/moira
 RUN govendor sync
+
+COPY . /go/src/github.com/moira-alert/moira/
+
 ARG GO_VERSION="GoVersion"
 ARG GIT_COMMIT="git_Commit"
 ARG MoiraVersion="MoiraVersion"

--- a/Dockerfile.checker
+++ b/Dockerfile.checker
@@ -1,9 +1,13 @@
 FROM golang:1.12.5 as builder
 
-WORKDIR /go/src/github.com/moira-alert/moira
-COPY . /go/src/github.com/moira-alert/moira/
 RUN go get github.com/kardianos/govendor
+
+COPY ./vendor/vendor.json /go/src/github.com/moira-alert/moira/vendor/vendor.json
+WORKDIR /go/src/github.com/moira-alert/moira
 RUN govendor sync
+
+COPY . /go/src/github.com/moira-alert/moira/
+
 ARG GO_VERSION="GoVersion"
 ARG GIT_COMMIT="git_Commit"
 ARG MoiraVersion="MoiraVersion"

--- a/Dockerfile.filter
+++ b/Dockerfile.filter
@@ -1,9 +1,13 @@
 FROM golang:1.12.5 as builder
 
-WORKDIR /go/src/github.com/moira-alert/moira
-COPY . /go/src/github.com/moira-alert/moira/
 RUN go get github.com/kardianos/govendor
+
+COPY ./vendor/vendor.json /go/src/github.com/moira-alert/moira/vendor/vendor.json
+WORKDIR /go/src/github.com/moira-alert/moira
 RUN govendor sync
+
+COPY . /go/src/github.com/moira-alert/moira/
+
 ARG GO_VERSION="GoVersion"
 ARG GIT_COMMIT="git_Commit"
 ARG MoiraVersion="MoiraVersion"

--- a/Dockerfile.notifier
+++ b/Dockerfile.notifier
@@ -1,9 +1,13 @@
 FROM golang:1.12.5 as builder
 
-WORKDIR /go/src/github.com/moira-alert/moira
-COPY . /go/src/github.com/moira-alert/moira/
 RUN go get github.com/kardianos/govendor
+
+COPY ./vendor/vendor.json /go/src/github.com/moira-alert/moira/vendor/vendor.json
+WORKDIR /go/src/github.com/moira-alert/moira
 RUN govendor sync
+
+COPY . /go/src/github.com/moira-alert/moira/
+
 ARG GO_VERSION="GoVersion"
 ARG GIT_COMMIT="git_Commit"
 ARG MoiraVersion="MoiraVersion"


### PR DESCRIPTION
The same technique is described [here](https://medium.com/@aidobreen/using-docker-dont-forget-to-use-build-caching-6e2b4f43771e).