### PR TITLE
Msteams support

### DIFF
--- a/local/api.yml
+++ b/local/api.yml
@@ -32,6 +32,8 @@ web:
       label: Twilio SMS
     - type: twilio voice
       label: Twilio voice
+    - type: msteams
+      label: MS Teams
 log:
   log_file: stdout
   log_level: debug

--- a/notifier/registrator.go
+++ b/notifier/registrator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/senders/discord"
 	"github.com/moira-alert/moira/senders/mail"
+	"github.com/moira-alert/moira/senders/msteams"
 	"github.com/moira-alert/moira/senders/opsgenie"
 	"github.com/moira-alert/moira/senders/pagerduty"
 	"github.com/moira-alert/moira/senders/pushover"
@@ -34,6 +35,7 @@ const (
 	opsgenieSender    = "opsgenie"
 	victoropsSender   = "victorops"
 	pagerdutySender   = "pagerduty"
+	msTeamsSender     = "msteams"
 )
 
 // RegisterSenders watch on senders config and register all configured senders
@@ -54,6 +56,8 @@ func (notifier *StandardNotifier) RegisterSenders(connector moira.Database) erro
 			err = notifier.RegisterSender(senderSettings, &slack.Sender{})
 		case telegramSender:
 			err = notifier.RegisterSender(senderSettings, &telegram.Sender{DataBase: connector})
+		case msTeamsSender:
+			err = notifier.RegisterSender(senderSettings, &msteams.Sender{})
 		case pagerdutySender:
 			err = notifier.RegisterSender(senderSettings, &pagerduty.Sender{ImageStores: notifier.imageStores})
 		case twilioSmsSender, twilioVoiceSender:

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,5 +1,9 @@
 package msteams
 
+import (
+	"fmt"
+)
+
 /*
 Fact models a fact in a MessageCard, contains a timestamp and trigger data
  {
@@ -105,3 +109,15 @@ type MessageCard struct {
 	Sections        []Section `json:"sections"`
 	PotentialAction []Actions `json:"potentialAction,omitempty"`
 }
+
+type ErrTeamsError struct {
+	error       string
+	description string
+	err         error
+}
+
+func (e *ErrTeamsError) Error() string {
+	return fmt.Sprintf("%s : %s", e.description, e.error)
+}
+
+func (e *ErrTeamsError) Unwrap() error { return e.err }

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,7 +1,7 @@
 package msteams
 
 /*
-Represents a Fact in a MessageCard, contains a timestamp and trigger data
+Fact models a fact in a MessageCard, contains a timestamp and trigger data
  {
 		"name": "10:45",
     "value": "someServer = 0.11 (NODATA to WARN)"
@@ -13,7 +13,7 @@ type Fact struct {
 }
 
 /*
-Represents a Section in a MessageCard, contains Facts and the Trigger description
+Section models a section in a MessageCard, contains Facts and the Trigger description
  {
 		"activityTitle": "Description",
 		"activityText": "A trigger description",
@@ -32,7 +32,7 @@ type Section struct {
 }
 
 /*
-Represents an OpenURITarget data in a MessageCard,creates a clickable target back to the trigger URI
+OpenURITarget creates a clickable target back to the trigger URI in a MessageCard
  {
 		"os": "default",
     "value": "http://moira.tld/trigger/ABCDEF-GH"
@@ -44,7 +44,7 @@ type OpenURITarget struct {
 }
 
 /*
-Represents possible actions in a MessageCard, limited to OpenURI actions
+Actions models possible actions in a MessageCard, currently limited to OpenURI actions
  {
 		"@type": "OpenUri",
     "name": "Open in Moira"
@@ -63,7 +63,7 @@ type Actions struct {
 }
 
 /*
-Represents an MSTeams compatible MessageCard
+MessageCard models an MSTeams compatible MessageCard
  {
 		"@context": "https://schema.org/extensions",
     "@type": "MessageCard",

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,28 +1,101 @@
 package msteams
 
+/*
+Represents a Fact in a MessageCard, contains a timestamp and trigger data
+ {
+		"name": "10:45",
+    "value": "someServer = 0.11 (NODATA to WARN)"
+ }
+*/
 type Fact struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
+/*
+Represents a Section in a MessageCard, contains Facts and the Trigger description
+ {
+		"activityTitle": "Description",
+		"activityText": "A trigger description",
+    "facts": [
+			 {
+					"name": "10:45",
+					"value": "someServer = 0.11 (NODATA to WARN)"
+			 }
+		]
+ }
+*/
 type Section struct {
 	ActivityTitle string `json:"activityTitle"`
 	ActivityText  string `json:"activityText"`
 	Facts         []Fact `json:"facts"`
 }
 
