### PR TITLE
[FIX] Matched actual and expected values

### DIFF
--- a/metric_source/remote/remote_test.go
+++ b/metric_source/remote/remote_test.go
@@ -77,6 +77,6 @@ func TestFetch(t *testing.T) {
 		remote := Remote{config: &Config{URL: url}}
 		result, err := remote.Fetch(target, from, until, false)
 		So(result, ShouldBeEmpty)
-		So(err.Error(), ShouldResemble, "parse \"💩%$&TR\": invalid URL escape \"%$&\"")
+		So(err.Error(), ShouldResemble, "parse 💩%$&TR: invalid URL escape \"%$&\"")
 	})
 }


### PR DESCRIPTION
# PR Summary

Fixed by removing `\"` to match the actual value.

**Closes issue**

#523 