### PR TITLE
Add cap on metric fetching to prevent checker OOM

### DIFF
--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -28,6 +28,7 @@ func TestExpressionModeMultipleTargetsWarnValue(t *testing.T) {
 		sourceProvider := metricSource.CreateMetricSourceProvider(localSource, remoteSource)
 
 		localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes()
+		localSource.EXPECT().GetMetricsTTLSeconds().Return(int64(3600)).AnyTimes()
 		localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil).AnyTimes()
 		fetchResult.EXPECT().GetPatterns().Return(make([]string, 0), nil).AnyTimes()
 		fetchResult.EXPECT().GetMetricsData().Return([]*metricSource.MetricData{metricSource.MakeMetricData("", []float64{}, 0, 0)}).AnyTimes()

--- a/checker/config.go
+++ b/checker/config.go
@@ -10,7 +10,6 @@ type Config struct {
 	NoDataCheckInterval         time.Duration
 	CheckInterval               time.Duration
 	LazyTriggersCheckInterval   time.Duration
-	MetricsTTLSeconds           int64
 	StopCheckingIntervalSeconds int64
 	MaxParallelChecks           int
 	MaxParallelRemoteChecks     int

--- a/checker/fetch.go
+++ b/checker/fetch.go
@@ -69,7 +69,7 @@ func (triggerChecker *TriggerChecker) fetch() (*metricSource.TriggerMetricsData,
 
 func (triggerChecker *TriggerChecker) cleanupMetricsValues(metrics []string, until int64) {
 	if len(metrics) > 0 {
-		if err := triggerChecker.database.RemoveMetricsValues(metrics, until-triggerChecker.config.MetricsTTLSeconds); err != nil {
+		if err := triggerChecker.database.RemoveMetricsValues(metrics, until-triggerChecker.database.GetMetricsTTLSeconds()); err != nil {
 			triggerChecker.logger.Error(err.Error())
 		}
 	}

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -83,6 +83,7 @@ func getDefault() config {
 			Host:            "localhost",
 			Port:            "6379",
 			ConnectionLimit: 512,
+			MetricsTTL:      "1h",
 		},
 		Logger: cmd.LoggerConfig{
 			LogFile:  "stdout",
@@ -107,7 +108,8 @@ func getDefault() config {
 			Pprof: cmd.ProfilerConfig{Enabled: false},
 		},
 		Remote: cmd.RemoteConfig{
-			Timeout: "60s",
+			Timeout:    "60s",
+			MetricsTTL: "7d",
 		},
 	}
 }

--- a/cmd/checker/config.go
+++ b/cmd/checker/config.go
@@ -24,8 +24,6 @@ type checkerConfig struct {
 	// Max period to perform lazy triggers re-check. Note: lazy triggers are triggers which has no subscription for it. Moira will check its state less frequently.
 	// Delay for check lazy trigger is random between LazyTriggersCheckInterval/2 and LazyTriggersCheckInterval.
 	LazyTriggersCheckInterval string `yaml:"lazy_triggers_check_interval"`
-	// Time interval to store metrics. Note: Increasing of this value leads to increasing of Redis memory consumption value
-	MetricsTTL string `yaml:"metrics_ttl"`
 	// Max concurrent checkers to run. Equals to the number of processor cores found on Moira host by default or when variable is defined as 0.
 	MaxParallelChecks int `yaml:"max_parallel_checks"`
 	// Max concurrent remote checkers to run. Equals to the number of processor cores found on Moira host by default or when variable is defined as 0.
@@ -34,7 +32,6 @@ type checkerConfig struct {
 
 func (config *checkerConfig) getSettings() *checker.Config {
 	return &checker.Config{
-		MetricsTTLSeconds:           int64(to.Duration(config.MetricsTTL).Seconds()),
 		CheckInterval:               to.Duration(config.CheckInterval),
 		LazyTriggersCheckInterval:   to.Duration(config.LazyTriggersCheckInterval),
 		NoDataCheckInterval:         to.Duration(config.NoDataCheckInterval),
@@ -50,6 +47,7 @@ func getDefault() config {
 			Host:            "localhost",
 			Port:            "6379",
 			ConnectionLimit: 512,
+			MetricsTTL:      "1h",
 		},
 		Logger: cmd.LoggerConfig{
 			LogFile:  "stdout",
@@ -59,7 +57,6 @@ func getDefault() config {
 			NoDataCheckInterval:       "60s",
 			CheckInterval:             "5s",
 			LazyTriggersCheckInterval: "10m",
-			MetricsTTL:                "1h",
 			StopCheckingInterval:      "30s",
 			MaxParallelChecks:         0,
 			MaxParallelRemoteChecks:   0,
@@ -78,6 +75,7 @@ func getDefault() config {
 		Remote: cmd.RemoteConfig{
 			CheckInterval: "60s",
 			Timeout:       "60s",
+			MetricsTTL:    "7d",
 		},
 	}
 }

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -25,6 +25,7 @@ func getDefault() config {
 			Host:            "localhost",
 			Port:            "6379",
 			ConnectionLimit: 512,
+			MetricsTTL:      "1h",
 		},
 		Cleanup: cleanupConfig{
 			Whitelist: []string{},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,9 @@ type RedisConfig struct {
 	DB              int  `yaml:"dbid"`
 	ConnectionLimit int  `yaml:"connection_limit"`
 	AllowSlaveReads bool `yaml:"allow_slave_reads"`
+	// Moira will delete metrics older than this value from Redis. Large values will lead to various problems everywhere.
+	// See https://github.com/moira-alert/moira/pull/519
+	MetricsTTL string `yaml:"metrics_ttl"`
 }
 
 // GetSettings returns redis config parsed from moira config files
@@ -43,6 +46,7 @@ func (config *RedisConfig) GetSettings() redis.Config {
 		DB:                config.DB,
 		ConnectionLimit:   config.ConnectionLimit,
 		AllowSlaveReads:   config.AllowSlaveReads,
+		MetricsTTL:        to.Duration(config.MetricsTTL),
 	}
 }
 
@@ -95,6 +99,10 @@ type RemoteConfig struct {
 	URL string `yaml:"url"`
 	// Min period to perform triggers re-check. Note: Reducing of this value leads to increasing of CPU and memory usage values
 	CheckInterval string `yaml:"check_interval"`
+	// Moira won't fetch metrics older than this value from remote storage. Note that Moira doesn't delete old data from
+	// remote storage. Large values will lead to OOM problems in checker.
+	// See https://github.com/moira-alert/moira/pull/519
+	MetricsTTL string `yaml:"metrics_ttl"`
 	// Timeout for remote requests
 	Timeout string `yaml:"timeout"`
 	// Username for basic auth
@@ -115,6 +123,7 @@ func (config *RemoteConfig) GetRemoteSourceSettings() *remoteSource.Config {
 	return &remoteSource.Config{
 		URL:           config.URL,
 		CheckInterval: to.Duration(config.CheckInterval),
+		MetricsTTL:    to.Duration(config.MetricsTTL),
 		Timeout:       to.Duration(config.Timeout),
 		User:          config.User,
 		Password:      config.Password,

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -34,6 +34,7 @@ func getDefault() config {
 			Host:            "localhost",
 			Port:            "6379",
 			ConnectionLimit: 512,
+			MetricsTTL:      "1h",
 		},
 		Logger: cmd.LoggerConfig{
 			LogFile:  "stdout",

--- a/cmd/notifier/config.go
+++ b/cmd/notifier/config.go
@@ -63,6 +63,7 @@ func getDefault() config {
 			Host:            "localhost",
 			Port:            "6379",
 			ConnectionLimit: 512,
+			MetricsTTL:      "1h",
 		},
 
 		Logger: cmd.LoggerConfig{
@@ -94,7 +95,8 @@ func getDefault() config {
 			Pprof: cmd.ProfilerConfig{Enabled: false},
 		},
 		Remote: cmd.RemoteConfig{
-			Timeout: "60s",
+			Timeout:    "60s",
+			MetricsTTL: "24h",
 		},
 		ImageStores: cmd.ImageStoreConfig{},
 	}

--- a/database/redis/config.go
+++ b/database/redis/config.go
@@ -1,5 +1,7 @@
 package redis
 
+import "time"
+
 // Config - Redis database connection config
 type Config struct {
 	MasterName        string
@@ -9,4 +11,5 @@ type Config struct {
 	DB                int
 	ConnectionLimit   int
 	AllowSlaveReads   bool
+	MetricsTTL        time.Duration
 }

--- a/database/redis/database.go
+++ b/database/redis/database.go
@@ -45,6 +45,7 @@ type DbConnector struct {
 	retentionSavingCache *cache.Cache
 	metricsCache         *cache.Cache
 	sync                 *redsync.Redsync
+	metricsTTLSeconds    int64
 	source               DBSource
 	slaveConnector       *DbConnector
 }
@@ -88,6 +89,7 @@ func NewDatabase(logger moira.Logger, config Config, source DBSource) *DbConnect
 		retentionSavingCache: cache.New(cache.NoExpiration, cache.DefaultExpiration),
 		metricsCache:         cache.New(cacheValueExpirationDuration, cacheCleanupInterval),
 		sync:                 redsync.New([]redsync.Pool{syncPool}),
+		metricsTTLSeconds:    int64(config.MetricsTTL.Seconds()),
 		source:               source,
 	}
 

--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -232,6 +232,11 @@ func (connector *DbConnector) RemoveMetricValues(metric string, toTime int64) er
 	return nil
 }
 
+// GetMetricsTTLSeconds returns maximum time in seconds to store metrics in Redis
+func (connector *DbConnector) GetMetricsTTLSeconds() int64 {
+	return connector.metricsTTLSeconds
+}
+
 // RemoveMetricsValues remove metrics timestamps values from 0 to given time
 func (connector *DbConnector) RemoveMetricsValues(metrics []string, toTime int64) error {
 	c := connector.pool.Get()

--- a/helpers.go
+++ b/helpers.go
@@ -195,3 +195,10 @@ func ChunkSlice(original []string, chunkSize int) (divided [][]string) {
 func RoundToNearestRetention(ts, retention int64) int64 {
 	return (ts + retention/2) / retention * retention
 }
+
+func MaxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -98,6 +98,7 @@ type Database interface {
 	GetMetricsValues(metrics []string, from int64, until int64) (map[string][]*MetricValue, error)
 	RemoveMetricValues(metric string, toTime int64) error
 	RemoveMetricsValues(metrics []string, toTime int64) error
+	GetMetricsTTLSeconds() int64
 
 	AddLocalTriggersToCheck(triggerIDs []string) error
 	GetLocalTriggersToCheck(count int) ([]string, error)

--- a/local/api.yml
+++ b/local/api.yml
@@ -3,6 +3,7 @@ redis:
   host: redis
   port: "6379"
   dbid: 0
+  metrics_ttl: 3h
 telemetry:
   graphite:
     enabled: true
@@ -18,6 +19,7 @@ remote:
   url: "http://graphite:80/render"
   check_interval: 60s
   timeout: 60s
+  metrics_ttl: 7d
 api:
   listen: ":8081"
   enable_cors: false

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -3,6 +3,7 @@ redis:
   host: redis
   port: "6379"
   dbid: 0
+  metrics_ttl: 3h
 telemetry:
   graphite:
     enabled: true
@@ -18,10 +19,10 @@ remote:
   url: "http://graphite:80/render"
   check_interval: 60s
   timeout: 60s
+  metrics_ttl: 7d
 checker:
   nodata_check_interval: 60s
   check_interval: 10s
-  metrics_ttl: 3h
   stop_checking_interval: 30s
 log:
   log_file: stdout

--- a/local/cli.yml
+++ b/local/cli.yml
@@ -2,6 +2,7 @@ redis:
   host: redis
   port: "6379"
   dbid: 0
+  metrics_ttl: 3h
 log_file: stdout
 log_level: debug
 

--- a/local/filter.yml
+++ b/local/filter.yml
@@ -3,6 +3,7 @@ redis:
   host: redis
   port: "6379"
   dbid: 0
+  metrics_ttl: 3h
 telemetry:
   graphite:
     enabled: true

--- a/local/notifier.yml
+++ b/local/notifier.yml
@@ -3,6 +3,7 @@ redis:
   host: redis
   port: "6379"
   dbid: 0
+  metrics_ttl: 3h
 telemetry:
   graphite:
     enabled: true
@@ -18,6 +19,7 @@ remote:
   url: "http://graphite:80/render"
   check_interval: 60s
   timeout: 60s
+  metrics_ttl: 7d
 notifier:
   sender_timeout: 10s
   resending_timeout: "1:00"

--- a/metric_source/local/local.go
+++ b/metric_source/local/local.go
@@ -106,6 +106,11 @@ func (local *Local) Fetch(target string, from int64, until int64, allowRealTimeA
 	return result, nil
 }
 
+// GetMetricsTTLSeconds returns metrics lifetime in Redis
+func (local *Local) GetMetricsTTLSeconds() int64 {
+	return local.dataBase.GetMetricsTTLSeconds()
+}
+
 // IsConfigured always returns true. It easy to configure local source =)
 func (local *Local) IsConfigured() (bool, error) {
 	return true, nil

--- a/metric_source/local/local.go
+++ b/metric_source/local/local.go
@@ -31,6 +31,10 @@ func Create(dataBase moira.Database) metricSource.MetricSource {
 
 // Fetch is analogue of evaluateTarget method in graphite-web, that gets target metrics value from DB and Evaluate it using carbon-api eval package
 func (local *Local) Fetch(target string, from int64, until int64, allowRealTimeAlerting bool) (metricSource.FetchResult, error) {
+	// Don't fetch intervals larger than metrics TTL to prevent OOM errors
+	// See https://github.com/moira-alert/moira/pull/519
+	from = moira.MaxInt64(from, until-local.dataBase.GetMetricsTTLSeconds())
+
 	result := CreateEmptyFetchResult()
 
 	targets := []string{target}

--- a/metric_source/remote/config.go
+++ b/metric_source/remote/config.go
@@ -6,6 +6,7 @@ import "time"
 type Config struct {
 	URL           string
 	CheckInterval time.Duration
+	MetricsTTL    time.Duration
 	Timeout       time.Duration
 	User          string
 	Password      string

--- a/metric_source/remote/remote.go
+++ b/metric_source/remote/remote.go
@@ -68,6 +68,11 @@ func (remote *Remote) Fetch(target string, from, until int64, allowRealTimeAlert
 	return &fetchResult, nil
 }
 
+// GetMetricsTTLSeconds returns maximum time interval that we are allowed to fetch from remote
+func (remote *Remote) GetMetricsTTLSeconds() int64 {
+	return int64(remote.config.MetricsTTL.Seconds())
+}
+
 // IsConfigured returns false in cases that user does not properly configure remote settings like graphite URL
 func (remote *Remote) IsConfigured() (bool, error) {
 	if remote.config.isEnabled() {

--- a/metric_source/remote/remote.go
+++ b/metric_source/remote/remote.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/moira-alert/moira"
 	metricSource "github.com/moira-alert/moira/metric_source"
 )
 
@@ -38,6 +39,10 @@ func Create(config *Config) metricSource.MetricSource {
 
 // Fetch fetches remote metrics and converts them to expected format
 func (remote *Remote) Fetch(target string, from, until int64, allowRealTimeAlerting bool) (metricSource.FetchResult, error) {
+	// Don't fetch intervals larger than metrics TTL to prevent OOM errors
+	// See https://github.com/moira-alert/moira/pull/519
+	from = moira.MaxInt64(from, until-int64(remote.config.MetricsTTL.Seconds()))
+
 	req, err := remote.prepareRequest(from, until, target)
 	if err != nil {
 		return nil, ErrRemoteTriggerResponse{

--- a/metric_source/source.go
+++ b/metric_source/source.go
@@ -3,6 +3,7 @@ package metricSource
 // MetricSource implements graphite metrics source abstraction
 type MetricSource interface {
 	Fetch(target string, from int64, until int64, allowRealTimeAlerting bool) (FetchResult, error)
+	GetMetricsTTLSeconds() int64
 	IsConfigured() (bool, error)
 }
 

--- a/mock/metric_source/source.go
+++ b/mock/metric_source/source.go
@@ -48,6 +48,20 @@ func (mr *MockMetricSourceMockRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockMetricSource)(nil).Fetch), arg0, arg1, arg2, arg3)
 }
 
+// GetMetricsTTLSeconds mocks base method
+func (m *MockMetricSource) GetMetricsTTLSeconds() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetricsTTLSeconds")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetMetricsTTLSeconds indicates an expected call of GetMetricsTTLSeconds
+func (mr *MockMetricSourceMockRecorder) GetMetricsTTLSeconds() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsTTLSeconds", reflect.TypeOf((*MockMetricSource)(nil).GetMetricsTTLSeconds))
+}
+
 // IsConfigured mocks base method
 func (m *MockMetricSource) IsConfigured() (bool, error) {
 	m.ctrl.T.Helper()

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -356,6 +356,20 @@ func (mr *MockDatabaseMockRecorder) GetMetricRetention(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricRetention", reflect.TypeOf((*MockDatabase)(nil).GetMetricRetention), arg0)
 }
 
+// GetMetricsTTLSeconds mocks base method
+func (m *MockDatabase) GetMetricsTTLSeconds() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetricsTTLSeconds")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetMetricsTTLSeconds indicates an expected call of GetMetricsTTLSeconds
+func (mr *MockDatabaseMockRecorder) GetMetricsTTLSeconds() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsTTLSeconds", reflect.TypeOf((*MockDatabase)(nil).GetMetricsTTLSeconds))
+}
+
 // GetMetricsUpdatesCount mocks base method
 func (m *MockDatabase) GetMetricsUpdatesCount() (int64, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# PR Summary

Some users specify a very large number in TTL field of a trigger with intent to disable TTL functionality. This is a wrong approach: instead, users should set a different state to replace NODATA (e.g. NODATA → OK).

We should not let users set trigger TTL to more than:

1. `MetricsTTLSeconds` from checker config for local triggers.
2. Some sensible predefined constant that prevents OOM for remote triggers. For example, 1 week.

**Don't forget to merge moira-alert/helmcharts#7**

### Note

Idea of this PR changed dramatically after additional research. Here is the original PR summary for historical purposes:

`lastCheck.Timestamp` denotes a most recent point in time when a trigger was checked. While checking trigger, we are interested only in metric points after `lastCheck.Timestamp`, because all previous points should have been checked during the previous check. There is no obvious reason to fetch more historical data points. At least, there is no test that shows why we should do that.

Why is this bad? Because we don't have any limits on TTL value set by user. Trying to fetch 1e15 metric points from a data source leads to OOM death of all checker instances.

Closes #190
