### PR TITLE
WIP: fix incorrect parsing of multiple equal signs in label

### DIFF
--- a/filter/metrics_parser.go
+++ b/filter/metrics_parser.go
@@ -95,7 +95,7 @@ func parseNameAndLabels(metricBytes []byte) (string, map[string]string, error) {
 			return "", nil, fmt.Errorf("too few equal-separated items: '%s'", labelBytes)
 		}
 		labelValueBytes = labelBytesScanner.Next()
-		if labelBytesScanner.HasNext() {
+		for labelBytesScanner.HasNext() {
 			var labelString strings.Builder
 			labelString.WriteString("=")
 			labelString.Write(labelBytesScanner.Next())

--- a/filter/metrics_parser.go
+++ b/filter/metrics_parser.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/moira-alert/moira"
@@ -95,7 +96,10 @@ func parseNameAndLabels(metricBytes []byte) (string, map[string]string, error) {
 		}
 		labelValueBytes = labelBytesScanner.Next()
 		if labelBytesScanner.HasNext() {
-			return "", nil, fmt.Errorf("too many equal-separated items: '%s'", labelBytes)
+			var labelString strings.Builder
+			labelString.WriteString("=")
+			labelString.Write(labelBytesScanner.Next())
+			labelValueBytes = append(labelValueBytes, labelString.String()...)
 		}
 		if len(labelNameBytes) == 0 {
 			return "", nil, fmt.Errorf("empty label name: '%s'", labelBytes)

--- a/filter/metrics_parser_test.go
+++ b/filter/metrics_parser_test.go
@@ -64,6 +64,10 @@ func TestParseMetric(t *testing.T) {
 			{"One.two.three;four= 123 1234567890", "One.two.three;four=", "One.two.three", map[string]string{"four": ""}, 123, 1234567890},
 			{"One.two.three;four=five;six=seven 123 1234567890", "One.two.three;four=five;six=seven", "One.two.three", map[string]string{"four": "five", "six": "seven"}, 123, 1234567890},
 			{"One.two.three;four=five;six=seven=eight 123 1234567890", "One.two.three;four=five;six=seven=eight", "One.two.three", map[string]string{"four": "five", "six": "seven=eight"}, 123, 1234567890},
+			{"One.two.three;four=five;six=seven=eight=nine 123 1234567890", "One.two.three;four=five;six=seven=eight=nine",
+				"One.two.three", map[string]string{"four": "five", "six": "seven=eight=nine"}, 123, 1234567890},
+			{"One.two.three;four=five;six=seven=eight=nine= 123 1234567890", "One.two.three;four=five;six=seven=eight=nine=",
+				"One.two.three", map[string]string{"four": "five", "six": "seven=eight=nine="}, 123, 1234567890},
 		}
 
 		for _, validMetric := range validMetrics {

--- a/filter/metrics_parser_test.go
+++ b/filter/metrics_parser_test.go
@@ -43,7 +43,6 @@ func TestParseMetric(t *testing.T) {
 			"No.labels.but.delimiter.in.the.end; 1 2",
 			"Empty.label.name;= 1 2",
 			"Only.label.name;name 1 2",
-			"Too.Many.=.In.Label;name=value= 1 2",
 		}
 
 		for _, invalidMetric := range invalidMetrics {
@@ -64,6 +63,7 @@ func TestParseMetric(t *testing.T) {
 			{"One.two.three;four=five 123 1234567890", "One.two.three;four=five", "One.two.three", map[string]string{"four": "five"}, 123, 1234567890},
 			{"One.two.three;four= 123 1234567890", "One.two.three;four=", "One.two.three", map[string]string{"four": ""}, 123, 1234567890},
 			{"One.two.three;four=five;six=seven 123 1234567890", "One.two.three;four=five;six=seven", "One.two.three", map[string]string{"four": "five", "six": "seven"}, 123, 1234567890},
+			{"One.two.three;four=five;six=seven=eight 123 1234567890", "One.two.three;four=five;six=seven=eight", "One.two.three", map[string]string{"four": "five", "six": "seven=eight"}, 123, 1234567890},
 		}
 
 		for _, validMetric := range validMetrics {


### PR DESCRIPTION
This fixes #489 (incorrect parsing of multiple equal signs in label).