### PR TITLE
pefr(filter): Reduce nodes slice capacity

### DIFF
--- a/filter/pattern_index.go
+++ b/filter/pattern_index.go
@@ -120,7 +120,7 @@ func (source *PatternIndex) MatchPatterns(metric string) []string {
 }
 
 func findPart(part string, currentLevel []*PatternNode) ([]*PatternNode, int) {
-	nextLevel := make([]*PatternNode, 0, 64)
+	nextLevel := make([]*PatternNode, 0, 5)
 
 	hash := xxhash.Sum64String(part)
 	for _, node := range currentLevel {


### PR DESCRIPTION
# Reduce capacity of a slice created  in filter/pattern_index.go for storing matched patterns.
Tests show that with patterns from prod environment, 97% of calls to findPart produce at most 5 matches, so there is no need for creating a slice that big.

Changing capacity from 65 to 5 yields about 10% increase in performance of metric processor (7155 ns/op _vs_ 6279 ns/op)