### PR TITLE
Moved tests to docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,3 @@ vendor
 !vendor/vendor.json
 build
 local
-
-**/*_test.go

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 log
-build/
 
 .DS_Store      
 *.coverprofile

--- a/build/test/Dockerfile.test
+++ b/build/test/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM golang:1.12.6
+
+RUN go get github.com/kardianos/govendor
+RUN go get github.com/smartystreets/goconvey
+
+COPY ./vendor/vendor.json /go/src/github.com/moira-alert/moira/vendor/vendor.json
+WORKDIR /go/src/github.com/moira-alert/moira
+RUN govendor sync
+
+COPY . /go/src/github.com/moira-alert/moira/
+
+ENTRYPOINT ["/go/bin/goconvey"]
+CMD ["-host=0.0.0.0", "-launchBrowser=false", "-timeout=120s"]

--- a/database/redis/database_test.go
+++ b/database/redis/database_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"os"
 	"testing"
 
 	"github.com/moira-alert/moira/logging/go-logging"
@@ -9,7 +10,10 @@ import (
 	"github.com/moira-alert/moira"
 )
 
-var config = Config{Port: "6379", Host: "0.0.0.0"}
+var redisPort = os.Getenv("REDIS_PORT")
+var redisHost = os.Getenv("REDIS_HOST")
+
+var config = Config{Port: redisPort, Host: redisHost}
 var emptyConfig = Config{}
 var testSource = DBSource("test")
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+services:
+  redis:
+    image: redis:alpine
+    expose:
+      - "6379"
+
+  goconvey:
+    build:
+      dockerfile: build/test/Dockerfile.test
+      context: .
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+    ports:
+      - "8080:8080"

--- a/integration_tests/notifier/notifier_test.go
+++ b/integration_tests/notifier/notifier_test.go
@@ -2,18 +2,19 @@ package notifier
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/moira-alert/moira/metric_source"
+	metricSource "github.com/moira-alert/moira/metric_source"
 	"github.com/moira-alert/moira/metric_source/local"
 	"github.com/op/go-logging"
 
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/database/redis"
 	"github.com/moira-alert/moira/metrics/graphite/go-metrics"
-	"github.com/moira-alert/moira/mock/moira-alert"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
 	"github.com/moira-alert/moira/notifier"
 	"github.com/moira-alert/moira/notifier/events"
 	"github.com/moira-alert/moira/notifier/notifications"
@@ -74,10 +75,13 @@ var event = moira.NotificationEvent{
 	TriggerID: "triggerID-0000000000001",
 }
 
+var redisPort = os.Getenv("REDIS_PORT")
+var redisHost = os.Getenv("REDIS_HOST")
+
 func TestNotifier(t *testing.T) {
 	mockCtrl = gomock.NewController(t)
 	defer mockCtrl.Finish()
-	database := redis.NewDatabase(logger, redis.Config{Port: "6379", Host: "localhost"}, redis.Notifier)
+	database := redis.NewDatabase(logger, redis.Config{Port: redisPort, Host: redisHost}, redis.Notifier)
 	metricsSourceProvider := metricSource.CreateMetricSourceProvider(local.Create(database), nil)
 	database.SaveContact(&contact)
 	database.SaveSubscription(&subscription)


### PR DESCRIPTION
# Добавил `docker-compose` для запуска тестов.

## Зачем

Кажется что сведение запуска тестов к одной команде (против двух сейчас) упростит процесс разработки, особенно для новых участников.

## Почему `docker-compose`

Мне показалось что создавать полноценное тестовое окружение проще и рациональнее, чем вызывать его в каждом тесте. Так же создание тестового окружения через `docker-compose` является более универсальным и гибким, и избавляет нас от необходимости тянуть дополнительные зависимости.

## Почему `/build` не в .gitignore

Насколько мне известно go не хранит там артефакты сборки в отличие от многих других языков.
В то же время [рекомендуется](https://github.com/golang-standards/project-layout) в этой папке хранить скрипты сборки.

## Почему *tests не в .dockerignore

Я не хотел делить проект для разделения контекста и создания раздельных .dockerignore, а тестовые файлы нужны были для, собственно, запуска тестов в контейнере.
Учитывая что наши контейнеры собираются "from scratch" это не должно негативно на них сказаться

## Проблемы

- нельзя в полной мере использовать возможности `goconvey`, т.к. файлы внутри контейнера не обновляются. Возможно с этим могли помочь `docker volume`, но мне это кажется лишним
- использование переменных окружения для передачи параметров редиса в тесты: мне это кажется оптимальным решением, т.к. настройка хранится в одном месте (`docker-compose`), но есть субъективное "ощущение костыльности"