### PR TITLE
add limit to FetchNotifications function for read notifications from db

### DIFF
--- a/database/redis/notification.go
+++ b/database/redis/notification.go
@@ -2,15 +2,51 @@ package redis
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/moira-alert/moira/notifier"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gomodule/redigo/redis"
 
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/database/redis/reply"
 )
+
+const (
+	transactionTriesLimit = 10
+  transactionHeuristicLimit = 10000
+)
+
+// Custom error for transaction error
+type transactionError struct {}
+
+func (e transactionError) Error() string {
+	return "Transaction Error"
+}
+
+// Drops all notifications with last timestamp
+func limitNotifications(notifications []*moira.ScheduledNotification) ([]*moira.ScheduledNotification) {
+	if len(notifications) == 0 {
+		return notifications
+	}
+	i := len(notifications) - 1
+	lastTs := notifications[i].Timestamp
+
+	for ;i >= 0; i-- {
+		if notifications[i].Timestamp != lastTs {
+			break
+		}
+	}
+
+	if i == -1 {
+		return notifications
+	}
+
+	return notifications[:i+1]
+}
 
 // GetNotifications gets ScheduledNotifications in given range and full range
 func (connector *DbConnector) GetNotifications(start, end int64) ([]*moira.ScheduledNotification, int64, error) {
@@ -98,7 +134,122 @@ func (connector *DbConnector) removeNotifications(notifications []*moira.Schedul
 }
 
 // FetchNotifications fetch notifications by given timestamp and delete it
-func (connector *DbConnector) FetchNotifications(to int64) ([]*moira.ScheduledNotification, error) {
+func (connector *DbConnector) FetchNotifications(to int64, limit int64) ([]*moira.ScheduledNotification, error) {
+
+	if limit == 0 {
+		return nil, fmt.Errorf("limit mustn't be 0")
+	}
+
+	// No limit
+	if limit == notifier.NotificationsLimitUnlimited {
+		return connector.fetchNotificationsNoLimit(to)
+	}
+
+	count, err := connector.notificationsCount(to)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hope count will be not greater then limit when we call fetchNotificationsNoLimit
+	if limit > transactionHeuristicLimit && count < limit/2 {
+		return connector.fetchNotificationsNoLimit(to)
+	}
+
+	return connector.fetchNotificationsWithLimit(to, limit)
+}
+
+func (connector *DbConnector) notificationsCount(to int64) (int64, error) {
+	c := connector.pool.Get()
+	defer c.Close()
+
+	count, err := redis.Int64(c.Do("ZCOUNT", notifierNotificationsKey, "-inf", to))
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to ZCOUNT to notificationsCount: %w", err)
+	}
+
+	return count, nil
+}
+
+// fetchNotificationsWithLimit reads and drops notifications from DB with limit
+func (connector *DbConnector) fetchNotificationsWithLimit(to int64, limit int64) ([]*moira.ScheduledNotification, error) {
+	// fetchNotifecationsWithLimitDo uses WATCH, so transaction may fail and will retry it
+	// see https://redis.io/topics/transactions
+
+	for i := 0; i < transactionTriesLimit; i++ {
+		res, err := connector.fetchNotificationsWithLimitDo(to, limit)
+
+		if err == nil {
+			return res, nil
+		}
+
+		if !errors.As(err, &transactionError{}) {
+			return nil, err
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return nil, fmt.Errorf("Transaction tries limit exceeded")
+}
+
+// same as fetchNotificationsWithLimit, but only once
+func (connector *DbConnector) fetchNotificationsWithLimitDo(to int64, limit int64) ([]*moira.ScheduledNotification, error) {
+	// see https://redis.io/topics/transactions
+
+	c := connector.pool.Get()
+	defer c.Close()
+
+	// start optimistic transaction and get notifications with LIMIT
+	c.Send("WATCH", notifierNotificationsKey)
+	response, err := redis.Values(c.Do("ZRANGEBYSCORE", notifierNotificationsKey, "-inf", to, "LIMIT", 0, limit))
+	if err != nil {
+		return nil, fmt.Errorf("failed to ZRANGEBYSCORE: %s", err)
+	}
+
+	if len(response) == 0 {
+		return make([]*moira.ScheduledNotification, 0), nil
+	}
+
+	notifications, err := reply.Notifications(response, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to EXEC: %s", err)
+	}
+
+	// ZRANGEBYSCORE with LIMIT may return not all notification with last timestamp
+	// (e.g. if we have notifications with timestamps [1, 2, 3, 3, 3] and limit == 3)
+	// but ZREMRANGEBYSCORE does not have LIMIT, so will delete all notifications with last timestamp
+	// (ts 3 in our example) and then run ZRANGEBYSCORE with our new last timestamp (2 in our example).
+
+	notificationsLimited := limitNotifications(notifications)
+	lastTs := notificationsLimited[len(notificationsLimited) - 1].Timestamp
+
+	if (len(notifications) == len(notificationsLimited)) {
+		// this means that all notifications have same timestamp,
+		// we hope that all notifications with same timestamp should fit our memory
+		c.Send("UNWATCH")
+		return connector.fetchNotificationsNoLimit(lastTs)
+	}
+
+	c.Send("MULTI")
+	c.Send("ZREMRANGEBYSCORE", notifierNotificationsKey, "-inf", lastTs)
+	deleteCount, errDelete := redis.Values(c.Do("EXEC"))
+	if errDelete != nil {
+		return nil, fmt.Errorf("failed to EXEC: %w", errDelete)
+	}
+
+	// someone has changed notifierNotificationsKey while we do our job
+	// and transaction fail (no notifications were deleted) :(
+	if deleteCount == nil {
+		tr := transactionError{}
+		return nil, &tr
+	}
+
+	return notificationsLimited, nil
+}
+
+// FetchNotifications fetch notifications by given timestamp and delete it
+func (connector *DbConnector) fetchNotificationsNoLimit(to int64) ([]*moira.ScheduledNotification, error) {
 	c := connector.pool.Get()
 	defer c.Close()
 

--- a/database/redis/notification_test.go
+++ b/database/redis/notification_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"fmt"
+	"github.com/moira-alert/moira/notifier"
 	"strings"
 	"testing"
 	"time"
@@ -52,7 +53,7 @@ func TestScheduledNotification(t *testing.T) {
 		})
 
 		Convey("Test fetch notifications", func() {
-			actual, err := dataBase.FetchNotifications(now - 3600)
+			actual, err := dataBase.FetchNotifications(now - 3600, notifier.NotificationsLimitUnlimited)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld})
 
@@ -61,7 +62,7 @@ func TestScheduledNotification(t *testing.T) {
 			So(total, ShouldEqual, 2)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notification, &notificationNew})
 
-			actual, err = dataBase.FetchNotifications(now + 3600)
+			actual, err = dataBase.FetchNotifications(now + 3600, notifier.NotificationsLimitUnlimited)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notification, &notificationNew})
 
