### PR TITLE
Add Prometheus endpoint for internal metrics

### DIFF
--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -29,6 +29,7 @@ func ConfigureTelemetry(logger moira.Logger, config TelemetryConfig, service str
 		return nil, err
 	}
 	prometheusRegistry := prometheus.NewRegistry()
+	prometheusRegistry.MustRegister(prometheus.NewGoCollector(), prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	prometheusRegistryAdapter := metrics.NewPrometheusRegistryAdapter(prometheusRegistry, service)
 	stopServer, err := startTelemetryServer(logger, config.Listen, config.Pprof, prometheusRegistry)
 	if err != nil {

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -28,8 +28,7 @@ func ConfigureTelemetry(logger moira.Logger, config TelemetryConfig, service str
 	if err != nil {
 		return nil, err
 	}
-	prometheusRegistry := prometheus.NewRegistry()
-	prometheusRegistry.MustRegister(prometheus.NewGoCollector(), prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	prometheusRegistry := metrics.NewPrometheusRegistry()
 	prometheusRegistryAdapter := metrics.NewPrometheusRegistryAdapter(prometheusRegistry, service)
 	stopServer, err := startTelemetryServer(logger, config.Listen, config.Pprof, prometheusRegistry)
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,14 @@ services:
     ports:
       - "7080:80"
 
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./local/prometheus.yml:/etc/prometheus/prometheus.yml
+    command: "--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus"
+    ports:
+      - "9080:9090"
+
   filter:
     build:
       context: .

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/opsgenie/opsgenie-go-sdk-v2 v0.0.0-20190710132028-b46b0594268d
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.3.0
 	github.com/rcrowley/go-metrics v0.0.0-20161128210544-1f30fe9094a5
 	github.com/rs/cors v0.0.0-20170801073201-eabcc6af4bbe
 	github.com/russross/blackfriday/v2 v2.0.1
@@ -75,7 +76,6 @@ require (
 	github.com/tecbot/gorocksdb v0.0.0-20190930194452-65a88f08537a // indirect
 	github.com/wangjohn/quickselect v0.0.0-20161129230411-ed8402a42d5f // indirect
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
-	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	gonum.org/v1/netlib v0.0.0-20190926062253-2d6e29b73a19 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,9 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/aclements/go-moremath v0.0.0-20190830160640-d16893ddf098 h1:a7+Y8VlXRC2VX5ue6tpCutr4PsrkRkWWVZv4zqfaHuc=
 github.com/aclements/go-moremath v0.0.0-20190830160640-d16893ddf098/go.mod h1:idZL3yvz4kzx1dsBOAC+oYv6L92P1oFEhUXUB1A/lwQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.20.15-0.20190702192017-e1b61fed9fc0 h1:9Fu0uAEkwWdCoHT6hxavg+/EvRNHhk95pCbJAqes08c=
 github.com/aws/aws-sdk-go v1.20.15-0.20190702192017-e1b61fed9fc0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -28,6 +30,8 @@ github.com/beevee/go-chart v2.0.2-0.20190523110126-273a59e48bcc+incompatible h1:
 github.com/beevee/go-chart v2.0.2-0.20190523110126-273a59e48bcc+incompatible/go.mod h1:evn74cztO3E5WNfA6BfAtMsAjZZYP5e5nYOVxMds4+Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blend/go-sdk v2.0.0+incompatible h1:FL9X/of4ZYO5D2JJNI4vHrbXPfuSDbUa7h8JP9+E92w=
 github.com/blend/go-sdk v2.0.0+incompatible/go.mod h1:3GUb0YsHFNTJ6hsJTpzdmCUl05o8HisKjx5OAlzYKdw=
 github.com/blevesearch/bleve v0.8.1 h1:20zBREtGe8dvBxCC+717SaxKcUVQOWk3/Fm75vabKpU=
@@ -107,6 +111,7 @@ github.com/go-graphite/carbonapi v0.0.0-20190604194342-5a4fa2112923/go.mod h1:Gc
 github.com/go-graphite/protocol v0.4.2 h1:Qs87wE1ln6ZFOmbZDfQNaai28U13dr+19mz45UFAQk8=
 github.com/go-graphite/protocol v0.4.2/go.mod h1:tJs3CWCesQ9Laqjz5pbMDHqJlPHDUZv502EtN7qujzQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -168,8 +173,10 @@ github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNu
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-querystring v1.0.1-0.20190318165438-c8c88dbee036 h1:Avad62mreCc9la5buHvHZXbvsY+GPYUVjd8xsi48FYY=
 github.com/google/go-querystring v1.0.1-0.20190318165438-c8c88dbee036/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99 h1:twflg0XRTjwKpxb/jFExr4HGq6on2dEOmnL6FV+fgPw=
@@ -204,6 +211,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -244,6 +253,7 @@ github.com/matoous/godox v0.0.0-20190910121045-032ad8106c86/go.mod h1:1BELzlh859
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -252,6 +262,10 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12 h1:dd7vnTDfjtwCETZDrRe+GPYNLA1jBtbZeyfyE8eZCyk=
 github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12/go.mod h1:i/KKcxEWEO8Yyl11DYafRPKOPVYTrhxiTRigjtEEXZU=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae h1:VeRdUYdCw49yizlSbMEn2SZ+gT+3IUKx8BqxyQdz+BY=
@@ -288,12 +302,23 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
+github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.3.0 h1:miYCvYqFXtl/J9FIy8eNpBfYthAEFg+Ys0XyUVEcDsc=
+github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=
+github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
+github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
+github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20161128210544-1f30fe9094a5 h1:gwcdIpH6NU2iF8CmcqD+CP6+1CkRBOhHaPR+iu6raBY=
@@ -413,6 +438,7 @@ golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190909003024-a7b16738d86b h1:XfVGCX+0T4WOStkaOsJRllbsiImhB2jgVBGc9L0lPGc=
 golang.org/x/net v0.0.0-20190909003024-a7b16738d86b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -421,6 +447,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20171026204733-164713f0dfce/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -437,6 +464,8 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190911201528-7ad0cfa0b7b5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
+golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/local/prometheus.yml
+++ b/local/prometheus.yml
@@ -1,0 +1,16 @@
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'moira-api'
+    static_configs:
+      - targets: ['api:8091']
+  - job_name: 'moira-checker'
+    static_configs:
+      - targets: ['checker:8092']
+  - job_name: 'moira-notifier'
+    static_configs:
+      - targets: ['notifier:8093']
+  - job_name: 'moira-filter'
+    static_configs:
+      - targets: ['filter:8094']

--- a/metrics/composite.go
+++ b/metrics/composite.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"time"
+)
+
+type CompositeRegistry struct {
+	registries []Registry
+}
+
+func NewCompositeRegistry(registries ...Registry) *CompositeRegistry {
+	return &CompositeRegistry{registries}
+}
+
+func (source *CompositeRegistry) NewMeter(path ...string) Meter {
+	var meters = make([]Meter, 0)
+	for _, registry := range source.registries {
+		meters = append(meters, registry.NewMeter(path...))
+	}
+	return &compositeMeter{meters}
+}
+
+func (source *CompositeRegistry) NewTimer(path ...string) Timer {
+	var timers = make([]Timer, 0)
+	for _, registry := range source.registries {
+		timers = append(timers, registry.NewTimer(path...))
+	}
+	return &compositeTimer{timers}
+}
+
+func (source *CompositeRegistry) NewHistogram(path ...string) Histogram {
+	var histograms = make([]Histogram, 0)
+	for _, registry := range source.registries {
+		histograms = append(histograms, registry.NewHistogram(path...))
+	}
+	return &compositeHistogram{histograms}
+}
+
+func (source *CompositeRegistry) NewCounter(path ...string) Counter {
+	var counters = make([]Counter, 0)
+	for _, registry := range source.registries {
+		counters = append(counters, registry.NewCounter(path...))
+	}
+	return &compositeCounter{counters}
+}
+
+type compositeMeter struct {
+	meters []Meter
+}
+
+func (source *compositeMeter) Count() int64 {
+	if len(source.meters) == 0 {
+		return 0
+	}
+
+	return source.meters[0].Count()
+}
+
+func (source *compositeMeter) Mark(value int64) {
+	for _, meter := range source.meters {
+		meter.Mark(value)
+	}
+}
+
+type compositeTimer struct {
+	timers []Timer
+}
+
+func (source *compositeTimer) Count() int64 {
+	if len(source.timers) == 0 {
+		return 0
+	}
+
+	return source.timers[0].Count()
+}
+
+func (source *compositeTimer) UpdateSince(ts time.Time) {
+	for _, timer := range source.timers {
+		timer.UpdateSince(ts)
+	}
+}
+
+type compositeHistogram struct {
+	histograms []Histogram
+}
+
+func (source *compositeHistogram) Count() int64 {
+	if len(source.histograms) == 0 {
+		return 0
+	}
+
+	return source.histograms[0].Count()
+}
+
+func (source *compositeHistogram) Update(value int64) {
+	for _, histogram := range source.histograms {
+		histogram.Update(value)
+	}
+}
+
+type compositeCounter struct {
+	counters []Counter
+}
+
+func (source *compositeCounter) Count() int64 {
+	if len(source.counters) == 0 {
+		return 0
+	}
+
+	return source.counters[0].Count()
+}
+
+func (source *compositeCounter) Inc() {
+	for _, counter := range source.counters {
+		counter.Inc()
+	}
+}

--- a/metrics/dummy.go
+++ b/metrics/dummy.go
@@ -1,0 +1,7 @@
+package metrics
+
+import goMetrics "github.com/rcrowley/go-metrics"
+
+func NewDummyRegistry() Registry {
+	return &GraphiteRegistry{goMetrics.NewRegistry()}
+}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,0 +1,113 @@
+package metrics
+
+import (
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const namespace = "moira"
+
+func NewPrometheusRegistry() *prometheus.Registry {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(prometheus.NewGoCollector(), prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	return registry
+}
+
+type PrometheusRegistryAdapter struct {
+	registry *prometheus.Registry
+	service  string
+}
+
+func NewPrometheusRegistryAdapter(registry *prometheus.Registry, service string) *PrometheusRegistryAdapter {
+	return &PrometheusRegistryAdapter{registry, service}
+}
+
+func (source *PrometheusRegistryAdapter) NewTimer(path ...string) Timer {
+	var histogramOpts = prometheus.HistogramOpts{Namespace: namespace, Subsystem: source.service, Name: getPrometheusMetricName(path)}
+	var histogram = prometheus.NewHistogram(histogramOpts)
+	source.registry.MustRegister(histogram)
+	return &prometheusTimer{histogram: histogram}
+}
+
+func (source *PrometheusRegistryAdapter) NewMeter(path ...string) Meter {
+	var summaryOpts = prometheus.SummaryOpts{Namespace: namespace, Subsystem: source.service, Name: getPrometheusMetricName(path)}
+	var summary = prometheus.NewSummary(summaryOpts)
+	source.registry.MustRegister(summary)
+	return &prometheusMeter{summary: summary}
+}
+
+func (source *PrometheusRegistryAdapter) NewCounter(path ...string) Counter {
+	var counterOpts = prometheus.CounterOpts{Namespace: namespace, Subsystem: source.service, Name: getPrometheusMetricName(path)}
+	var counter = prometheus.NewCounter(counterOpts)
+	source.registry.MustRegister(counter)
+	return &prometheusCounter{counter: counter}
+}
+
+func (source *PrometheusRegistryAdapter) NewHistogram(path ...string) Histogram {
+	var histogramOpts = prometheus.HistogramOpts{Namespace: namespace, Subsystem: source.service, Name: getPrometheusMetricName(path)}
+	var histogram = prometheus.NewHistogram(histogramOpts)
+	source.registry.MustRegister(histogram)
+	return &prometheusHistogram{histogram: histogram}
+}
+
+type prometheusHistogram struct {
+	count     int64
+	histogram prometheus.Histogram
+}
+
+func (source *prometheusHistogram) Update(value int64) {
+	atomic.AddInt64(&source.count, 1)
+	source.histogram.Observe(float64(value))
+}
+
+func (source *prometheusHistogram) Count() int64 {
+	return atomic.LoadInt64(&source.count)
+}
+
+type prometheusMeter struct {
+	count   int64
+	summary prometheus.Summary
+}
+
+func (source *prometheusMeter) Mark(int64) {
+	atomic.AddInt64(&source.count, 1)
+}
+
+func (source *prometheusMeter) Count() int64 {
+	return atomic.LoadInt64(&source.count)
+}
+
+type prometheusTimer struct {
+	histogram prometheus.Histogram
+	count     int64
+}
+
+func (source *prometheusTimer) UpdateSince(ts time.Time) {
+	source.histogram.Observe(float64(int64(time.Since(ts))))
+	atomic.AddInt64(&source.count, 1)
+}
+
+func (source *prometheusTimer) Count() int64 {
+	return atomic.LoadInt64(&source.count)
+}
+
+type prometheusCounter struct {
+	counter prometheus.Counter
+	count   int64
+}
+
+func (source *prometheusCounter) Inc() {
+	source.counter.Inc()
+	atomic.AddInt64(&source.count, 1)
+}
+
+func (source *prometheusCounter) Count() int64 {
+	return atomic.LoadInt64(&source.count)
+}
+
+func getPrometheusMetricName(path []string) string {
+	return strings.Join(path, "_")
+}


### PR DESCRIPTION
Fixes #380

- [x] Implement prometheus registry
- [x] Allow to collect/send metrics from prometheus/to graphite seamlessly through metrics facade(`Registry`)
- [x] Add `/metrics`endpoint to api, checker, filter, notifier
- [x] Setup prometheus in docker-compose to allow to test metrics capturing locally