### PR TITLE
Slave replicas read

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -28,8 +28,9 @@ type RedisConfig struct {
 	// Redis node port
 	Port string `yaml:"port"`
 	// Redis database
-	DB              int `yaml:"dbid"`
-	ConnectionLimit int `yaml:"connection_limit"`
+	DB              int  `yaml:"dbid"`
+	ConnectionLimit int  `yaml:"connection_limit"`
+	AllowSlaveReads bool `yaml:"allow_slave_reads"`
 }
 
 // GetSettings returns redis config parsed from moira config files
@@ -41,6 +42,7 @@ func (config *RedisConfig) GetSettings() redis.Config {
 		Port:              config.Port,
 		DB:                config.DB,
 		ConnectionLimit:   config.ConnectionLimit,
+		AllowSlaveReads:   config.AllowSlaveReads,
 	}
 }
 

--- a/database/redis/config.go
+++ b/database/redis/config.go
@@ -8,4 +8,5 @@ type Config struct {
 	Port              string
 	DB                int
 	ConnectionLimit   int
+	AllowSlaveReads   bool
 }

--- a/database/redis/database.go
+++ b/database/redis/database.go
@@ -46,8 +46,7 @@ type DbConnector struct {
 	metricsCache         *cache.Cache
 	sync                 *redsync.Redsync
 	source               DBSource
-
-	slaveConnector *DbConnector
+	slaveConnector       *DbConnector
 }
 
 // NewDatabase creates Redis pool based on config
@@ -144,7 +143,7 @@ func createPoolDialers(logger moira.Logger, config Config) (mainDialer, slaveDia
 		db:            config.DB,
 		dialTimeout:   dialTimeout,
 	}