@@ -71,8 +72,13 @@ func TestScheduledNotification(t *testing.T) {
 			So(actual, ShouldResemble, make([]*moira.ScheduledNotification, 0))
 		})
 
+		Convey("Test fetch notifications limit 0", func() {
+			actual, err := dataBase.FetchNotifications(now - 3600, 0)
+			So(err, ShouldBeError)
+			So(actual, ShouldBeNil )
+		})
+
 		Convey("Test remove notifications by key", func() {
-			now := time.Now().Unix()
 			id1 := "id1"
 			notification1 := moira.ScheduledNotification{
 				Contact:   moira.ContactData{ID: id1},
@@ -107,7 +113,7 @@ func TestScheduledNotification(t *testing.T) {
 			So(total, ShouldEqual, 1)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notification3})
 
-			total, err = dataBase.RemoveNotification(strings.Join([]string{fmt.Sprintf("%v", now+3600), id1, id1}, ""))
+			total, err = dataBase.RemoveNotification(strings.Join([]string{fmt.Sprintf("%v", now + 3600), id1, id1}, ""))
 			So(err, ShouldBeNil)
 			So(total, ShouldEqual, 1)
 
@@ -116,13 +122,12 @@ func TestScheduledNotification(t *testing.T) {
 			So(total, ShouldEqual, 0)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
 
-			actual, err = dataBase.FetchNotifications(now + 3600)
+			actual, err = dataBase.FetchNotifications(now + 3600, notifier.NotificationsLimitUnlimited)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
 		})
 
 		Convey("Test remove all notifications", func() {
-			now := time.Now().Unix()
 			id1 := "id1"
 			notification1 := moira.ScheduledNotification{
 				Contact:   moira.ContactData{ID: id1},
@@ -156,7 +161,7 @@ func TestScheduledNotification(t *testing.T) {
 			So(total, ShouldEqual, 0)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
 
-			actual, err = dataBase.FetchNotifications(now + 3600)
+			actual, err = dataBase.FetchNotifications(now + 3600, notifier.NotificationsLimitUnlimited)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
 		})
@@ -186,7 +191,7 @@ func TestScheduledNotificationErrorConnection(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(total, ShouldEqual, 0)
 
-		actual2, err := dataBase.FetchNotifications(0)
+		actual2, err := dataBase.FetchNotifications(0, notifier.NotificationsLimitUnlimited)
 		So(err, ShouldNotBeNil)
 		So(actual2, ShouldBeNil)
 
@@ -199,5 +204,342 @@ func TestScheduledNotificationErrorConnection(t *testing.T) {
 
 		err = dataBase.RemoveAllNotifications()
 		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestFetchNotifications(t *testing.T) {
+	logger, _ := logging.GetLogger("dataBase")
+	dataBase := newTestDatabase(logger, config)
+	dataBase.flush()
+	defer dataBase.flush()
+
+	Convey("FetchNotifications manipulation", t, func() {
+		now := time.Now().Unix()
+		notificationNew := moira.ScheduledNotification{
+			SendFail:  1,
+			Timestamp: now + 3600,
+		}
+		notification := moira.ScheduledNotification{
+			SendFail:  2,
+			Timestamp: now,
+		}
+		notificationOld := moira.ScheduledNotification{
+			SendFail:  3,
+			Timestamp: now - 3600,
+		}
+
+		Convey("Test fetch notifications with limit if all notifications has diff timestamp", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.FetchNotifications(now + 6000, 1)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld})
+
+			actual, total, err := dataBase.GetNotifications(0, -1)
+			So(err, ShouldBeNil)
+			So(total, ShouldEqual, 2)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notification, &notificationNew})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test fetch notifications with limit little bit greater than count if all notifications has diff timestamp", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.FetchNotifications(now + 6000, 4)
+			So(err, ShouldBeNil)
+
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification})
+
+			actual, total, err := dataBase.GetNotifications(0, -1)
+			So(err, ShouldBeNil)
+			So(total, ShouldEqual, 1)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationNew})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test fetch notifications with limit greater than count if all notifications has diff timestamp", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.FetchNotifications(now + 6000, 200000)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification, &notificationNew})
+
+			actual, total, err := dataBase.GetNotifications(0, -1)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
+			So(total, ShouldEqual, 0)
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test fetch notifications without limit", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.FetchNotifications(now + 6000, notifier.NotificationsLimitUnlimited)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification, &notificationNew})
+
+			actual, total, err := dataBase.GetNotifications(0, -1)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
+			So(total, ShouldEqual, 0)
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestNotificationsCount(t *testing.T) {
+	logger, _ := logging.GetLogger("dataBase")
+	dataBase := newTestDatabase(logger, config)
+	dataBase.flush()
+	defer dataBase.flush()
+
+	Convey("notificationsCount in db", t, func() {
+		now := time.Now().Unix()
+		notificationNew := moira.ScheduledNotification{
+			SendFail:  1,
+			Timestamp: now + 3600,
+		}
+		notification := moira.ScheduledNotification{
+			SendFail:  2,
+			Timestamp: now,
+		}
+		notificationOld := moira.ScheduledNotification{
+			SendFail:  3,
+			Timestamp: now - 3600,
+		}
+
+		Convey("Test all notification with different ts in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.notificationsCount(now + 6000)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, int64(3))
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test get 0 notification with ts in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.notificationsCount(now - 7000)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, int64(0))
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test part notification in db with ts", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.notificationsCount(now)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, int64(2))
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test 0 notification in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{})
+			actual, err := dataBase.notificationsCount(now)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, int64(0))
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestFetchNotificationsWithLimitDo(t *testing.T) {
+	logger, _ := logging.GetLogger("dataBase")
+	dataBase := newTestDatabase(logger, config)
+	dataBase.flush()
+	defer dataBase.flush()
+
+	Convey("notificationsCount in db", t, func() {
+		now := time.Now().Unix()
+		notificationNew := moira.ScheduledNotification{
+			SendFail:  1,
+			Timestamp: now + 3600,
+		}
+		notification := moira.ScheduledNotification{
+			SendFail:  2,
+			Timestamp: now,
+		}
+		notificationOld := moira.ScheduledNotification{
+			SendFail:  3,
+			Timestamp: now - 3600,
+		}
+		notification4 := moira.ScheduledNotification{
+			SendFail:  4,
+			Timestamp: now - 3600,
+		}
+
+		Convey("Test all notification with ts and limit in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.fetchNotificationsWithLimitDo(now + 6000, 1)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test 0 notification with ts and limit in empty db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{})
+			actual, err := dataBase.fetchNotificationsWithLimitDo(now + 6000, 10)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test all notification with ts and big limit in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.fetchNotificationsWithLimitDo(now + 6000, 100)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test notification with ts and small limit in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld, notification4})
+			actual, err := dataBase.fetchNotificationsWithLimitDo(now + 6000, 3)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification4})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test notification with ts and limit = count", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.fetchNotificationsWithLimitDo(now + 6000, 3)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestLimitNotifications(t *testing.T)  {
+	Convey("limitNotifications manipulation", t, func() {
+		now := time.Now().Unix()
+		notificationNew := moira.ScheduledNotification{
+			SendFail:  1,
+			Timestamp: now + 3600,
+		}
+		notification := moira.ScheduledNotification{
+			SendFail:  2,
+			Timestamp: now,
+		}
+		notificationOld := moira.ScheduledNotification{
+			SendFail:  3,
+			Timestamp: now - 3600,
+		}
+		notification4 := moira.ScheduledNotification{
+			SendFail:  4,
+			Timestamp: now - 3600,
+		}
+		notification5 := moira.ScheduledNotification{
+			SendFail:  5,
+			Timestamp: now + 3600,
+		}
+
+		Convey("Test limit Notifications zero notifications", func() {
+			notifications := []*moira.ScheduledNotification{}
+			actual := limitNotifications(notifications)
+			So(actual, ShouldResemble, notifications)
+		})
+
+		Convey("Test limit Notifications notifications diff ts", func() {
+			notifications := []*moira.ScheduledNotification{&notificationOld, &notification, &notificationNew}
+			actual := limitNotifications(notifications)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification})
+		})
+
+		Convey("Test limit Notifications all notifications same ts", func() {
+			notifications := []*moira.ScheduledNotification{&notificationOld, &notification4}
+			actual := limitNotifications(notifications)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification4})
+		})
+
+		Convey("Test limit Notifications 1 notifications diff ts and 2 same ts", func() {
+			notifications := []*moira.ScheduledNotification{&notificationOld, &notificationNew, &notification5}
+			actual := limitNotifications(notifications)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld})
+		})
+
+		Convey("Test limit Notifications 2 notifications same ts and 1 diff ts", func() {
+			notifications := []*moira.ScheduledNotification{&notificationOld, &notification4, &notification5}
+			actual := limitNotifications(notifications)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification4})
+		})
+	})
+}
+
+func TestFetchNotificationsNoLimit(t *testing.T) {
+	logger, _ := logging.GetLogger("dataBase")
+	dataBase := newTestDatabase(logger, config)
+	dataBase.flush()
+	defer dataBase.flush()
+
+	Convey("fetchNotificationsNoLimit manipulation", t, func() {
+		now := time.Now().Unix()
+		notificationNew := moira.ScheduledNotification{
+			SendFail:  1,
+			Timestamp: now + 3600,
+		}
+		notification := moira.ScheduledNotification{
+			SendFail:  2,
+			Timestamp: now,
+		}
+		notificationOld := moira.ScheduledNotification{
+			SendFail:  3,
+			Timestamp: now - 3600,
+		}
+		notification4 := moira.ScheduledNotification{
+			SendFail:  4,
+			Timestamp: now - 3600,
+		}
+
+		Convey("Test all notifications with diff ts in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld})
+			actual, err := dataBase.fetchNotificationsNoLimit(now + 6000)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification, &notificationNew})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test zero notifications in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{})
+			actual, err := dataBase.fetchNotificationsNoLimit(now + 6000)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Test all notifications with various ts in db", func() {
+			addNotifications(dataBase, []moira.ScheduledNotification{notification, notificationNew, notificationOld, notification4})
+			actual, err := dataBase.fetchNotificationsNoLimit(now + 6000)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []*moira.ScheduledNotification{&notificationOld, &notification4, &notification, &notificationNew})
+
+			err = dataBase.RemoveAllNotifications()
+			So(err, ShouldBeNil)
+		})
 	})
 }

