### PR TITLE
Add twimlets support for Twilio sender

### DIFF
--- a/senders/twilio/twilio.go
+++ b/senders/twilio/twilio.go
@@ -57,15 +57,19 @@ func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger
 		sender.sender = &twilioSenderSms{twilioSender1}
 
 	case "twilio voice":
+		twimletsEcho := senderSettings["twimlets_echo"] == "true"
+		appendMessage := (senderSettings["append_message"] == "true") || (twimletsEcho)
+
 		voiceURL := senderSettings["voiceurl"]
-		if voiceURL == "" {
+		if voiceURL == "" && !twimletsEcho {
 			return fmt.Errorf("can not read [%s] voiceurl param from config", apiType)
 		}
 
 		sender.sender = &twilioSenderVoice{
 			twilioSender:  twilioSender1,
 			voiceURL:      voiceURL,
-			appendMessage: senderSettings["append_message"] == "true",
+			twimletsEcho:  twimletsEcho,
+			appendMessage: appendMessage,
 		}
 
 	default:

--- a/senders/twilio/voice.go
+++ b/senders/twilio/voice.go
@@ -8,10 +8,13 @@ import (
 	"github.com/moira-alert/moira"
 )
 
+const twimletsEchoURL = "https://twimlets.com/echo?Twiml="
+
 type twilioSenderVoice struct {
 	twilioSender
 	voiceURL      string
 	appendMessage bool
+	twimletsEcho  bool
 }
 
 func (sender *twilioSenderVoice) SendEvents(events moira.NotificationEvents, contact moira.ContactData, trigger moira.TriggerData, plot []byte, throttled bool) error {
@@ -25,9 +28,14 @@ func (sender *twilioSenderVoice) SendEvents(events moira.NotificationEvents, con
 }
 
 func (sender *twilioSenderVoice) buildVoiceURL(trigger moira.TriggerData) string {
+	message := fmt.Sprintf("Hi! This is a notification for Moira trigger %s. Please, visit Moira web interface for details.", trigger.Name)
 	voiceURL := sender.voiceURL
 	if sender.appendMessage {
-		voiceURL += url.QueryEscape(fmt.Sprintf("Hi! This is a notification for Moira trigger %s. Please, visit Moira web interface for details.", trigger.Name))
+		voiceURL += url.QueryEscape(message)
+	}
+	if sender.twimletsEcho {
+		voiceURL = twimletsEchoURL
+		voiceURL += url.QueryEscape(fmt.Sprintf("<Response><Say>%s</Say></Response>", message))
 	}
 	return voiceURL
 }

--- a/senders/twilio/voice_test.go
+++ b/senders/twilio/voice_test.go
@@ -48,4 +48,10 @@ func TestBuildVoiceURL(t *testing.T) {
 		sender.appendMessage = true
 		So(sender.buildVoiceURL(moira.TriggerData{Name: "Name"}), ShouldResemble, "url hereHi%21+This+is+a+notification+for+Moira+trigger+Name.+Please%2C+visit+Moira+web+interface+for+details.")
 	})
+
+	Convey("twimlets echo is true", t, func() {
+		sender.twimletsEcho = true
+		So(sender.buildVoiceURL(moira.TriggerData{Name: "Name"}), ShouldResemble,
+			"https://twimlets.com/echo?Twiml=%3CResponse%3E%3CSay%3EHi%21+This+is+a+notification+for+Moira+trigger+Name.+Please%2C+visit+Moira+web+interface+for+details.%3C%2FSay%3E%3C%2FResponse%3E")
+	})
 }


### PR DESCRIPTION
Use TwiML generator supported by TwilioLabs [link](https://www.twilio.com/labs/twimlets/echo). In this case instead of using `voiceurl` Echo url will be provided to Twilio as callback.
Managed by `twimlets_echo` parameter in Twilio Voice sender section