-	return
+	return mainDialer, nil
 }
 
 func (connector *DbConnector) makePubSubConnection(channel string) (*redis.PubSubConn, error) {

--- a/database/redis/database_dialer_test.go
+++ b/database/redis/database_dialer_test.go
@@ -1,0 +1,70 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moira-alert/moira/logging/go-logging"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var logger, _ = logging.ConfigureLog("stdout", "debug", "test")
+
+var sentinelConfig = SentinelPoolDialerConfig{
+	MasterName: "master01",
+	DB: 0,
+	DialTimeout: time.Millisecond,
+	SentinelAddresses: []string{
+		"fake-sentinel:26379",
+	},
+}
+
+func TestDirectDialer(t *testing.T) {
+	Convey("Direct dialer", t, func() {
+		Convey("Tries dial and fails", func() {
+			dialer := DirectPoolDialer {
+				serverAddress: "fake-redis:6379",
+				db: 0,
+				dialTimeout: time.Millisecond,
+			}
+
+			_, err := dialer.Dial()
+
+			So(err.Error(), ShouldEqual, "dial tcp: i/o timeout")
+		})
+		
+		Convey("Test dials successfully", func() {
+			dialer := DirectPoolDialer {
+				serverAddress: "localhost:6379",
+				db: 0,
+				dialTimeout: 5 * time.Second,
+			}
+
+			conn, err := dialer.Dial()
+
+			So(err, ShouldBeNil)
+			
+			err = dialer.Test(conn, time.Now())
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestSentinelDialer(t *testing.T) {
+	dialer := NewSentinelPoolDialer(logger, sentinelConfig)
+
+	Convey("Tries dial and fails", t, func() {
+		_, err := dialer.Dial()
+		So(err.Error(), ShouldEqual, "redigo: no sentinels available; last error: dial tcp: i/o timeout")
+	})
+}
+
+func TestSlaveDialer(t *testing.T) {	
+	dialer := NewSentinelPoolDialer(logger, sentinelConfig)
+	slaveDialer := NewSentinelSlavePoolDialer(dialer)
+
+	Convey("Tries dial and fails", t, func() {
+		_, err := slaveDialer.Dial()
+		So(err.Error(), ShouldEqual, "redigo: no sentinels available; last error: dial tcp: i/o timeout")
+	})
+}

--- a/database/redis/database_test.go
+++ b/database/redis/database_test.go
@@ -41,6 +41,20 @@ func TestAllowStale(t *testing.T) {
 			So(staleDatabase, ShouldPointTo, database)
 		})
 
+		Convey("When using sentinel with slave reads disabled, returns same db", func() {
+			sentinelConfig := Config{
+				MasterName:        "mstr",
+				SentinelAddresses: []string{"addr.ru"},
+				DB:                0,
+				AllowSlaveReads:   false,
+			}
+			database := newTestDatabase(logger, sentinelConfig)
+
+			staleDatabase := database.AllowStale()
+
+			So(staleDatabase, ShouldPointTo, database)
+		})
+
 		Convey("When using sentinel, returns slave db instance, retains references", func() {
 			sentinelConfig := Config{
 				MasterName:        "mstr",

--- a/database/redis/database_test.go
+++ b/database/redis/database_test.go
@@ -28,3 +28,36 @@ func TestInitialization(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 }
+
+func TestAllowStale(t *testing.T) {
+	logger, _ := logging.ConfigureLog("stdout", "info", "test")
+
+	Convey("Allow stale", t, func() {
+		Convey("When using redis directly, returns same db", func() {
+			database := newTestDatabase(logger, emptyConfig)
+
+			staleDatabase := database.AllowStale()
+
+			So(staleDatabase, ShouldPointTo, database)
+		})
+
+		Convey("When using sentinel, returns slave db instance, retains references", func() {
+			sentinelConfig := Config{
+				MasterName:        "mstr",
+				SentinelAddresses: []string{"addr.ru"},
+				DB:                0,
+				AllowSlaveReads:   true,
+			}
+			database := newTestDatabase(logger, sentinelConfig)
+
+			staleDatabase := database.AllowStale()
+
+			So(staleDatabase, ShouldNotPointTo, database)
+			staleConnector := staleDatabase.(*DbConnector)
+			So(staleConnector.metricsCache, ShouldPointTo, database.metricsCache)
+			So(staleConnector.retentionCache, ShouldPointTo, database.retentionCache)
+			So(staleConnector.retentionSavingCache, ShouldPointTo, database.retentionSavingCache)
+			So(staleConnector.sync, ShouldPointTo, database.sync)
+		})
+	})
+}

--- a/database/redis/trigger.go
+++ b/database/redis/trigger.go
@@ -314,8 +314,8 @@ func (connector *DbConnector) getTriggerWithTags(triggerRaw interface{}, tagsRaw
 	return trigger, nil
 }
 
-func (connector *DbConnector) cleanupPatternsOutOfUse(pattern []string) error {
-	for _, pattern := range pattern {
+func (connector *DbConnector) cleanupPatternsOutOfUse(patterns []string) error {
+	for _, pattern := range patterns {
 		triggerIDs, err := connector.GetPatternTriggerIDs(pattern)
 		if err != nil {
 			return err

--- a/filter/patterns_storage.go
+++ b/filter/patterns_storage.go
@@ -30,7 +30,7 @@ func NewPatternStorage(database moira.Database, metrics *metrics.FilterMetrics, 
 
 // Refresh builds pattern's indexes from redis data
 func (storage *PatternStorage) Refresh() error {
-	newPatterns, err := storage.database.GetPatterns()
+	newPatterns, err := storage.database.AllowStale().GetPatterns()
 	if err != nil {
 		return err
 	}

--- a/filter/patterns_storage_test.go
+++ b/filter/patterns_storage_test.go
@@ -19,6 +19,7 @@ func TestProcessIncomingMetric(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	database := mock_moira_alert.NewMockDatabase(mockCtrl)
+	database.EXPECT().AllowStale().AnyTimes().Return(database)
 	logger, _ := logging.GetLogger("Scheduler")
 
 	Convey("Create new pattern storage, GetPatterns returns error, should error", t, func() {

--- a/interfaces.go
+++ b/interfaces.go
@@ -9,6 +9,9 @@ import (
 
 // Database implements DB functionality
 type Database interface {
+	// Get database instance for requests that do not require realtime data
+	AllowStale() Database
+
 	// SelfState
 	UpdateMetricsHeartbeat() error
 	GetMetricsUpdatesCount() (int64, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -119,6 +119,20 @@ func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
+// AllowStale mocks base method
+func (m *MockDatabase) AllowStale() moira.Database {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllowStale")
+	ret0, _ := ret[0].(moira.Database)
+	return ret0
+}
+
+// AllowStale indicates an expected call of AllowStale
+func (mr *MockDatabaseMockRecorder) AllowStale() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllowStale", reflect.TypeOf((*MockDatabase)(nil).AllowStale))
+}
+
 // DeleteTriggerCheckLock mocks base method
 func (m *MockDatabase) DeleteTriggerCheckLock(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/perfomance_tests/filter/filter_test.go
+++ b/perfomance_tests/filter/filter_test.go
@@ -39,6 +39,7 @@ func BenchmarkProcessIncomingMetric(b *testing.B) {
 
 	mockCtrl := gomock.NewController(b)
 	database := mock_moira_alert.NewMockDatabase(mockCtrl)
+	database.EXPECT().AllowStale().AnyTimes().Return(database)
 	logger, _ := logging.GetLogger("Benchmark")
 
 	database.EXPECT().GetPatterns().Return(patterns, nil)


### PR DESCRIPTION
# Implement reading patterns from slave

Implemented reading patterns from slave replicas in an attempt to balance some load. Replicas may contain stale data, but it does not seem like a problem in case of updating the pattern index. 

Did not implement things like replica staleness checking or random replicas iteration. Should consider adding those sometime.