### PR TITLE
fix(notifier): Move plot boundaries

### DIFF
--- a/filter/cache_storage.go
+++ b/filter/cache_storage.go
@@ -50,7 +50,7 @@ func NewCacheStorage(logger moira.Logger, metrics *metrics.FilterMetrics, reader
 // EnrichMatchedMetric calculate retention and filter cached values
 func (storage *Storage) EnrichMatchedMetric(batch map[string]*moira.MatchedMetric, m *moira.MatchedMetric) {
 	m.Retention = storage.getRetention(m)
-	m.RetentionTimestamp = roundToNearestRetention(m.Timestamp, int64(m.Retention))
+	m.RetentionTimestamp = moira.RoundToNearestRetention(m.Timestamp, int64(m.Retention))
 	if ex, ok := storage.metricsCache[m.Metric]; ok && ex.RetentionTimestamp == m.RetentionTimestamp && ex.Value == m.Value {
 		return
 	}
@@ -139,8 +139,4 @@ func rawRetentionToSeconds(rawRetention string) (int, error) {
 	}
 
 	return retention * multiplier, nil
-}
-
-func roundToNearestRetention(ts, retention int64) int64 {
-	return (ts + retention/2) / retention * retention
 }

--- a/helpers.go
+++ b/helpers.go
@@ -191,3 +191,7 @@ func ChunkSlice(original []string, chunkSize int) (divided [][]string) {
 	}
 	return
 }
+
+func RoundToNearestRetention(ts, retention int64) int64 {
+	return (ts + retention/2) / retention * retention
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -209,3 +209,34 @@ func TestIsValidFloat64(t *testing.T) {
 		So(IsValidFloat64(3.14), ShouldBeTrue)
 	})
 }
+
+func TestRoundToNearestRetention(t *testing.T) {
+	var baseTimestamp, retentionSeconds int64
+	baseTimestamp = 1582286400 // 17:00:00
+
+	Convey("Test even retention: 60s", t, func() {
+		retentionSeconds = 60
+		testRounding(baseTimestamp, retentionSeconds)
+	})
+
+	Convey("Test odd retention: 15s", t, func() {
+		retentionSeconds = 15
+		testRounding(baseTimestamp, retentionSeconds)
+	})
+}
+
+func testRounding(baseTimestamp, retention int64) {
+	halfRetention := retention / 2
+	nextTimestamp := baseTimestamp + retention
+
+	Convey("round to self", func() {
+		So(RoundToNearestRetention(baseTimestamp, retention), ShouldEqual, baseTimestamp)
+	})
+
+	So(RoundToNearestRetention(baseTimestamp+1, retention), ShouldEqual, baseTimestamp)
+	So(RoundToNearestRetention(baseTimestamp+(halfRetention-1), retention), ShouldEqual, baseTimestamp)
+	So(RoundToNearestRetention(baseTimestamp+halfRetention+retention%2, retention), ShouldEqual, nextTimestamp)
+
+	So(RoundToNearestRetention(baseTimestamp-1, retention), ShouldEqual, baseTimestamp)
+	So(RoundToNearestRetention(baseTimestamp-halfRetention, retention), ShouldEqual, baseTimestamp)
+}

--- a/notifier/plotting_test.go
+++ b/notifier/plotting_test.go
@@ -49,9 +49,10 @@ func TestResolveMetricsWindow(t *testing.T) {
 			pkgs = []NotificationPackage{triggerJustCreatedEvents, realtimeTriggerEvents}
 			for _, pkg := range pkgs {
 				_, expectedTo, err := pkg.GetWindow()
+				expectedTo = roundToRetention(expectedTo)
 				So(err, ShouldBeNil)
 				from, to := resolveMetricsWindow(logger, trigger, pkg)
-				So(from, ShouldEqual, alignToMinutes(expectedTo)-timeRange+timeShift)
+				So(from, ShouldEqual, expectedTo-timeRange+timeShift)
 				So(to, ShouldEqual, expectedTo+timeShift)
 			}
 		})
