### PR TITLE
fix: disallow empty plots

### DIFF
--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -62,7 +62,7 @@ func (notifier *StandardNotifier) buildNotificationPackagePlot(pkg NotificationP
 	}
 	if err = renderable.Render(chart.PNG, buff); err != nil {
 		buff.Reset()
-		return buff.Bytes(), err
+		return []byte{}, err
 	}
 	return buff.Bytes(), nil
 }

--- a/notifier/plotting.go
+++ b/notifier/plotting.go
@@ -61,7 +61,6 @@ func (notifier *StandardNotifier) buildNotificationPackagePlot(pkg NotificationP
 		return buff.Bytes(), err
 	}
 	if err = renderable.Render(chart.PNG, buff); err != nil {
-		buff.Reset()
 		return []byte{}, err
 	}
 	return buff.Bytes(), nil

--- a/plotting/limits.go
+++ b/plotting/limits.go
@@ -38,12 +38,8 @@ func resolveLimits(metricsData []*metricSource.MetricData) plotLimits {
 				allValues = append(allValues, metricValue)
 			}
 		}
-		if !math.IsInf(float64(metricData.StartTime), 0) {
-			allTimes = append(allTimes, moira.Int64ToTime(metricData.StartTime))
-		}
-		if !math.IsInf(float64(metricData.StopTime), 0) {
-			allTimes = append(allTimes, moira.Int64ToTime(metricData.StopTime))
-		}
+		allTimes = append(allTimes, moira.Int64ToTime(metricData.StartTime))
+		allTimes = append(allTimes, moira.Int64ToTime(metricData.StopTime))
 	}
 	from, to := util.Time.StartAndEnd(allTimes...)
 	if from == to {

--- a/plotting/limits.go
+++ b/plotting/limits.go
@@ -18,6 +18,9 @@ const (
 	// generate plotLimits lowest/highest additional increment
 	// used in plot-prettifying purposes only
 	defaultYAxisRangePercent = 10
+	// defaultFromToDelta is an additional value to
+	// cover cases with equal from/to limit values
+	defaultFromToDelta = 2
 )
 
 // plotLimits is a set of limits for given metricsData
@@ -43,8 +46,8 @@ func resolveLimits(metricsData []*metricSource.MetricData) plotLimits {
 	}
 	from, to := util.Time.StartAndEnd(allTimes...)
 	if from == to {
-		from = from.Add(-1 * defaultRangeDelta * 1e9 / 2)
-		to = to.Add(defaultRangeDelta * 1e9 / 2)
+		from = from.Add(-1 * defaultFromToDelta / 2 * time.Second)
+		to = to.Add(defaultFromToDelta / 2 * time.Second)
 	}
 	lowest, highest := util.Math.MinAndMax(allValues...)
 	if highest == lowest {

--- a/plotting/limits.go
+++ b/plotting/limits.go
@@ -34,14 +34,22 @@ func resolveLimits(metricsData []*metricSource.MetricData) plotLimits {
 	allTimes := make([]time.Time, 0)
 	for _, metricData := range metricsData {
 		for _, metricValue := range metricData.Values {
-			if !math.IsNaN(metricValue) {
+			if !math.IsNaN(metricValue) && !math.IsInf(metricValue, 0) {
 				allValues = append(allValues, metricValue)
 			}
 		}
-		allTimes = append(allTimes, moira.Int64ToTime(metricData.StartTime))
-		allTimes = append(allTimes, moira.Int64ToTime(metricData.StopTime))
+		if !math.IsInf(float64(metricData.StartTime), 0) {
+			allTimes = append(allTimes, moira.Int64ToTime(metricData.StartTime))
+		}
+		if !math.IsInf(float64(metricData.StopTime), 0) {
+			allTimes = append(allTimes, moira.Int64ToTime(metricData.StopTime))
+		}
 	}
 	from, to := util.Time.StartAndEnd(allTimes...)
+	if from == to {
+		from = from.Add(-1 * defaultRangeDelta * 1e9 / 2)
+		to = to.Add(defaultRangeDelta * 1e9 / 2)
+	}
 	lowest, highest := util.Math.MinAndMax(allValues...)
 	if highest == lowest {
 		highest = highest + (defaultRangeDelta / 2)


### PR DESCRIPTION
# PR Summary
This PR disallows empty plots

- Used `[]byte{}` instead of `buff.bytes()` for NotificationPackage when Render() fails.
- [limits] Added validation of ranges by using `math.IsInf`.
- [limits/resolveLimits] Handled the case of equal `from` and `to` by adding delta to the time
- Unit test to verify that unequal `from` and `to` values are returned by `resolveLimits`

Closes/Relates #254 
