### PR TITLE
[FEAT] Check expression validity on trigger update and save

### DIFF
--- a/api/controller/triggers_test.go
+++ b/api/controller/triggers_test.go
@@ -18,9 +18,10 @@ func TestCreateTrigger(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+	expr := "t1 >= 5 ? WARN : OK"
 
 	Convey("Success with trigger.ID empty", t, func() {
-		triggerModel := dto.TriggerModel{}
+		triggerModel := dto.TriggerModel{Targets: []string{"t1"}, TriggerType: "expression", Expression: expr}
 		dataBase.EXPECT().AcquireTriggerCheckLock(gomock.Any(), 10)
 		dataBase.EXPECT().DeleteTriggerCheckLock(gomock.Any())
 		dataBase.EXPECT().GetTriggerLastCheck(gomock.Any()).Return(moira.CheckData{}, database.ErrNil)
@@ -33,7 +34,7 @@ func TestCreateTrigger(t *testing.T) {
 
 	Convey("Success with triggerID", t, func() {
 		triggerID := uuid.Must(uuid.NewV4()).String()
-		triggerModel := dto.TriggerModel{ID: triggerID}
+		triggerModel := dto.TriggerModel{ID: triggerID, Targets: []string{"t1"}, TriggerType: "expression", Expression: expr}
 		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
 		dataBase.EXPECT().AcquireTriggerCheckLock(gomock.Any(), 10)
 		dataBase.EXPECT().DeleteTriggerCheckLock(gomock.Any())
@@ -47,7 +48,7 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Trigger already exists", t, func() {
-		triggerModel := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String()}
+		triggerModel := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String(), Targets: []string{"t1"}, TriggerType: "expression", Expression: expr}
 		trigger := triggerModel.ToMoiraTrigger()
 		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(*trigger, nil)
 		resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))
@@ -56,7 +57,7 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Get trigger error", t, func() {
-		trigger := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String()}
+		trigger := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String(), Targets: []string{"t1"}, TriggerType: "expression", Expression: expr}
 		expected := fmt.Errorf("soo bad trigger")
 		dataBase.EXPECT().GetTrigger(trigger.ID).Return(moira.Trigger{}, expected)
 		resp, err := CreateTrigger(dataBase, &trigger, make(map[string]bool))
@@ -65,7 +66,7 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Error", t, func() {
-		triggerModel := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String()}
+		triggerModel := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String(), Targets: []string{"t1"}, TriggerType: "expression", Expression: expr}
 		expected := fmt.Errorf("soo bad trigger")
 		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
 		dataBase.EXPECT().AcquireTriggerCheckLock(gomock.Any(), 10)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -21,11 +21,11 @@ var exprCache = cache.New(cache.NoExpiration, cache.NoExpiration)
 
 // ErrInvalidExpression represents bad expression or its state error
 type ErrInvalidExpression struct {
-	internalError error
+	InternalError error
 }
 
 func (err ErrInvalidExpression) Error() string {
-	return err.internalError.Error()
+	return err.InternalError.Error()
 }
 
 // TriggerExpression represents trigger expression handler parameters, what can be used for trigger expression handling
@@ -79,17 +79,17 @@ func (triggerExpression TriggerExpression) Get(name string) (interface{}, error)
 func (triggerExpression *TriggerExpression) Evaluate() (moira.State, error) {
 	expr, err := getExpression(triggerExpression)
 	if err != nil {
-		return "", ErrInvalidExpression{internalError: err}
+		return "", ErrInvalidExpression{InternalError: err}
 	}
 	result, err := expr.Eval(triggerExpression)
 	if err != nil {
-		return "", ErrInvalidExpression{internalError: err}
+		return "", ErrInvalidExpression{InternalError: err}
 	}
 	switch res := result.(type) {
 	case moira.State:
 		return res, nil
 	default:
-		return "", ErrInvalidExpression{internalError: fmt.Errorf("expression result must be state value")}
+		return "", ErrInvalidExpression{InternalError: fmt.Errorf("expression result must be state value")}
 	}
 }
 


### PR DESCRIPTION
# PR Summary

- Added `checkExpressionValidity` function which checks for the validity of the expression.
- This function user `expression.go/Evaluate` function.
- Added tests for same - *wrong syntax* & *wrong state*. 

**Related issue**
#216 