### PR TITLE
Add description to message in telegram sender (moira-alert#353)

### DIFF
--- a/senders/message_utils.go
+++ b/senders/message_utils.go
@@ -1,0 +1,70 @@
+package senders
+
+import (
+	"fmt"
+	"github.com/moira-alert/moira"
+	"time"
+)
+
+func BuildTitle(events moira.NotificationEvents, trigger moira.TriggerData, frontURI string) string {
+	title := fmt.Sprintf("*%s*", events.GetSubjectState())
+	triggerURI := trigger.GetTriggerURI(frontURI)
+	if triggerURI != "" {
+		title += fmt.Sprintf(" <%s|%s>", triggerURI, trigger.Name)
+	} else if trigger.Name != "" {
+		title += " " + trigger.Name
+	}
+
+	tags := trigger.GetTags()
+	if tags != "" {
+		title += " " + tags
+	}
+
+	title += "\n"
+	return title
+}
+
+// buildEventsString builds the string from moira events and limits it to charsForEvents.
+// if n is negative buildEventsString does not limit the events string
+func BuildEventsString(events moira.NotificationEvents, charsForEvents int, throttled bool, location *time.Location) string {
+	charsForThrottleMsg := 0
+	throttleMsg := "\nPlease, *fix your system or tune this trigger* to generate less events."
+	if throttled {
+		charsForThrottleMsg = len([]rune(throttleMsg))
+	}
+	charsLeftForEvents := charsForEvents - charsForThrottleMsg
+
+	var eventsString string
+	eventsString += "```"
+	var tailString string
+
+	eventsLenLimitReached := false
+	eventsPrinted := 0
+	for _, event := range events {
+		line := fmt.Sprintf("\n%s: %s = %s (%s to %s)", event.FormatTimestamp(location), event.Metric, event.GetMetricValue(), event.OldState, event.State)
+		if msg := event.CreateMessage(location); len(msg) > 0 {
+			line += fmt.Sprintf(". %s", msg)
+		}
+
+		tailString = fmt.Sprintf("\n...and %d more events.", len(events)-eventsPrinted)
+		tailStringLen := len([]rune("```")) + len([]rune(tailString))
+		if !(charsForEvents < 0) && (len([]rune(eventsString))+len([]rune(line)) > charsLeftForEvents-tailStringLen) {
+			eventsLenLimitReached = true
+			break
+		}
+
+		eventsString += line
+		eventsPrinted++
+	}
+	eventsString += "```"
+
+	if eventsLenLimitReached {
+		eventsString += tailString
+	}
+
+	if throttled {
+		eventsString += throttleMsg
+	}
+
+	return eventsString
+}

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -18,13 +18,6 @@ const (
 
 var (
 	pollerTimeout = 10 * time.Second
-	emojiStates   = map[moira.State]string{
-		moira.StateOK:     "\xe2\x9c\x85",
-		moira.StateWARN:   "\xe2\x9a\xa0",
-		moira.StateERROR:  "\xe2\xad\x95",
-		moira.StateNODATA: "\xf0\x9f\x92\xa3",
-		moira.StateTEST:   "\xf0\x9f\x98\x8a",
-	}
 )
 
 // Sender implements moira sender interface via telegram

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -3,7 +3,6 @@ package telegram
 import (
 	"bytes"
 	"fmt"
-
 	"gopkg.in/tucnak/telebot.v2"
 
 	"github.com/moira-alert/moira"
@@ -22,6 +21,7 @@ const (
 	photoCaptionMaxCharacters     = 1024
 	messageMaxCharacters          = 4096
 	additionalInfoCharactersCount = 400
+	maxDescriptionSize            = 450
 )
 
 var characterLimits = map[messageType]int{
@@ -46,11 +46,18 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 
 func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moira.TriggerData, throttled bool, maxChars int) string {
 	var buffer bytes.Buffer
+	var descr string
 	state := events.GetSubjectState()
 	tags := trigger.GetTags()
 	emoji := emojiStates[state]
 
-	title := fmt.Sprintf("%s%s %s %s (%d)\n", emoji, state, trigger.Name, tags, len(events))
+	if len(trigger.Desc) > maxDescriptionSize {
+		descr = trigger.Desc[:maxDescriptionSize]
+	} else {
+		descr = trigger.Desc
+	}
+
+	title := fmt.Sprintf("%s%s %s %s (%d)\n%s\n", emoji, state, trigger.Name, tags, len(events), descr)
 	buffer.WriteString(title)
 
 	var messageCharsCount, printEventsCount int

--- a/senders/telegram/send_test.go
+++ b/senders/telegram/send_test.go
@@ -34,6 +34,7 @@ func TestBuildMessage(t *testing.T) {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, false, messageMaxCharacters)
 			expected := `💣NODATA Trigger Name [tag1][tag2] (1)
 
+
 02:40: Metric name = 97.4458331200185 (OK to NODATA)
 
 http://moira.url/trigger/TriggerID
@@ -45,6 +46,7 @@ http://moira.url/trigger/TriggerID
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, moira.TriggerData{Name: "Name"}, false, messageMaxCharacters)
 			expected := `💣NODATA Name  (1)
 
+
 02:40: Metric name = 97.4458331200185 (OK to NODATA)`
 			So(actual, ShouldResemble, expected)
 		})
@@ -52,6 +54,7 @@ http://moira.url/trigger/TriggerID
 		Convey("Print moira message with empty trigger", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, moira.TriggerData{}, false, messageMaxCharacters)
 			expected := `💣NODATA   (1)
+
 
 02:40: Metric name = 97.4458331200185 (OK to NODATA)`
 			So(actual, ShouldResemble, expected)
@@ -65,6 +68,7 @@ http://moira.url/trigger/TriggerID
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, false, messageMaxCharacters)
 			expected := `💣NODATA Trigger Name [tag1][tag2] (1)
 
+
 02:40: Metric name = 97.4458331200185 (OK to NODATA). This metric has been in bad state for more than 24 hours - please, fix.`
 			So(actual, ShouldResemble, expected)
 		})
@@ -72,6 +76,7 @@ http://moira.url/trigger/TriggerID
 		Convey("Print moira message with one event and throttled", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, true, messageMaxCharacters)
 			expected := `💣NODATA Trigger Name [tag1][tag2] (1)
+
 
 02:40: Metric name = 97.4458331200185 (OK to NODATA)
 
@@ -88,6 +93,7 @@ Please, fix your system or tune this trigger to generate less events.`
 			}
 			actual := sender.buildMessage(events, trigger, false, photoCaptionMaxCharacters)
 			expected := `💣NODATA Trigger Name [tag1][tag2] (18)
+
 
 02:40: Metric name = 97.4458331200185 (OK to NODATA)
 02:40: Metric name = 97.4458331200185 (OK to NODATA)

--- a/senders/telegram/send_test.go
+++ b/senders/telegram/send_test.go
@@ -26,91 +26,53 @@ func TestBuildMessage(t *testing.T) {
 
 		trigger := moira.TriggerData{
 			Tags: []string{"tag1", "tag2"},
-			Name: "Trigger Name",
+			Name: "Name",
 			ID:   "TriggerID",
 		}
 
 		Convey("Print moira message with one event", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, false, messageMaxCharacters)
-			expected := `💣NODATA Trigger Name [tag1][tag2] (1)
-
-
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-
-http://moira.url/trigger/TriggerID
-`
+			expected := "*NODATA* <http://moira.url/trigger/TriggerID|Name> [tag1][tag2]\n"+
+			"```\n02:40: Metric name = 97.4458331200185 (OK to NODATA)```"
 			So(actual, ShouldResemble, expected)
 		})
 
 		Convey("Print moira message with empty triggerID, but with trigger Name", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, moira.TriggerData{Name: "Name"}, false, messageMaxCharacters)
-			expected := `💣NODATA Name  (1)
-
-
-02:40: Metric name = 97.4458331200185 (OK to NODATA)`
+			expected := "*NODATA* Name\n```\n02:40: Metric name = 97.4458331200185 (OK to NODATA)```"
 			So(actual, ShouldResemble, expected)
 		})
 
 		Convey("Print moira message with empty trigger", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, moira.TriggerData{}, false, messageMaxCharacters)
-			expected := `💣NODATA   (1)
-
-
-02:40: Metric name = 97.4458331200185 (OK to NODATA)`
+			expected := "*NODATA*\n```\n02:40: Metric name = 97.4458331200185 (OK to NODATA)```"
 			So(actual, ShouldResemble, expected)
 		})
 
 		Convey("Print moira message with one event and message", func() {
-			event.TriggerID = ""
-			trigger.ID = ""
 			var interval int64 = 24
 			event.MessageEventInfo = &moira.EventInfo{Interval: &interval}
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, false, messageMaxCharacters)
-			expected := `💣NODATA Trigger Name [tag1][tag2] (1)
-
-
-02:40: Metric name = 97.4458331200185 (OK to NODATA). This metric has been in bad state for more than 24 hours - please, fix.`
+			expected := "*NODATA* <http://moira.url/trigger/TriggerID|Name> [tag1][tag2]\n" +
+				"```\n02:40: Metric name = 97.4458331200185 (OK to NODATA). This metric has been in bad state for more than 24 hours - please, fix.```"
 			So(actual, ShouldResemble, expected)
 		})
 
 		Convey("Print moira message with one event and throttled", func() {
 			actual := sender.buildMessage([]moira.NotificationEvent{event}, trigger, true, messageMaxCharacters)
-			expected := `💣NODATA Trigger Name [tag1][tag2] (1)
-
-
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-
-http://moira.url/trigger/TriggerID
-
-Please, fix your system or tune this trigger to generate less events.`
+			expected := "*NODATA* <http://moira.url/trigger/TriggerID|Name> [tag1][tag2]\n" +
+				"```\n02:40: Metric name = 97.4458331200185 (OK to NODATA)```\nPlease, *fix your system or tune this trigger* to generate less events."
 			So(actual, ShouldResemble, expected)
 		})
 
 		events := make([]moira.NotificationEvent, 0)
 		Convey("Print moira message with 6 events and photo message length", func() {
-			for i := 0; i < 18; i++ {
+			for i := 0; i < 6; i++ {
 				events = append(events, event)
 			}
 			actual := sender.buildMessage(events, trigger, false, photoCaptionMaxCharacters)
-			expected := `💣NODATA Trigger Name [tag1][tag2] (18)
-
-
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-02:40: Metric name = 97.4458331200185 (OK to NODATA)
-
-...and 7 more events.
-
-http://moira.url/trigger/TriggerID
-`
+			expected := "*NODATA* <http://moira.url/trigger/TriggerID|Name> [tag1][tag2]\n" +
+				"```\n02:40: Metric name = 97.4458331200185 (OK to NODATA)\n02:40: Metric name = 97.4458331200185 (OK to NODATA)\n02:40: Metric name = 97.4458331200185 (OK to NODATA)\n02:40: Metric name = 97.4458331200185 (OK to NODATA)\n02:40: Metric name = 97.4458331200185 (OK to NODATA)\n02:40: Metric name = 97.4458331200185 (OK to NODATA)```"
 			fmt.Println(fmt.Sprintf("Bytes: %v", len(expected)))
 			fmt.Println(fmt.Sprintf("Symbols: %v", len([]rune(expected))))
 			So(actual, ShouldResemble, expected)


### PR DESCRIPTION
# PR Summary
Add description without markdown to telegram sender.
Additional information
I think it's good feature without markdown which can help to understand alerts in team.
Closes/Relates #issue
#353 