-type OpenUriTarget struct {
+/*
+Represents an OpenURITarget data in a MessageCard,creates a clickable target back to the trigger URI
+ {
+		"os": "default",
+    "value": "http://moira.tld/trigger/ABCDEF-GH"
+ }
+*/
+type OpenURITarget struct {
 	Os  string `json:"os"`
-	Uri string `json:"uri"`
+	URI string `json:"uri"`
 }
 
-//limited to OpenURI actions
+/*
+Represents possible actions in a MessageCard, limited to OpenURI actions
+ {
+		"@type": "OpenUri",
+    "name": "Open in Moira"
+		"targets": [
+			{
+				"os": "default",
+				"value": "http://moira.tld/trigger/ABCDEF-GH"
+ 			}
+		]
+ }
+*/
 type Actions struct {
 	Type    string          `json:"@type"`
 	Name    string          `json:"name"`
-	Targets []OpenUriTarget `json:"targets"`
+	Targets []OpenURITarget `json:"targets"`
 }
 
+/*
+Represents an MSTeams compatible MessageCard
+ {
+		"@context": "https://schema.org/extensions",
+    "@type": "MessageCard",
+		"summary": "Moira Alert"
+		"title" : "WARN Trigger Name [tag1]"
+		"themeColor": "ffa500"
+		"sections": [
+			 {
+					"activityTitle": "Description",
+					"activityText": "A trigger description",
+					"facts": [
+						 {
+								"name": "10:45",
+								"value": "someServer = 0.11 (NODATA to WARN)"
+						 }
+					]
+			 }
+		]
+		"potentialAction": [
+			{
+				"@type": "OpenUri",
+				"name": "Open in Moira"
+				"targets": [
+					{
+						"os": "default",
+						"value": "http://moira.tld/trigger/ABCDEF-GH"
+					}
+				]
+			}
+		]
+ }
+*/
 type MessageCard struct {
 	Context         string    `json:"@context"`
 	MessageType     string    `json:"@type"`

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -50,7 +50,7 @@ type OpenURITarget struct {
 }
 
 /*
-Actions models possible actions in a MessageCard, currently limited to OpenURI actions
+Action models possible action in a MessageCard, currently limited to OpenURI actions
  {
 		"@type": "OpenUri",
     "name": "Open in Moira"

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -109,5 +109,5 @@ type MessageCard struct {
 	ThemeColor      string    `json:"themeColor"`
 	Title           string    `json:"title"`
 	Sections        []Section `json:"sections"`
-	PotentialAction []Actions `json:"potentialAction,omitempty"`
+	PotentialAction []Action `json:"potentialAction,omitempty"`
 }

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,11 +1,8 @@
 package msteams
 
-import "github.com/moira-alert/moira"
-
 type Fact struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
-	state moira.State
 }
 
 type Section struct {
@@ -33,5 +30,5 @@ type MessageCard struct {
 	ThemeColor      string    `json:"themeColor"`
 	Title           string    `json:"title"`
 	Sections        []Section `json:"sections"`
-	PotentialAction []Actions `json:"potentialAction"`
+	PotentialAction []Actions `json:"potentialAction,omitempty"`
 }

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,5 +1,11 @@
 package msteams
 
+const Green = "008000"
+const Orange = "ffa500"
+const Red = "ff0000"
+const Black = "000000"
+const White = "ffffff"
+
 /*
 Fact models a fact in a MessageCard, contains a timestamp and trigger data
  {

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -62,7 +62,7 @@ Actions models possible actions in a MessageCard, currently limited to OpenURI a
 		]
  }
 */
-type Actions struct {
+type Action struct {
 	Type    string          `json:"@type"`
 	Name    string          `json:"name"`
 	Targets []OpenURITarget `json:"targets"`

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,0 +1,37 @@
+package msteams
+
+import "github.com/moira-alert/moira"
+
+type Fact struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	state moira.State
+}
+
+type Section struct {
+	ActivityTitle string `json:"activityTitle"`
+	ActivityText  string `json:"activityText"`
+	Facts         []Fact `json:"facts"`
+}
+
+type OpenUriTarget struct {
+	Os  string `json:"os"`
+	Uri string `json:"uri"`
+}
+
+//limited to OpenURI actions
+type Actions struct {
+	Type    string          `json:"@type"`
+	Name    string          `json:"name"`
+	Targets []OpenUriTarget `json:"targets"`
+}
+
+type MessageCard struct {
+	Context         string    `json:"@context"`
+	MessageType     string    `json:"@type"`
+	Summary         string    `json:"summary"`
+	ThemeColor      string    `json:"themeColor"`
+	Title           string    `json:"title"`
+	Sections        []Section `json:"sections"`
+	PotentialAction []Actions `json:"potentialAction"`
+}

--- a/senders/msteams/datatypes.go
+++ b/senders/msteams/datatypes.go
@@ -1,9 +1,5 @@
 package msteams
 
-import (
-	"fmt"
-)
-
 /*
 Fact models a fact in a MessageCard, contains a timestamp and trigger data
  {
@@ -109,15 +105,3 @@ type MessageCard struct {
 	Sections        []Section `json:"sections"`
 	PotentialAction []Actions `json:"potentialAction,omitempty"`
 }
-
-type ErrTeamsError struct {
-	error       string
-	description string
-	err         error
-}
-
-func (e *ErrTeamsError) Error() string {
-	return fmt.Sprintf("%s : %s", e.description, e.error)
-}
-
-func (e *ErrTeamsError) Unwrap() error { return e.err }

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -21,6 +21,7 @@ type Sender struct {
 	client   *http.Client
 }
 
+// Initialise basic settings and HTTP client
 func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger, location *time.Location, dateTimeFormat string) error {
 	sender.logger = logger
 	sender.location = location
@@ -64,7 +65,7 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 
 func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moira.TriggerData, throttled bool) MessageCard {
 
-	title, uri := sender.buildTitleAndUri(events, trigger)
+	title, uri := sender.buildTitleAndURI(events, trigger)
 	var triggerDescription string
 	if trigger.Desc != "" {
 		triggerDescription = string(blackfriday.Run([]byte(trigger.Desc)))
@@ -75,10 +76,10 @@ func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moir
 		actions = append(actions, Actions{
 			Type: "OpenUri",
 			Name: "View in Moira",
-			Targets: []OpenUriTarget{
+			Targets: []OpenURITarget{
 				{
 					Os:  "default",
-					Uri: uri,
+					URI: uri,
 				},
 			},
 		})
@@ -125,8 +126,8 @@ func (sender *Sender) buildRequest(events moira.NotificationEvents, contact moir
 	return request, nil
 }
 
-func (sender *Sender) buildTitleAndUri(events moira.NotificationEvents, trigger moira.TriggerData) (string, string) {
-	title := fmt.Sprintf("%s", events.GetSubjectState())
+func (sender *Sender) buildTitleAndURI(events moira.NotificationEvents, trigger moira.TriggerData) (string, string) {
+	title := string(events.GetSubjectState())
 
 	if trigger.Name != "" {
 		title += " " + trigger.Name
@@ -184,7 +185,7 @@ func (sender *Sender) isValidWebhookURL(webhookURL string) error {
 	}
 	// only pass MS teams webhook URLs
 	hasPrefix := strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/")
-	if hasPrefix != true {
+	if !hasPrefix {
 		err = errors.New("unvalid ms teams webhook url")
 		return err
 	}

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -170,7 +170,7 @@ func (sender *Sender) buildTitleAndURI(events moira.NotificationEvents, trigger 
 
 	tags := trigger.GetTags()
 	if tags != "" {
-		title += " " + tags
+		title = fmt.Sprintf("%s %s", title, tags)
 	}
 	triggerURI := trigger.GetTriggerURI(sender.frontURI)
 

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -45,6 +45,11 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 	}
 
 	request, err := sender.buildRequest(events, contact, trigger, plot, throttled)
+
+	if err != nil {
+		return fmt.Errorf("failed to build request: %s", err.Error())
+	}
+
 	if request != nil {
 		defer request.Body.Close()
 	}

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -80,18 +80,13 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 
 	//handle non 2xx responses
 	if response.StatusCode >= http.StatusBadRequest && response.StatusCode <= http.StatusNetworkAuthenticationRequired {
-		return &ErrTeamsError{
-			error:       strconv.Itoa(response.StatusCode),
-			description: "server responded with a non 2xx code",
-		}
+		return fmt.Errorf("server responded with a non 2xx code: %d", response.StatusCode)
+
 	}
 
 	responseData := string(body)
 	if responseData != TeamsOKResponse {
-		return &ErrTeamsError{
-			error:       responseData,
-			description: "teams endpoint responded with an error",
-		}
+		return fmt.Errorf("teams endpoint responded with an error: %s", responseData)
 	}
 
 	return nil
@@ -218,10 +213,7 @@ func (sender *Sender) isValidWebhookURL(webhookURL string) error {
 	// only pass MS teams webhook URLs
 	hasPrefix := strings.HasPrefix(webhookURL, TeamsBaseURL)
 	if !hasPrefix {
-		return &ErrTeamsError{
-			error:       webhookURL,
-			description: "invalid teams webhook",
-		}
+		return fmt.Errorf("%s is an invalid ms teams webhook url", webhookURL)
 	}
 	return nil
 }

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -9,6 +9,7 @@ import (
 	"github.com/russross/blackfriday/v2"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -26,9 +27,13 @@ func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger
 	sender.logger = logger
 	sender.location = location
 	sender.frontURI = senderSettings["front_uri"]
+	disableKeepAlives, err := strconv.ParseBool(senderSettings["disable_keepalives"])
+	if err != nil {
+		disableKeepAlives = false
+	}
 	sender.client = &http.Client{
 		Timeout:   time.Duration(30) * time.Second,
-		Transport: &http.Transport{DisableKeepAlives: true},
+		Transport: &http.Transport{DisableKeepAlives: disableKeepAlives},
 	}
 	return nil
 }
@@ -199,7 +204,7 @@ func getColourForState(state moira.State) string {
 	case moira.StateWARN:
 		return "ffa500" //orange
 	case moira.StateERROR:
-		return "ffa500" //red
+		return "ff0000" //red
 	case moira.StateNODATA:
 		return "000000" //black
 	default:

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -109,9 +109,9 @@ func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moir
 		triggerDescription = string(blackfriday.Run([]byte(trigger.Desc)))
 	}
 	facts := sender.buildEventsFacts(events, sender.maxEvents, throttled)
-	var actions []Actions
+	var actions []Action
 	if uri != "" {
-		actions = append(actions, Actions{
+		actions = append(actions, Action{
 			Type: openUri,
 			Name: openUriMessage,
 			Targets: []OpenURITarget{

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -149,7 +149,6 @@ func (sender *Sender) buildRequest(events moira.NotificationEvents, contact moir
 		return nil, err
 	}
 
-	sender.logger.Debugf("%s\n", requestBody)
 	request, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return request, err
@@ -158,7 +157,7 @@ func (sender *Sender) buildRequest(events moira.NotificationEvents, contact moir
 	for k, v := range headers {
 		request.Header.Set(k, v)
 	}
-	sender.logger.Debugf("%s %s '%s'", request.Method, request.URL.String(), string(requestBody))
+	sender.logger.Debugf("created payload '%s' for teams endpoint %s", string(requestBody), request.URL.String())
 	return request, nil
 }
 

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -61,21 +61,6 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 	return nil
 }
 
-func isValidWebhookURL(webhookURL string) (bool, error) {
-	// basic URL check
-	_, err := url.Parse(webhookURL)
-	if err != nil {
-		return false, err
-	}
-	// only pass MS teams webhook URLs
-	hasPrefix := strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/")
-	if hasPrefix != true {
-		err = errors.New("unvalid ms teams webhook url")
-		return false, err
-	}
-	return true, nil
-}
-
 func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moira.TriggerData, throttled bool) MessageCard {
 
 	title, uri := sender.buildTitleAndUri(events, trigger)
@@ -188,6 +173,21 @@ func (sender *Sender) buildEventsFacts(events moira.NotificationEvents, maxEvent
 		})
 	}
 	return facts
+}
+
+func isValidWebhookURL(webhookURL string) (bool, error) {
+	// basic URL check
+	_, err := url.Parse(webhookURL)
+	if err != nil {
+		return false, err
+	}
+	// only pass MS teams webhook URLs
+	hasPrefix := strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/")
+	if hasPrefix != true {
+		err = errors.New("unvalid ms teams webhook url")
+		return false, err
+	}
+	return true, nil
 }
 
 func getColourForState(state moira.State) string {

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -9,7 +9,6 @@ import (
 	"github.com/russross/blackfriday/v2"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -27,13 +26,9 @@ func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger
 	sender.logger = logger
 	sender.location = location
 	sender.frontURI = senderSettings["front_uri"]
-	disableKeepAlives, err := strconv.ParseBool(senderSettings["disable_keepalives"])
-	if err != nil {
-		disableKeepAlives = false
-	}
 	sender.client = &http.Client{
 		Timeout:   time.Duration(30) * time.Second,
-		Transport: &http.Transport{DisableKeepAlives: disableKeepAlives},
+		Transport: &http.Transport{DisableKeepAlives: false},
 	}
 	return nil
 }

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/moira-alert/moira"
+	"gopkg.in/russross/blackfriday.v2"
 	"net/http"
 	"net/url"
 	"strings"
@@ -80,7 +81,7 @@ func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moir
 	title, uri := sender.buildTitleAndUri(events, trigger)
 	var triggerDescription string
 	if trigger.Desc != "" {
-		triggerDescription = strings.ReplaceAll(trigger.Desc, "\n", "  \n\n")
+		triggerDescription = string(blackfriday.Run([]byte(trigger.Desc)))
 	}
 	facts := sender.buildEventsFacts(events, -1, throttled)
 	var actions []Actions

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -21,7 +21,7 @@ type Sender struct {
 	client   *http.Client
 }
 
-// Initialise basic settings and HTTP client
+// Init initialises settings required for full functionality
 func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger, location *time.Location, dateTimeFormat string) error {
 	sender.logger = logger
 	sender.location = location

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -27,8 +27,7 @@ func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger
 	sender.location = location
 	sender.frontURI = senderSettings["front_uri"]
 	sender.client = &http.Client{
-		Timeout:   time.Duration(30) * time.Second,
-		Transport: &http.Transport{DisableKeepAlives: false},
+		Timeout: time.Duration(30) * time.Second,
 	}
 	return nil
 }

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -1,0 +1,210 @@
+package msteams
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/moira-alert/moira"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Sender implements moira sender interface via MS Teams
+type Sender struct {
+	frontURI string
+	logger   moira.Logger
+	location *time.Location
+	client   *http.Client
+}
+
+type Fact struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	state moira.State
+}
+
+type Section struct {
+	ActivityTitle    string `json:"activityTitle"`
+	ActivitySubtitle string `json:"activitySubtitle"`
+	Facts            []Fact `json:"facts"`
+}
+
+type MessageCard struct {
+	Context     string    `json:"@context"`
+	MessageType string    `json:"@type"`
+	Summary     string    `json:"summary"`
+	ThemeColor  string    `json:"themeColor"`
+	Title       string    `json:"title"`
+	Sections    []Section `json:"sections"`
+}
+
+func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger, location *time.Location, dateTimeFormat string) error {
+	sender.logger = logger
+	sender.location = location
+	sender.client = &http.Client{
+		Timeout:   time.Duration(30) * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	return nil
+}
+
+// SendEvents implements Sender interface Send
+func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.ContactData, trigger moira.TriggerData, plot []byte, throttled bool) error {
+
+	valid, err := isValidWebhookURL(contact.Value)
+	if valid != true {
+		return err
+	}
+
+	if err != nil {
+		sender.logger.Error(err)
+	}
+
+	request, err := sender.buildRequest(events, contact, trigger, plot, throttled)
+	if request != nil {
+		defer request.Body.Close()
+	}
+
+	response, err := sender.client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to perform request: %s", err.Error())
+	}
+
+	return nil
+}
+
+func isValidWebhookURL(webhookURL string) (bool, error) {
+	// basic URL check
+	_, err := url.Parse(webhookURL)
+	if err != nil {
+		return false, err
+	}
+	// only pass MS teams webhook URLs
+	hasPrefix := strings.HasPrefix(webhookURL, "https://outlook.office.com/webhook/")
+	if hasPrefix != true {
+		err = errors.New("unvalid ms teams webhook url")
+		return false, err
+	}
+	return true, nil
+}
+
+func buildMessageCard(title string, state moira.State, data moira.TriggerData, facts []Fact) MessageCard {
+	messageCard := MessageCard{
+		Context:     "http://schema.org/extensions",
+		MessageType: "MessageCard",
+		Summary:     "Alert",
+		ThemeColor:  getColourForState(state),
+		Title:       title,
+		Sections: []Section{
+			{
+				ActivityTitle:    "tags",
+				ActivitySubtitle: data.GetTags(),
+				Facts:            facts,
+			},
+		},
+	}
+	return messageCard
+}
+
+func (sender *Sender) buildRequest(events moira.NotificationEvents, contact moira.ContactData, trigger moira.TriggerData, plot []byte, throttled bool) (*http.Request, error) {
+
+	title := sender.buildTitle(events, trigger)
+	facts := sender.buildEventsFacts(events, -1, throttled)
+
+	messageCard := buildMessageCard(title, events.GetSubjectState(), trigger, facts)
+	requestURL := contact.Value
+	requestBody, err := json.Marshal(messageCard)
+	if err != nil {
+		return nil, err
+	}
+
+	sender.logger.Infof("%s\n", requestBody)
+	request, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return request, err
+	}
+	headers := map[string]string{
+		"User-Agent":   "Moira",
+		"Content-Type": "application/json",
+	}
+	for k, v := range headers {
+		request.Header.Set(k, v)
+	}
+	sender.logger.Debugf("%s %s '%s'", request.Method, request.URL.String(), string(requestBody))
+	return request, nil
+}
+
+func (sender *Sender) buildTitle(events moira.NotificationEvents, trigger moira.TriggerData) string {
+	title := fmt.Sprintf("%s", events.GetSubjectState())
+	triggerURI := trigger.GetTriggerURI(sender.frontURI)
+	if triggerURI != "" {
+		title += fmt.Sprintf(" [%s|%s]", triggerURI, trigger.Name)
+	} else if trigger.Name != "" {
+		title += " " + trigger.Name
+	}
+
+	tags := trigger.GetTags()
+	if tags != "" {
+		title += " " + tags
+	}
+
+	return title
+}
+
+// buildEventsFacts builds Facts from moira events
+// if n is negative buildEventsFacts does not limit the Facts array
+func (sender *Sender) buildEventsFacts(events moira.NotificationEvents, maxEvents int, throttled bool) []Fact {
+	var facts []Fact
+
+	eventsPrinted := 0
+	for _, event := range events {
+		line := fmt.Sprintf("%s = %s (%s to %s)", event.Metric, event.GetMetricValue(), event.OldState, event.State)
+		if len(moira.UseString(event.Message)) > 0 {
+			line += fmt.Sprintf(". %s", moira.UseString(event.Message))
+		}
+		facts = append(facts, Fact{
+			Name:  event.FormatTimestamp(sender.location),
+			Value: "```" + line + "```",
+			state: event.State,
+		})
+
+		if maxEvents != -1 && len(facts) > maxEvents {
+			facts = append(facts, Fact{
+				Name:  "Info",
+				Value: "```" + fmt.Sprintf("\n...and %d more events.", len(events)-eventsPrinted) + "```",
+			})
+			break
+		}
+		eventsPrinted++
+	}
+
+	if throttled {
+		facts = append(facts, Fact{
+			Name:  "Warning",
+			Value: "Please, *fix your system or tune this trigger* to generate less events.",
+		})
+	}
+	return facts
+}
+
+func getColourForState(state moira.State) string {
+	switch state := state; state {
+	case moira.StateOK:
+		return "008000" //green
+	case moira.StateWARN:
+		return "ffa500" //orange
+	case moira.StateERROR:
+		return "ffa500" //red
+	case moira.StateNODATA:
+		return "000000" //black
+	default:
+		return "ffffff" //unhandled state
+	}
+}

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -99,7 +99,7 @@ func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moir
 	if trigger.Desc != "" {
 		triggerDescription = string(blackfriday.Run([]byte(trigger.Desc)))
 	}
-	facts := sender.buildEventsFacts(events, -1, throttled)
+	facts := sender.buildEventsFacts(events, sender.maxEvents, throttled)
 	var actions []Actions
 	if uri != "" {
 		actions = append(actions, Actions{
@@ -141,7 +141,7 @@ func (sender *Sender) buildRequest(events moira.NotificationEvents, contact moir
 	}
 
 	sender.logger.Debugf("%s\n", requestBody)
-	request, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(requestBody))
+	request, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return request, err
 	}

--- a/senders/msteams/msteams.go
+++ b/senders/msteams/msteams.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/moira-alert/moira"
-	"gopkg.in/russross/blackfriday.v2"
+	"github.com/russross/blackfriday/v2"
 	"net/http"
 	"net/url"
 	"strings"

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -17,10 +17,15 @@ func TestInit(t *testing.T) {
 		senderSettings := map[string]string{
 			"max_events": "-1",
 		}
-		Convey("Empty map", func() {
+		Convey("Empty map should fail", func() {
+			err := sender.Init(map[string]string{}, logger, nil, "")
+			So(err, ShouldNotResemble, nil)
+		})
+		Convey("Minimal settings", func() {
 			err := sender.Init(senderSettings, logger, nil, "")
 			So(err, ShouldResemble, nil)
 			So(sender, ShouldNotResemble, Sender{})
+			So(sender.maxEvents, ShouldResemble, -1)
 		})
 	})
 }

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -22,6 +22,21 @@ func TestInit(t *testing.T) {
 	})
 }
 
+func TestValidWebhook(t *testing.T) {
+	location, _ := time.LoadLocation("UTC")
+	sender := Sender{location: location, frontURI: "http://moira.url"}
+	Convey("MS Teams Webhook validity", t, func() {
+		Convey("https://outlook.office.com/webhook/foo is valid", func() {
+			err := sender.isValidWebhookURL("https://outlook.office.com/webhook/foo")
+			So(err, ShouldResemble, nil)
+		})
+		Convey("https://moira.url is invalid", func() {
+			err := sender.isValidWebhookURL("https://moira.url")
+			So(err, ShouldNotResemble, nil)
+		})
+	})
+}
+
 func TestBuildMessage(t *testing.T) {
 	location, _ := time.LoadLocation("UTC")
 	sender := Sender{location: location, frontURI: "http://moira.url"}

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -1,0 +1,231 @@
+package msteams
+
+import (
+	"github.com/moira-alert/moira/logging/go-logging"
+	"testing"
+	"time"
+
+	"github.com/moira-alert/moira"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestInit(t *testing.T) {
+	logger, _ := logging.ConfigureLog("stdout", "debug", "test")
+	Convey("Init tests", t, func() {
+		sender := Sender{}
+		senderSettings := map[string]string{}
+		Convey("Empty map", func() {
+			err := sender.Init(senderSettings, logger, nil, "")
+			So(err, ShouldResemble, nil)
+			So(sender, ShouldNotResemble, Sender{})
+		})
+	})
+}
+
+func TestBuildMessage(t *testing.T) {
+	location, _ := time.LoadLocation("UTC")
+	sender := Sender{location: location, frontURI: "http://moira.url"}
+	value := float64(123)
+
+	Convey("Build Moira Message tests", t, func() {
+		event := moira.NotificationEvent{
+			TriggerID: "TriggerID",
+			Value:     &value,
+			Timestamp: 150000000,
+			Metric:    "Metric",
+			OldState:  moira.StateOK,
+			State:     moira.StateNODATA,
+			Message:   nil,
+		}
+
+		trigger := moira.TriggerData{
+			Tags: []string{"tag1", "tag2"},
+			Name: "Name",
+			ID:   "TriggerID",
+			Desc: `# header1
+some text **bold text**
+## header 2
+some other text _italic text_`,
+		}
+
+		Convey("Create MessageCard with one event", func() {
+			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, false)
+			expected := MessageCard{
+				Context:     "http://schema.org/extensions",
+				MessageType: "MessageCard",
+				Summary:     "Moira Alert",
+				ThemeColor:  "000000",
+				Title:       "NODATA Name [tag1][tag2]",
+				Sections: []Section{
+					{
+						ActivityTitle: "Description",
+						ActivityText:  "# header1  \n\nsome text **bold text**  \n\n## header 2  \n\nsome other text _italic text_",
+						Facts: []Fact{
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+						},
+					},
+				},
+				PotentialAction: []Actions{
+					{
+						Type: "OpenUri",
+						Name: "View in Moira",
+						Targets: []OpenUriTarget{
+							{
+								Os:  "default",
+								Uri: "http://moira.url/trigger/TriggerID",
+							},
+						},
+					},
+				},
+			}
+			So(actual, ShouldResemble, expected)
+		})
+
+		Convey("Create MessageCard with empty trigger", func() {
+			expected := MessageCard{
+				Context:     "http://schema.org/extensions",
+				MessageType: "MessageCard",
+				Summary:     "Moira Alert",
+				ThemeColor:  "000000",
+				Title:       "NODATA",
+				Sections: []Section{
+					{
+						ActivityTitle: "Description",
+						ActivityText:  "",
+						Facts: []Fact{
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+						},
+					},
+				},
+			}
+			actual := sender.buildMessage([]moira.NotificationEvent{event}, moira.TriggerData{}, false)
+			So(actual, ShouldResemble, expected)
+		})
+
+		Convey("Create MessageCard with one event and a throttle warning", func() {
+			expected := MessageCard{
+				Context:     "http://schema.org/extensions",
+				MessageType: "MessageCard",
+				Summary:     "Moira Alert",
+				ThemeColor:  "000000",
+				Title:       "NODATA Name [tag1][tag2]",
+				Sections: []Section{
+					{
+						ActivityTitle: "Description",
+						ActivityText:  "# header1  \n\nsome text **bold text**  \n\n## header 2  \n\nsome other text _italic text_",
+						Facts: []Fact{
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+							{
+								Name:  "Warning",
+								Value: "Please, *fix your system or tune this trigger* to generate less events.",
+							},
+						},
+					},
+				},
+				PotentialAction: []Actions{
+					{
+						Type: "OpenUri",
+						Name: "View in Moira",
+						Targets: []OpenUriTarget{
+							{
+								Os:  "default",
+								Uri: "http://moira.url/trigger/TriggerID",
+							},
+						},
+					},
+				},
+			}
+			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, true)
+			So(actual, ShouldResemble, expected)
+		})
+
+		Convey("Create MessageCard with 6 events", func() {
+			expected := MessageCard{
+				Context:     "http://schema.org/extensions",
+				MessageType: "MessageCard",
+				Summary:     "Moira Alert",
+				ThemeColor:  "000000",
+				Title:       "NODATA Name [tag1][tag2]",
+				Sections: []Section{
+					{
+						ActivityTitle: "Description",
+						ActivityText:  "# header1  \n\nsome text **bold text**  \n\n## header 2  \n\nsome other text _italic text_",
+						Facts: []Fact{
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+						},
+					},
+				},
+				PotentialAction: []Actions{
+					{
+						Type: "OpenUri",
+						Name: "View in Moira",
+						Targets: []OpenUriTarget{
+							{
+								Os:  "default",
+								Uri: "http://moira.url/trigger/TriggerID",
+							},
+						},
+					},
+				},
+			}
+			actual := sender.buildMessage([]moira.NotificationEvent{event, event, event, event, event, event}, trigger, false)
+			So(actual, ShouldResemble, expected)
+		})
+
+		Convey("Create MessageCard without Trigger action, but with trigger name", func() {
+			expected := MessageCard{
+				Context:     "http://schema.org/extensions",
+				MessageType: "MessageCard",
+				Summary:     "Moira Alert",
+				ThemeColor:  "000000",
+				Title:       "NODATA Name",
+				Sections: []Section{
+					{
+						ActivityTitle: "Description",
+						ActivityText:  "",
+						Facts: []Fact{
+							{
+								Name:  "02:40",
+								Value: "```Metric = 123 (OK to NODATA)```",
+							},
+						},
+					},
+				},
+			}
+			actual := sender.buildMessage([]moira.NotificationEvent{event}, moira.TriggerData{Name: "Name"}, false)
+			So(actual, ShouldResemble, expected)
+		})
+	})
+}

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -137,7 +137,7 @@ some other text _italic text_`,
 		}
 
 		Convey("Card uses the correct colour for subject state", func() {
-			Convey("State is RED for Error", func() {
+			Convey("State is Red for Error", func() {
 				actual := sender.buildMessage([]moira.NotificationEvent{{
 					TriggerID: "TriggerID",
 					Value:     &value,
@@ -151,7 +151,7 @@ some other text _italic text_`,
 					Context:     "http://schema.org/extensions",
 					MessageType: "MessageCard",
 					Summary:     "Moira Alert",
-					ThemeColor:  "ff0000",
+					ThemeColor:  Red,
 					Title:       "ERROR Name",
 					Sections: []Section{
 						{
@@ -168,7 +168,7 @@ some other text _italic text_`,
 				}
 				So(actual, ShouldResemble, expected)
 			})
-			Convey("State is ORANGE for Warning", func() {
+			Convey("State is Orange for Warning", func() {
 				actual := sender.buildMessage([]moira.NotificationEvent{{
 					TriggerID: "TriggerID",
 					Value:     &value,
@@ -182,7 +182,7 @@ some other text _italic text_`,
 					Context:     "http://schema.org/extensions",
 					MessageType: "MessageCard",
 					Summary:     "Moira Alert",
-					ThemeColor:  "ffa500",
+					ThemeColor:  Orange,
 					Title:       "WARN Name",
 					Sections: []Section{
 						{
@@ -199,7 +199,7 @@ some other text _italic text_`,
 				}
 				So(actual, ShouldResemble, expected)
 			})
-			Convey("State is GREEN for OK", func() {
+			Convey("State is Green for OK", func() {
 				actual := sender.buildMessage([]moira.NotificationEvent{{
 					TriggerID: "TriggerID",
 					Value:     &value,
@@ -213,7 +213,7 @@ some other text _italic text_`,
 					Context:     "http://schema.org/extensions",
 					MessageType: "MessageCard",
 					Summary:     "Moira Alert",
-					ThemeColor:  "008000",
+					ThemeColor:  Green,
 					Title:       "OK Name",
 					Sections: []Section{
 						{
@@ -230,7 +230,7 @@ some other text _italic text_`,
 				}
 				So(actual, ShouldResemble, expected)
 			})
-			Convey("State is BLACK for NODATA", func() {
+			Convey("State is Black for NODATA", func() {
 				actual := sender.buildMessage([]moira.NotificationEvent{{
 					TriggerID: "TriggerID",
 					Value:     &value,
@@ -244,7 +244,7 @@ some other text _italic text_`,
 					Context:     "http://schema.org/extensions",
 					MessageType: "MessageCard",
 					Summary:     "Moira Alert",
-					ThemeColor:  "000000",
+					ThemeColor:  Black,
 					Title:       "NODATA Name",
 					Sections: []Section{
 						{
@@ -270,7 +270,7 @@ some other text _italic text_`,
 				Context:     "http://schema.org/extensions",
 				MessageType: "MessageCard",
 				Summary:     "Moira Alert",
-				ThemeColor:  "000000",
+				ThemeColor:  Black,
 				Title:       "NODATA Name [tag1][tag2]",
 				Sections: []Section{
 					{
@@ -305,7 +305,7 @@ some other text _italic text_`,
 				Context:     "http://schema.org/extensions",
 				MessageType: "MessageCard",
 				Summary:     "Moira Alert",
-				ThemeColor:  "000000",
+				ThemeColor:  Black,
 				Title:       "NODATA",
 				Sections: []Section{
 					{
@@ -329,7 +329,7 @@ some other text _italic text_`,
 				Context:     "http://schema.org/extensions",
 				MessageType: "MessageCard",
 				Summary:     "Moira Alert",
-				ThemeColor:  "000000",
+				ThemeColor:  Black,
 				Title:       "NODATA Name [tag1][tag2]",
 				Sections: []Section{
 					{
@@ -369,7 +369,7 @@ some other text _italic text_`,
 				Context:     "http://schema.org/extensions",
 				MessageType: "MessageCard",
 				Summary:     "Moira Alert",
-				ThemeColor:  "000000",
+				ThemeColor:  Black,
 				Title:       "NODATA Name [tag1][tag2]",
 				Sections: []Section{
 					{
@@ -425,7 +425,7 @@ some other text _italic text_`,
 				Context:     "http://schema.org/extensions",
 				MessageType: "MessageCard",
 				Summary:     "Moira Alert",
-				ThemeColor:  "000000",
+				ThemeColor:  Black,
 				Title:       "NODATA Name",
 				Sections: []Section{
 					{

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -59,7 +59,7 @@ some other text _italic text_`,
 				Sections: []Section{
 					{
 						ActivityTitle: "Description",
-						ActivityText:  "# header1  \n\nsome text **bold text**  \n\n## header 2  \n\nsome other text _italic text_",
+						ActivityText:  "<h1>header1</h1>\n\n<p>some text <strong>bold text</strong></p>\n\n<h2>header 2</h2>\n\n<p>some other text <em>italic text</em></p>\n",
 						Facts: []Fact{
 							{
 								Name:  "02:40",
@@ -118,7 +118,7 @@ some other text _italic text_`,
 				Sections: []Section{
 					{
 						ActivityTitle: "Description",
-						ActivityText:  "# header1  \n\nsome text **bold text**  \n\n## header 2  \n\nsome other text _italic text_",
+						ActivityText:  "<h1>header1</h1>\n\n<p>some text <strong>bold text</strong></p>\n\n<h2>header 2</h2>\n\n<p>some other text <em>italic text</em></p>\n",
 						Facts: []Fact{
 							{
 								Name:  "02:40",
@@ -158,7 +158,7 @@ some other text _italic text_`,
 				Sections: []Section{
 					{
 						ActivityTitle: "Description",
-						ActivityText:  "# header1  \n\nsome text **bold text**  \n\n## header 2  \n\nsome other text _italic text_",
+						ActivityText:  "<h1>header1</h1>\n\n<p>some text <strong>bold text</strong></p>\n\n<h2>header 2</h2>\n\n<p>some other text <em>italic text</em></p>\n",
 						Facts: []Fact{
 							{
 								Name:  "02:40",

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -107,7 +107,7 @@ func TestValidWebhook(t *testing.T) {
 
 func TestBuildMessage(t *testing.T) {
 	location, _ := time.LoadLocation("UTC")
-	sender := Sender{location: location, frontURI: "http://moira.url"}
+	sender := Sender{location: location, maxEvents: -1, frontURI: "http://moira.url"}
 	value := float64(123)
 
 	Convey("Build Moira Message tests", t, func() {

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -2,7 +2,6 @@ package msteams
 
 import (
 	"github.com/moira-alert/moira/logging/go-logging"
-	"net/http"
 	"testing"
 	"time"
 
@@ -19,13 +18,6 @@ func TestInit(t *testing.T) {
 			err := sender.Init(senderSettings, logger, nil, "")
 			So(err, ShouldResemble, nil)
 			So(sender, ShouldNotResemble, Sender{})
-		})
-		Convey("HTTP keep-alive should always be enabled", func() {
-			err := sender.Init(senderSettings, logger, nil, "")
-			So(err, ShouldResemble, nil)
-			transport, ok := sender.client.Transport.(*http.Transport)
-			So(ok, ShouldResemble, true)
-			So(transport.DisableKeepAlives, ShouldResemble, false)
 		})
 	})
 }

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -73,10 +73,7 @@ some other text _italic text_`,
 				BodyString("Some error")
 			contact := moira.ContactData{Value: "https://outlook.office.com/webhook/foo"}
 			err := sender.SendEvents([]moira.NotificationEvent{event}, contact, trigger, make([]byte, 0, 1), false)
-			So(err, ShouldResemble, &ErrTeamsError{
-				error:       "Some error",
-				description: "teams endpoint responded with an error",
-			})
+			So(err.Error(), ShouldResemble, "teams endpoint responded with an error: Some error")
 			So(gock.IsDone(), ShouldBeTrue)
 		})
 		Convey("is not any of HTTP success, result should be an error", func() {
@@ -87,7 +84,7 @@ some other text _italic text_`,
 				BodyString("Some error")
 			contact := moira.ContactData{Value: "https://outlook.office.com/webhook/foo"}
 			err := sender.SendEvents([]moira.NotificationEvent{event}, contact, trigger, make([]byte, 0, 1), false)
-			So(err.Error(), ShouldResemble, "server responded with a non 2xx code : 500")
+			So(err.Error(), ShouldResemble, "server responded with a non 2xx code: 500")
 			So(gock.IsDone(), ShouldBeTrue)
 		})
 	})

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -20,20 +20,12 @@ func TestInit(t *testing.T) {
 			So(err, ShouldResemble, nil)
 			So(sender, ShouldNotResemble, Sender{})
 		})
-		Convey("Default value for disabling HTTP Keepalive should be false", func() {
+		Convey("HTTP keep-alive should always be enabled", func() {
 			err := sender.Init(senderSettings, logger, nil, "")
 			So(err, ShouldResemble, nil)
 			transport, ok := sender.client.Transport.(*http.Transport)
 			So(ok, ShouldResemble, true)
 			So(transport.DisableKeepAlives, ShouldResemble, false)
-		})
-		Convey("disabling HTTP Keepalive should be true", func() {
-			senderSettings["disable_keepalives"] = "True"
-			err := sender.Init(senderSettings, logger, nil, "")
-			So(err, ShouldResemble, nil)
-			transport, ok := sender.client.Transport.(*http.Transport)
-			So(ok, ShouldResemble, true)
-			So(transport.DisableKeepAlives, ShouldResemble, true)
 		})
 	})
 }

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -284,7 +284,7 @@ some other text _italic text_`,
 						},
 					},
 				},
-				PotentialAction: []Actions{
+				PotentialAction: []Action{
 					{
 						Type: "OpenUri",
 						Name: "View in Moira",
@@ -347,7 +347,7 @@ some other text _italic text_`,
 						},
 					},
 				},
-				PotentialAction: []Actions{
+				PotentialAction: []Action{
 					{
 						Type: "OpenUri",
 						Name: "View in Moira",
@@ -403,7 +403,7 @@ some other text _italic text_`,
 						},
 					},
 				},
-				PotentialAction: []Actions{
+				PotentialAction: []Action{
 					{
 						Type: "OpenUri",
 						Name: "View in Moira",

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -87,10 +87,10 @@ some other text _italic text_`,
 					{
 						Type: "OpenUri",
 						Name: "View in Moira",
-						Targets: []OpenUriTarget{
+						Targets: []OpenURITarget{
 							{
 								Os:  "default",
-								Uri: "http://moira.url/trigger/TriggerID",
+								URI: "http://moira.url/trigger/TriggerID",
 							},
 						},
 					},
@@ -150,10 +150,10 @@ some other text _italic text_`,
 					{
 						Type: "OpenUri",
 						Name: "View in Moira",
-						Targets: []OpenUriTarget{
+						Targets: []OpenURITarget{
 							{
 								Os:  "default",
-								Uri: "http://moira.url/trigger/TriggerID",
+								URI: "http://moira.url/trigger/TriggerID",
 							},
 						},
 					},
@@ -206,10 +206,10 @@ some other text _italic text_`,
 					{
 						Type: "OpenUri",
 						Name: "View in Moira",
-						Targets: []OpenUriTarget{
+						Targets: []OpenURITarget{
 							{
 								Os:  "default",
-								Uri: "http://moira.url/trigger/TriggerID",
+								URI: "http://moira.url/trigger/TriggerID",
 							},
 						},
 					},


### PR DESCRIPTION
Adds support for Microsoft Teams, via inbound channel WebHooks

* Add a delivery channel using the MSTeams Incoming Webhook 
![image](https://user-images.githubusercontent.com/1764981/65957178-17d11c00-e444-11e9-86b0-cda876465692.png)
* Assign the delivery channel to a Subscription (graphs are not yet supported)
![image](https://user-images.githubusercontent.com/1764981/65957298-5e267b00-e444-11e9-82c3-eaf1673cc8da.png)


Wait for the alerts to roll in the channel

![image](https://user-images.githubusercontent.com/1764981/65945857-c49f9f00-e42c-11e9-983b-a56d4bcc2061.png)
