### PR TITLE
Shift plot window when not realtime (#188)

### DIFF
--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -69,8 +69,8 @@ func (notifier *StandardNotifier) buildNotificationPackagePlot(pkg NotificationP
 func resolveMetricsWindow(logger moira.Logger, trigger moira.TriggerData, pkg NotificationPackage) (int64, int64) {
 	// resolve default realtime window for any case
 	now := time.Now()
-	defaultFrom := now.UTC().Add(-defaultTimeRange).Unix()
-	defaultTo := now.UTC().Unix()
+	defaultFrom := now.UTC().Add(-defaultTimeRange - defaultTimeShift).Unix()
+	defaultTo := now.UTC().Add(-defaultTimeShift).Unix()
 	// try to resolve package window, force default realtime window on fail for both local and remote triggers
 	from, to, err := pkg.GetWindow()
 	if err != nil {

--- a/notifier/plotting_test.go
+++ b/notifier/plotting_test.go
@@ -60,8 +60,8 @@ func TestResolveMetricsWindow(t *testing.T) {
 			_, _, err := pkg.GetWindow()
 			So(err, ShouldBeNil)
 			from, to := resolveMetricsWindow(logger, trigger, pkg)
-			So(from, ShouldEqual, alignToMinutes(testLaunchTime.Add(-defaultTimeRange).UTC().Unix()))
-			So(to, ShouldEqual, testLaunchTime.UTC().Unix())
+			So(from, ShouldEqual, alignToMinutes(testLaunchTime.Add(-defaultTimeRange-defaultTimeShift).UTC().Unix()))
+			So(to, ShouldEqual, testLaunchTime.Add(-defaultTimeShift).UTC().Unix())
 		})
 	})
 	Convey("REMOTE TRIGGER | Resolve remote trigger metrics window", t, func() {
@@ -90,8 +90,8 @@ func TestResolveMetricsWindow(t *testing.T) {
 		for _, trigger := range allTriggers {
 			pkg := emptyEventsPackage
 			from, to := resolveMetricsWindow(logger, trigger, pkg)
-			expectedFrom := testLaunchTime.Add(-defaultTimeRange).Unix()
-			expectedTo := testLaunchTime.Unix()
+			expectedFrom := testLaunchTime.Add(-defaultTimeRange - defaultTimeShift).Unix()
+			expectedTo := testLaunchTime.Add(-defaultTimeShift).Unix()
 			_, _, err := pkg.GetWindow()
 			So(err, ShouldResemble, fmt.Errorf("not enough data to resolve package window"))
 			So(from, ShouldEqual, alignToMinutes(expectedFrom))


### PR DESCRIPTION
Shift plot window one minute to the left when forcing realtime window to avoid empty space at right boundary. 
Fixes #188