### PR TITLE
build: Bump go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - redis-server
 language: go
 go:
-  - 1.12.6
+  - 1.13.1
 git:
   depth: 1000
 addons:

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.12.6 as builder
+FROM golang:1.13.1 as builder
 
 RUN go get github.com/kardianos/govendor
 

--- a/Dockerfile.checker
+++ b/Dockerfile.checker
@@ -1,4 +1,4 @@
-FROM golang:1.12.6 as builder
+FROM golang:1.13.1 as builder
 
 RUN go get github.com/kardianos/govendor
 

--- a/Dockerfile.filter
+++ b/Dockerfile.filter
@@ -1,4 +1,4 @@
-FROM golang:1.12.6 as builder
+FROM golang:1.13.1 as builder
 
 RUN go get github.com/kardianos/govendor
 

--- a/Dockerfile.notifier
+++ b/Dockerfile.notifier
@@ -1,4 +1,4 @@
-FROM golang:1.12.6 as builder
+FROM golang:1.13.1 as builder
 
 RUN go get github.com/kardianos/govendor
 

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ prepare:
 .PHONY: lint
 lint: prepare
 	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
-	gometalinter ./... --aggregate --vendor --skip mock --disable=errcheck --disable=gocyclo --disable=gosec --deadline=5m
+	GO111MODULE=off gometalinter --install
+	GO111MODULE=off gometalinter ./... --aggregate --vendor --skip mock --disable=errcheck --disable=gocyclo --disable=gosec --deadline=5m
 
 .PHONY: test
 test: prepare


### PR DESCRIPTION
Go version bumped to 1.13.1 to fix problems occured during migration to
go modules.