### PR TITLE
fix(api): enable reporting of why notifications were turned off

### DIFF
--- a/api/controller/health.go
+++ b/api/controller/health.go
@@ -8,14 +8,14 @@ import (
 
 // GetNotifierState return current notifier state
 func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorResponse) {
-	state, err := database.GetNotifierState()
+	state, message, err := database.GetNotifierState()
 	if err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}
 
-	notifierState := dto.NotifierState{State: state}
-	if state == moira.SelfStateERROR {
-		notifierState.Message = dto.ErrorMessage
+	notifierState := dto.NotifierState{State: state, Message: message}
+	if state == moira.SelfStateERROR && message == "" {
+		notifierState.Message = moira.SelfStateErrorMessage
 	}
 
 	return &notifierState, nil
@@ -23,7 +23,10 @@ func GetNotifierState(database moira.Database) (*dto.NotifierState, *api.ErrorRe
 
 // UpdateNotifierState update current notifier state
 func UpdateNotifierState(database moira.Database, state *dto.NotifierState) *api.ErrorResponse {
-	err := database.SetNotifierState(state.State)
+	if state.State == moira.SelfStateERROR && state.Message == "" {
+		state.Message = moira.SelfStateErrorMessage
+	}
+	err := database.SetNotifierState(state.State, state.Message)
 	if err != nil {
 		return api.ErrorInternalServer(err)
 	}

--- a/api/controller/health_test.go
+++ b/api/controller/health_test.go
@@ -17,7 +17,7 @@ func TestGetNotifierState(t *testing.T) {
 
 	Convey("On startup should return OK", t, func() {
 		expectedState := dto.NotifierState{State: moira.SelfStateOK}
-		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, nil)
+		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, moira.SelfStateOKMessage, nil)
 		actualState, err := GetNotifierState(dataBase)
 
 		So(*actualState, ShouldResemble, expectedState)
@@ -31,9 +31,9 @@ func TestUpdateNotifierState(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	Convey("Setting OK notifier state", t, func() {
-		expectedState := dto.NotifierState{State: moira.SelfStateOK}
-		dataBase.EXPECT().SetNotifierState(moira.SelfStateOK).Return(nil)
-		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, nil)
+		expectedState := dto.NotifierState{State: moira.SelfStateOK, Message: moira.SelfStateOKMessage}
+		dataBase.EXPECT().SetNotifierState(moira.SelfStateOK, moira.SelfStateOKMessage).Return(nil)
+		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, moira.SelfStateOKMessage, nil)
 
 		err := UpdateNotifierState(dataBase, &dto.NotifierState{State: moira.SelfStateOK})
 		So(err, ShouldBeNil)
@@ -44,16 +44,31 @@ func TestUpdateNotifierState(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
-	Convey("Setting ERROR notifier state", t, func() {
-		expectedState := dto.NotifierState{State: moira.SelfStateERROR, Message: dto.ErrorMessage}
-		dataBase.EXPECT().SetNotifierState(moira.SelfStateERROR).Return(nil)
-		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateERROR, nil)
+	Convey("Setting ERROR notifier state with no message", t, func() {
+		expectedState := dto.NotifierState{State: moira.SelfStateERROR, Message: moira.SelfStateErrorMessage}
+		dataBase.EXPECT().SetNotifierState(moira.SelfStateERROR, moira.SelfStateErrorMessage).Return(nil)
+		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateERROR, moira.SelfStateErrorMessage, nil)
 
-		err := UpdateNotifierState(dataBase, &dto.NotifierState{State: moira.SelfStateERROR})
+		err := UpdateNotifierState(dataBase, &dto.NotifierState{State: moira.SelfStateERROR, Message: ""})
 		So(err, ShouldBeNil)
 
 		actualState, err := GetNotifierState(dataBase)
 
+		So(*actualState, ShouldResemble, expectedState)
+		So(err, ShouldBeNil)
+	})
+
+
+	Convey("Setting ERROR notifier state with custom error message", t, func() {
+		message := "Moira has been turned off for routine maintenance"
+		expectedState := dto.NotifierState{State: moira.SelfStateERROR, Message: message}
+		dataBase.EXPECT().SetNotifierState(moira.SelfStateERROR, message).Return(nil)
+		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateERROR, message, nil)
+
+		err := UpdateNotifierState(dataBase, &dto.NotifierState{State: moira.SelfStateERROR, Message: message})
+		So(err, ShouldBeNil)
+
+		actualState, err := GetNotifierState(dataBase)
 		So(*actualState, ShouldResemble, expectedState)
 		So(err, ShouldBeNil)
 	})

--- a/api/dto/health.go
+++ b/api/dto/health.go
@@ -8,10 +8,6 @@ import (
 	"github.com/moira-alert/moira"
 )
 
-const (
-	ErrorMessage = "Something unexpected happened to Moira, so we temporarily turned off the notification mailing. We are already working on the problem and will fix it in the near future."
-)
-
 type NotifierState struct {
 	State   string `json:"state"`
 	Message string `json:"message,omitempty"`

--- a/database/redis/selfstate_test.go
+++ b/database/redis/selfstate_test.go
@@ -114,32 +114,36 @@ func TestNotifierState(t *testing.T) {
 	defer dataBase.flush()
 	Convey(fmt.Sprintf("Test on empty key '%v'", selfStateNotifierHealth), t, func() {
 		Convey("On empty database should return ERROR", func() {
-			notifierState, err := emptyDataBase.GetNotifierState()
+			notifierState, notifierMessage, err := emptyDataBase.GetNotifierState()
 			So(notifierState, ShouldEqual, moira.SelfStateERROR)
+			So(notifierMessage, ShouldEqual, moira.SelfStateErrorMessage)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("On real database should return OK", func() {
-			notifierState, err := dataBase.GetNotifierState()
+			notifierState, notifierMessage, err := dataBase.GetNotifierState()
 			So(notifierState, ShouldEqual, moira.SelfStateOK)
+			So(notifierMessage, ShouldEqual, moira.SelfStateOKMessage)
 			So(err, ShouldBeNil)
 		})
 	})
 
 	Convey(fmt.Sprintf("Test setting '%v' and reading it back", selfStateNotifierHealth), t, func() {
 		Convey("Switch notifier to OK", func() {
-			err := dataBase.SetNotifierState(moira.SelfStateOK)
-			actualNotifierState, err2 := dataBase.GetNotifierState()
+			err := dataBase.SetNotifierState(moira.SelfStateOK, moira.SelfStateOKMessage)
+			actualNotifierState, actualNotifierMessage, err2 := dataBase.GetNotifierState()
 
 			So(actualNotifierState, ShouldEqual, moira.SelfStateOK)
+			So(actualNotifierMessage, ShouldEqual, moira.SelfStateOKMessage)
 			So(err, ShouldBeNil)
 			So(err2, ShouldBeNil)
 		})
 
 		Convey("Switch notifier to ERROR", func() {
-			err := dataBase.SetNotifierState(moira.SelfStateERROR)
-			actualNotifierState, err2 := dataBase.GetNotifierState()
+			err := dataBase.SetNotifierState(moira.SelfStateERROR, moira.SelfStateErrorMessage)
+			actualNotifierState, actualNotifierMessage, err2 := dataBase.GetNotifierState()
 
 			So(actualNotifierState, ShouldEqual, moira.SelfStateERROR)
+			So(actualNotifierMessage, ShouldEqual, moira.SelfStateErrorMessage)
 			So(err, ShouldBeNil)
 			So(err2, ShouldBeNil)
 		})

--- a/interfaces.go
+++ b/interfaces.go
@@ -14,8 +14,8 @@ type Database interface {
 	GetMetricsUpdatesCount() (int64, error)
 	GetChecksUpdatesCount() (int64, error)
 	GetRemoteChecksUpdatesCount() (int64, error)
-	GetNotifierState() (string, error)
-	SetNotifierState(string) error
+	GetNotifierState() (state, message string, err error)
+	SetNotifierState(state, message string) error
 
 	// Tag storing
 	GetTagNames() ([]string, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -418,12 +418,13 @@ func (mr *MockDatabaseMockRecorder) GetNotifications(arg0, arg1 interface{}) *go
 }
 
 // GetNotifierState mocks base method
-func (m *MockDatabase) GetNotifierState() (string, error) {
+func (m *MockDatabase) GetNotifierState() (string, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotifierState")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetNotifierState indicates an expected call of GetNotifierState
@@ -1122,17 +1123,17 @@ func (mr *MockDatabaseMockRecorder) SaveTriggersSearchResults(arg0, arg1 interfa
 }
 
 // SetNotifierState mocks base method
-func (m *MockDatabase) SetNotifierState(arg0 string) error {
+func (m *MockDatabase) SetNotifierState(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetNotifierState", arg0)
+	ret := m.ctrl.Call(m, "SetNotifierState", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetNotifierState indicates an expected call of SetNotifierState
-func (mr *MockDatabaseMockRecorder) SetNotifierState(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) SetNotifierState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNotifierState", reflect.TypeOf((*MockDatabase)(nil).SetNotifierState), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNotifierState", reflect.TypeOf((*MockDatabase)(nil).SetNotifierState), arg0, arg1)
 }
 
 // SetTriggerCheckLock mocks base method

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -54,12 +54,12 @@ func (worker *FetchNotificationsWorker) Stop() error {
 }
 
 func (worker *FetchNotificationsWorker) processScheduledNotifications() error {
-	state, err := worker.Database.GetNotifierState()
+	state, message, err := worker.Database.GetNotifierState()
 	if err != nil {
 		return notifierInBadStateError("can't get current notifier state")
 	}
 	if state != moira.SelfStateOK {
-		return notifierInBadStateError(fmt.Sprintf("notifier in a bad state: %v", state))
+		return notifierInBadStateError(fmt.Sprintf("notifier in error state: %v", message))
 	}
 	notifications, err := worker.Database.FetchNotifications(time.Now().Unix())
 	if err != nil {

--- a/notifier/notifications/notifications_test.go
+++ b/notifier/notifications/notifications_test.go
@@ -90,7 +90,7 @@ func TestProcessScheduledEvent(t *testing.T) {
 		}
 		notifier.EXPECT().Send(&pkg1, gomock.Any())
 		notifier.EXPECT().Send(&pkg2, gomock.Any())
-		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, nil)
+		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, moira.SelfStateOKMessage, nil)
 		err := worker.processScheduledNotifications()
 		So(err, ShouldBeEmpty)
 	})
@@ -114,7 +114,7 @@ func TestProcessScheduledEvent(t *testing.T) {
 		}
 
 		notifier.EXPECT().Send(&pkg, gomock.Any())
-		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, nil)
+		dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, moira.SelfStateOKMessage, nil)
 		err := worker.processScheduledNotifications()
 		So(err, ShouldBeEmpty)
 	})
@@ -159,7 +159,7 @@ func TestGoRoutine(t *testing.T) {
 	dataBase.EXPECT().FetchNotifications(gomock.Any()).Return([]*moira.ScheduledNotification{&notification1}, nil)
 	notifier.EXPECT().Send(&pkg, gomock.Any()).Do(func(f ...interface{}) { close(shutdown) })
 	notifier.EXPECT().StopSenders()
-	dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, nil)
+	dataBase.EXPECT().GetNotifierState().Return(moira.SelfStateOK, moira.SelfStateOKMessage, nil)
 
 	worker.Start()
 	waitTestEnd(shutdown, worker)

--- a/senders/selfstate/selfstate.go
+++ b/senders/selfstate/selfstate.go
@@ -21,21 +21,21 @@ func (sender *Sender) Init(senderSettings map[string]string, logger moira.Logger
 
 // SendEvents implements Sender interface Send
 func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.ContactData, trigger moira.TriggerData, plot []byte, throttled bool) error {
-	selfState, err := sender.Database.GetNotifierState()
+	selfState, message, err := sender.Database.GetNotifierState()
 	if err != nil {
 		return fmt.Errorf("failed to get notifier state: %s", err.Error())
 	}
 	subjectState := events.GetSubjectState()
 	switch subjectState {
 	case moira.StateTEST:
-		sender.logger.Infof("current notifier state: %s", selfState)
+		sender.logger.Infof("current notifier state: %s - %v", selfState, message)
 		return nil
 	case moira.StateOK, moira.StateEXCEPTION:
 		sender.logger.Errorf("[trigger: %s] state %s is ignorable", trigger.ID, subjectState.String())
 		return nil
 	default:
 		if selfState != subjectState.ToSelfState() {
-			if err := sender.Database.SetNotifierState(moira.SelfStateERROR); err != nil {
+			if err := sender.Database.SetNotifierState(moira.SelfStateERROR, moira.SelfStateErrorMessage); err != nil {
 				return fmt.Errorf("failed to disable notifications: %s", err.Error())
 			}
 		}

--- a/state.go
+++ b/state.go
@@ -10,6 +10,8 @@ type TTLState string
 const (
 	SelfStateOK    = "OK"    // OK means notifier is healthy
 	SelfStateERROR = "ERROR" // ERROR means notifier is stopped, admin intervention is required
+	SelfStateOKMessage = ""
+	SelfStateErrorMessage = "Something unexpected happened to Moira, so we temporarily turned off the notification mailing."
 )
 
 // Moira trigger and metric states


### PR DESCRIPTION
# PR Summary
When Moira notifications are turned off, we show a default message (`dto.ErrorMessage`) and this isn't always helpful. Instead: 
- Let users describe their purpose when they disable notifications from the web UI. This is possible as the `NotifierState` struct already supports both `State` and `Message`.
- Log a more helpful message when Moira turns itself off but is still able to access the database (e.g `filter` receives no metrics for longer than last_metric_received_delay)

# Additional information
We need to add a text field to the `notifications` page for users to describe their purpose when disabling notifications. I plan to do that once the API changes are okay and merged.

Closes #469 