@@ -60,8 +61,8 @@ func TestResolveMetricsWindow(t *testing.T) {
 			_, _, err := pkg.GetWindow()
 			So(err, ShouldBeNil)
 			from, to := resolveMetricsWindow(logger, trigger, pkg)
-			So(from, ShouldEqual, alignToMinutes(testLaunchTime.Add(-defaultTimeRange).UTC().Unix()))
-			So(to, ShouldEqual, testLaunchTime.UTC().Unix())
+			So(from, ShouldEqual, roundToRetention(testLaunchTime.Add(-defaultTimeRange).UTC().Unix()))
+			So(to, ShouldEqual, roundToRetention(testLaunchTime.UTC().Unix()))
 		})
 	})
 	Convey("REMOTE TRIGGER | Resolve remote trigger metrics window", t, func() {
@@ -69,18 +70,21 @@ func TestResolveMetricsWindow(t *testing.T) {
 		Convey("Window is wide: use package window to fetch limited historical data from graphite", func() {
 			pkg = oldTriggerEvents
 			expectedFrom, expectedTo, err := pkg.GetWindow()
+			expectedFrom = roundToRetention(expectedFrom)
+			expectedTo = roundToRetention(expectedTo)
 			So(err, ShouldBeNil)
 			from, to := resolveMetricsWindow(logger, trigger, pkg)
-			So(from, ShouldEqual, alignToMinutes(expectedFrom))
+			So(from, ShouldEqual, expectedFrom)
 			So(to, ShouldEqual, expectedTo)
 		})
 		Convey("Window is not wide: use shifted window to fetch extended historical data from graphite", func() {
 			pkgs = []NotificationPackage{triggerJustCreatedEvents, realtimeTriggerEvents}
 			for _, pkg := range pkgs {
 				_, expectedTo, err := pkg.GetWindow()
+				expectedTo = roundToRetention(expectedTo)
 				So(err, ShouldBeNil)
 				from, to := resolveMetricsWindow(logger, trigger, pkg)
-				So(from, ShouldEqual, alignToMinutes(expectedTo-timeRange+timeShift))
+				So(from, ShouldEqual, expectedTo-timeRange+timeShift)
 				So(to, ShouldEqual, expectedTo+timeShift)
 			}
 		})
@@ -90,11 +94,11 @@ func TestResolveMetricsWindow(t *testing.T) {
 		for _, trigger := range allTriggers {
 			pkg := emptyEventsPackage
 			from, to := resolveMetricsWindow(logger, trigger, pkg)
-			expectedFrom := testLaunchTime.Add(-defaultTimeRange).Unix()
-			expectedTo := testLaunchTime.Unix()
+			expectedFrom := roundToRetention(testLaunchTime.Add(-defaultTimeRange).Unix())
+			expectedTo := roundToRetention(testLaunchTime.Unix())
 			_, _, err := pkg.GetWindow()
 			So(err, ShouldResemble, fmt.Errorf("not enough data to resolve package window"))
-			So(from, ShouldEqual, alignToMinutes(expectedFrom))
+			So(from, ShouldEqual, expectedFrom)
 			So(to, ShouldEqual, expectedTo)
 		}
 	})


### PR DESCRIPTION
Fixed the missing point on the right side of plots.

# PR Summary
Fix the missing right dot in non-realtime triggers due to rounding in redis.
## Example:
Say we have two metric values for some non-realtime trigger.
|value|          ts          |        score       |    tsTime        |  scoreTime    |
|------|----------------|----------------|---------------|----------------|
|11    |   1582287284  | 1582287300  | 12:14:44 PM  |   12:15:00 PM|
|15    |   1582287344  | 1582287360  | 12:15:44 PM  |   12:16:00 PM|

Metric value 11 is the event that we want on a plot. 15 is a value that should get trimmed cause the trigger is not realtime. When notifier tries to fetch data, it specifies the right boundary as event's time plus one minute, so 12:15:45 PM (1582287345). Since fetch ranges values by score, we only get value 11, that later gets trimmed by graphite's expression evaluator. To fix that we need to first round the time to retention, and then increment it by one minute.

## Changes:
- Round boundaries to retention at `notifier/plotting.go` to ensure we get all the needed metric points from redis. This is required because metric's score in redis is a timestamp rounded to retention.

Closes #188
