### PR TITLE
[FIX] Division by zero situation 

### DIFF
--- a/metric_source/metric_data.go
+++ b/metric_source/metric_data.go
@@ -47,7 +47,12 @@ func (metricData *MetricData) GetTimestampValue(valueTimestamp int64) float64 {
 	if valueTimestamp < metricData.StartTime {
 		return math.NaN()
 	}
-	valueIndex := int((valueTimestamp - metricData.StartTime) / metricData.StepTime)
+	var valueIndex int
+	if metricData.StepTime != 0 {
+		valueIndex = int((valueTimestamp - metricData.StartTime) / metricData.StepTime)
+	} else {
+		valueIndex = int(math.Inf(0))
+	}
 	if len(metricData.Values) <= valueIndex {
 		return math.NaN()
 	}


### PR DESCRIPTION
# PR Summary

Error was caused due to division by zero, i.e. when step time is zero. So now, when this situation occurs  `valueIndex` is set to infinity.

**Closes issue**
#319 