### PR TITLE
[BREAKING CHANGE] Removed paging mechanism

### DIFF
--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -7,16 +7,14 @@ import (
 )
 
 // GetTriggerEvents gets trigger event from current page and all trigger event count
-func GetTriggerEvents(database moira.Database, triggerID string, page int64, size int64) (*dto.EventsList, *api.ErrorResponse) {
-	events, err := database.GetNotificationEvents(triggerID, page*size, size-1)
+func GetTriggerEvents(database moira.Database, triggerID string) (*dto.EventsList, *api.ErrorResponse) {
+
+	eventCount := database.GetNotificationEventCount(triggerID, -1)
+	events, err := database.GetNotificationEvents(triggerID, eventCount-1)
 	if err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}
-	eventCount := database.GetNotificationEventCount(triggerID, -1)
-
 	eventsList := &dto.EventsList{
-		Size:  size,
-		Page:  page,
 		Total: eventCount,
 		List:  make([]moira.NotificationEvent, 0),
 	}

--- a/api/controller/events_test.go
+++ b/api/controller/events_test.go
@@ -18,41 +18,37 @@ func TestGetEvents(t *testing.T) {
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	defer mockCtrl.Finish()
 	triggerID := uuid.Must(uuid.NewV4()).String()
-	var page int64 = 10
-	var size int64 = 100
 
 	Convey("Test has events", t, func() {
-		var total int64 = 6000000
-		dataBase.EXPECT().GetNotificationEvents(triggerID, page*size, size-1).Return([]*moira.NotificationEvent{{State: moira.StateNODATA, OldState: moira.StateOK}, {State: moira.StateOK, OldState: moira.StateNODATA}}, nil)
-		dataBase.EXPECT().GetNotificationEventCount(triggerID, int64(-1)).Return(total)
-		list, err := GetTriggerEvents(dataBase, triggerID, page, size)
+		var size int64 = 100
+		dataBase.EXPECT().GetNotificationEvents(triggerID, size-1).Return([]*moira.NotificationEvent{{State: moira.StateNODATA, OldState: moira.StateOK}, {State: moira.StateOK, OldState: moira.StateNODATA}}, nil)
+		dataBase.EXPECT().GetNotificationEventCount(triggerID, int64(-1)).Return(size)
+		list, err := GetTriggerEvents(dataBase, triggerID)
 		So(err, ShouldBeNil)
 		So(list, ShouldResemble, &dto.EventsList{
 			List:  []moira.NotificationEvent{{State: moira.StateNODATA, OldState: moira.StateOK}, {State: moira.StateOK, OldState: moira.StateNODATA}},
-			Total: total,
-			Size:  size,
-			Page:  page,
+			Total: size,
 		})
 	})
 
 	Convey("Test no events", t, func() {
-		var total int64
-		dataBase.EXPECT().GetNotificationEvents(triggerID, page*size, size-1).Return(make([]*moira.NotificationEvent, 0), nil)
-		dataBase.EXPECT().GetNotificationEventCount(triggerID, int64(-1)).Return(total)
-		list, err := GetTriggerEvents(dataBase, triggerID, page, size)
+		var size int64
+		dataBase.EXPECT().GetNotificationEvents(triggerID, size-1).Return(make([]*moira.NotificationEvent, 0), nil)
+		dataBase.EXPECT().GetNotificationEventCount(triggerID, int64(-1)).Return(size)
+		list, err := GetTriggerEvents(dataBase, triggerID)
 		So(err, ShouldBeNil)
 		So(list, ShouldResemble, &dto.EventsList{
 			List:  make([]moira.NotificationEvent, 0),
-			Total: total,
-			Size:  size,
-			Page:  page,
+			Total: size,
 		})
 	})
 
 	Convey("Test error", t, func() {
+		var size int64 = 100
 		expected := fmt.Errorf("oooops! Can not get all contacts")
-		dataBase.EXPECT().GetNotificationEvents(triggerID, page*size, size-1).Return(nil, expected)
-		list, err := GetTriggerEvents(dataBase, triggerID, page, size)
+		dataBase.EXPECT().GetNotificationEvents(triggerID, size-1).Return(nil, expected)
+		dataBase.EXPECT().GetNotificationEventCount(triggerID, int64(-1)).Return(size)
+		list, err := GetTriggerEvents(dataBase, triggerID)
 		So(err, ShouldResemble, api.ErrorInternalServer(expected))
 		So(list, ShouldBeNil)
 	})

--- a/api/dto/events.go
+++ b/api/dto/events.go
@@ -8,8 +8,6 @@ import (
 )
 
 type EventsList struct {
-	Page  int64                     `json:"page"`
-	Size  int64                     `json:"size"`
 	Total int64                     `json:"total"`
 	List  []moira.NotificationEvent `json:"list"`
 }

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -17,9 +17,7 @@ func event(router chi.Router) {
 
 func getEventsList(writer http.ResponseWriter, request *http.Request) {
 	triggerID := middleware.GetTriggerID(request)
-	size := middleware.GetSize(request)
-	page := middleware.GetPage(request)
-	eventsList, err := controller.GetTriggerEvents(database, triggerID, page, size)
+	eventsList, err := controller.GetTriggerEvents(database, triggerID)
 	if err != nil {
 		render.Render(writer, request, err)
 		return

--- a/database/redis/notification_event.go
+++ b/database/redis/notification_event.go
@@ -15,11 +15,13 @@ import (
 var eventsTTL int64 = 3600 * 24 * 30
 
 // GetNotificationEvents gets NotificationEvents by given triggerID and interval
-func (connector *DbConnector) GetNotificationEvents(triggerID string, start int64, size int64) ([]*moira.NotificationEvent, error) {
+func (connector *DbConnector) GetNotificationEvents(triggerID string, size int64) ([]*moira.NotificationEvent, error) {
 	c := connector.pool.Get()
 	defer c.Close()
-
-	eventsData, err := reply.Events(c.Do("ZREVRANGE", triggerEventsKey(triggerID), start, start+size))
+	if size == -1 {
+		size = 0
+	}
+	eventsData, err := reply.Events(c.Do("ZREVRANGE", triggerEventsKey(triggerID), 0, size))
 
 	if err != nil {
 		if err == redis.ErrNil {

--- a/database/redis/notification_event_test.go
+++ b/database/redis/notification_event_test.go
@@ -22,7 +22,7 @@ func TestNotificationEvents(t *testing.T) {
 	Convey("Notification events manipulation", t, func() {
 		Convey("Test push-get-get count-fetch", func() {
 			Convey("Should no events", func() {
-				actual, err := dataBase.GetNotificationEvents(notificationEvent.TriggerID, 0, 1)
+				actual, err := dataBase.GetNotificationEvents(notificationEvent.TriggerID, 1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, make([]*moira.NotificationEvent, 0))
 
@@ -39,7 +39,7 @@ func TestNotificationEvents(t *testing.T) {
 				err := dataBase.PushNotificationEvent(&notificationEvent, true)
 				So(err, ShouldBeNil)
 
-				actual, err := dataBase.GetNotificationEvents(notificationEvent.TriggerID, 0, 1)
+				actual, err := dataBase.GetNotificationEvents(notificationEvent.TriggerID, 1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{&notificationEvent})
 
@@ -52,7 +52,7 @@ func TestNotificationEvents(t *testing.T) {
 			})
 
 			Convey("Should has event by triggerID after fetch", func() {
-				actual, err := dataBase.GetNotificationEvents(notificationEvent.TriggerID, 0, 1)
+				actual, err := dataBase.GetNotificationEvents(notificationEvent.TriggerID, 1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{&notificationEvent})
 
@@ -76,14 +76,14 @@ func TestNotificationEvents(t *testing.T) {
 				err = dataBase.PushNotificationEvent(&notificationEvent2, true)
 				So(err, ShouldBeNil)
 
-				actual, err := dataBase.GetNotificationEvents(notificationEvent1.TriggerID, 0, 1)
+				actual, err := dataBase.GetNotificationEvents(notificationEvent1.TriggerID, 1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{&notificationEvent1})
 
 				total := dataBase.GetNotificationEventCount(notificationEvent1.TriggerID, 0)
 				So(total, ShouldEqual, 1)
 
-				actual, err = dataBase.GetNotificationEvents(notificationEvent2.TriggerID, 0, 1)
+				actual, err = dataBase.GetNotificationEvents(notificationEvent2.TriggerID, 1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{&notificationEvent2})
 
@@ -96,7 +96,7 @@ func TestNotificationEvents(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(actual1, ShouldResemble, notificationEvent1)
 
-				actual, err := dataBase.GetNotificationEvents(notificationEvent1.TriggerID, 0, 1)
+				actual, err := dataBase.GetNotificationEvents(notificationEvent1.TriggerID, 1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{&notificationEvent1})
 
@@ -129,7 +129,7 @@ func TestNotificationEvents(t *testing.T) {
 			err := dataBase.PushNotificationEvent(&event, true)
 			So(err, ShouldBeNil)
 
-			actual, err := dataBase.GetNotificationEvents(event.TriggerID, 0, 1)
+			actual, err := dataBase.GetNotificationEvents(event.TriggerID, 1)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.NotificationEvent{&event})
 
@@ -144,10 +144,6 @@ func TestNotificationEvents(t *testing.T) {
 
 			total = dataBase.GetNotificationEventCount(event.TriggerID, now+1)
 			So(total, ShouldEqual, 0)
-
-			actual, err = dataBase.GetNotificationEvents(event.TriggerID, 1, 1)
-			So(err, ShouldBeNil)
-			So(actual, ShouldResemble, make([]*moira.NotificationEvent, 0))
 		})
 
 		Convey("Test removing notification events", func() {
@@ -188,7 +184,7 @@ func TestNotificationEventErrorConnection(t *testing.T) {
 	}
 
 	Convey("Should throw error when no connection", t, func() {
-		actual1, err := dataBase.GetNotificationEvents("123", 0, 1)
+		actual1, err := dataBase.GetNotificationEvents("123", 1)
 		So(actual1, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -50,7 +50,7 @@ type Database interface {
 	DeleteTriggerThrottling(triggerID string) error
 
 	// NotificationEvent storing
-	GetNotificationEvents(triggerID string, start, size int64) ([]*NotificationEvent, error)
+	GetNotificationEvents(triggerID string, size int64) ([]*NotificationEvent, error)
 	PushNotificationEvent(event *NotificationEvent, ui bool) error
 	GetNotificationEventCount(triggerID string, from int64) int64
 	FetchNotificationEvent() (NotificationEvent, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -5,11 +5,12 @@
 package mock_moira_alert
 
 import (
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	moira "github.com/moira-alert/moira"
 	tomb "gopkg.in/tomb.v2"
-	reflect "reflect"
-	time "time"
 )
 
 // MockDatabase is a mock of Database interface
@@ -387,18 +388,18 @@ func (mr *MockDatabaseMockRecorder) GetNotificationEventCount(arg0, arg1 interfa
 }
 
 // GetNotificationEvents mocks base method
-func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2 int64) ([]*moira.NotificationEvent, error) {
+func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1 int64) ([]*moira.NotificationEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1)
 	ret0, _ := ret[0].([]*moira.NotificationEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNotificationEvents indicates an expected call of GetNotificationEvents
-func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1)
 }
 
 // GetNotifications mocks base method

--- a/mock/moira-alert/locks.go
+++ b/mock/moira-alert/locks.go
@@ -5,9 +5,8 @@
 package mock_moira_alert
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLock is a mock of Lock interface
@@ -35,6 +34,7 @@ func (m *MockLock) EXPECT() *MockLockMockRecorder {
 
 // Acquire mocks base method
 func (m *MockLock) Acquire(arg0 <-chan struct{}) (<-chan struct{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Acquire", arg0)
 	ret0, _ := ret[0].(<-chan struct{})
 	ret1, _ := ret[1].(error)
@@ -43,15 +43,18 @@ func (m *MockLock) Acquire(arg0 <-chan struct{}) (<-chan struct{}, error) {
 
 // Acquire indicates an expected call of Acquire
 func (mr *MockLockMockRecorder) Acquire(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockLock)(nil).Acquire), arg0)
 }
 
 // Release mocks base method
 func (m *MockLock) Release() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Release")
 }
 
 // Release indicates an expected call of Release
 func (mr *MockLockMockRecorder) Release() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Release", reflect.TypeOf((*MockLock)(nil).Release))
 }


### PR DESCRIPTION
# PR Summary

**Details**

1. Now `GetTriggerEvents` returns all events in one go.
2. To do this, first calculated total event count and then passed it `GetNotificationEvents` to get all events.
3. Updated tests accordingly.
4. Db mock is also updated accordingly.

**Additional information**

This PR results in frontend breakage.
Frontend PR : https://github.com/moira-alert/web2.0/pull/305 
 
**Related issue**
#363 