--- a/integration_tests/notifier/notifier_test.go
+++ b/integration_tests/notifier/notifier_test.go
@@ -31,6 +31,7 @@ var notifierConfig = notifier.Config{
 	ResendingTimeout: time.Hour * 24,
 	Location:         location,
 	DateTimeFormat:   dateTimeFormat,
+	ReadBatchSize:    notifier.NotificationsLimitUnlimited,
 }
 
 var shutdown = make(chan struct{})

--- a/interfaces.go
+++ b/interfaces.go
@@ -80,7 +80,7 @@ type Database interface {
 	GetNotifications(start, end int64) ([]*ScheduledNotification, int64, error)
 	RemoveNotification(notificationKey string) (int64, error)
 	RemoveAllNotifications() error
-	FetchNotifications(to int64) ([]*ScheduledNotification, error)
+	FetchNotifications(to int64, limit int64) ([]*ScheduledNotification, error)
 	AddNotification(notification *ScheduledNotification) error
 	AddNotifications(notification []*ScheduledNotification, timestamp int64) error
 

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -177,18 +177,18 @@ func (mr *MockDatabaseMockRecorder) FetchNotificationEvent() *gomock.Call {
 }
 
 // FetchNotifications mocks base method
-func (m *MockDatabase) FetchNotifications(arg0 int64) ([]*moira.ScheduledNotification, error) {
+func (m *MockDatabase) FetchNotifications(arg0, arg1 int64) ([]*moira.ScheduledNotification, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchNotifications", arg0)
+	ret := m.ctrl.Call(m, "FetchNotifications", arg0, arg1)
 	ret0, _ := ret[0].([]*moira.ScheduledNotification)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchNotifications indicates an expected call of FetchNotifications
-func (mr *MockDatabaseMockRecorder) FetchNotifications(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) FetchNotifications(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNotifications", reflect.TypeOf((*MockDatabase)(nil).FetchNotifications), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNotifications", reflect.TypeOf((*MockDatabase)(nil).FetchNotifications), arg0, arg1)
 }
 
 // FetchTriggersToReindex mocks base method

--- a/mock/notifier/notifier.go
+++ b/mock/notifier/notifier.go
@@ -35,6 +35,20 @@ func (m *MockNotifier) EXPECT() *MockNotifierMockRecorder {
 	return m.recorder
 }
 
+// GetReadBatchSize mocks base method
+func (m *MockNotifier) GetReadBatchSize() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReadBatchSize")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetReadBatchSize indicates an expected call of GetReadBatchSize
+func (mr *MockNotifierMockRecorder) GetReadBatchSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReadBatchSize", reflect.TypeOf((*MockNotifier)(nil).GetReadBatchSize))
+}
+
 // GetSenders mocks base method
 func (m *MockNotifier) GetSenders() map[string]bool {
 	m.ctrl.T.Helper()

--- a/notifier/config.go
+++ b/notifier/config.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const NotificationsLimitUnlimited = int64(-1)
+
 // Config is sending settings including log settings
 type Config struct {
 	Enabled           bool
@@ -17,4 +19,5 @@ type Config struct {
 	FrontURL          string
 	Location          *time.Location
 	DateTimeFormat    string
+	ReadBatchSize     int64
 }

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -61,7 +61,7 @@ func (worker *FetchNotificationsWorker) processScheduledNotifications() error {
 	if state != moira.SelfStateOK {
 		return notifierInBadStateError(fmt.Sprintf("notifier in a bad state: %v", state))
 	}
-	notifications, err := worker.Database.FetchNotifications(time.Now().Unix())
+	notifications, err := worker.Database.FetchNotifications(time.Now().Unix(), worker.Notifier.GetReadBatchSize())
 	if err != nil {
 		return err
 	}

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -66,6 +66,7 @@ type Notifier interface {
 	RegisterSender(senderSettings map[string]string, sender moira.Sender) error
 	StopSenders()
 	GetSenders() map[string]bool
+	GetReadBatchSize() int64
 }
 
 // StandardNotifier represent notification functionality
@@ -123,6 +124,11 @@ func (notifier *StandardNotifier) GetSenders() map[string]bool {
 		hash[key] = true
 	}
 	return hash
+}
+
+// GetReadBatchSize returns amount of messages notifier reads from Redis per iteration
+func (notifier *StandardNotifier) GetReadBatchSize() int64 {
+	return int64(notifier.config.ReadBatchSize)
 }
 
 func (notifier *StandardNotifier) resend(pkg *NotificationPackage, reason string) {


### PR DESCRIPTION
# PR Summary

Add params ReadBatchSize to notifier/config.go
Add 'limit' to FetchNotifications. Notification drops using "optimistic" transactions. See comment in fetchNotificationsWithLimitDo for more details.

Closes/Relates #501
