### PR TITLE
feat(notifier): Add metrics for every possible state transition

### DIFF
--- a/metrics/interfaces.go
+++ b/metrics/interfaces.go
@@ -15,7 +15,7 @@ type Registry interface {
 
 // MetersCollection implements meter collection abstraction
 type MetersCollection interface {
-	RegisterMeter(name string, path ...string)
+	RegisterMeter(name string, path ...string) Meter
 	GetRegisteredMeter(name string) (Meter, bool)
 }
 
@@ -55,11 +55,12 @@ type DefaultMetersCollection struct {
 	mutex    sync.Mutex
 }
 
-func (source *DefaultMetersCollection) RegisterMeter(name string, path ...string) {
+func (source *DefaultMetersCollection) RegisterMeter(name string, path ...string) Meter {
 	source.mutex.Lock()
 	defer source.mutex.Unlock()
 
 	source.meters[name] = source.registry.NewMeter(path...)
+	return source.meters[name]
 }
 
 func (source *DefaultMetersCollection) GetRegisteredMeter(name string) (Meter, bool) {

--- a/metrics/notifier.go
+++ b/metrics/notifier.go
@@ -6,6 +6,7 @@ type NotifierMetrics struct {
 	EventsReceived         Meter
 	EventsMalformed        Meter
 	EventsProcessingFailed Meter
+	EventsByState          MetersCollection
 	SendingFailed          Meter
 	SendersOkMetrics       MetersCollection
 	SendersFailedMetrics   MetersCollection
@@ -18,6 +19,7 @@ func ConfigureNotifierMetrics(registry Registry, prefix string) *NotifierMetrics
 		EventsReceived:         registry.NewMeter("events", "received"),
 		EventsMalformed:        registry.NewMeter("events", "malformed"),
 		EventsProcessingFailed: registry.NewMeter("events", "failed"),
+		EventsByState:          NewMetersCollection(registry),
 		SendingFailed:          registry.NewMeter("sending", "failed"),
 		SendersOkMetrics:       NewMetersCollection(registry),
 		SendersFailedMetrics:   NewMetersCollection(registry),

--- a/notifier/events/event.go
+++ b/notifier/events/event.go
@@ -43,7 +43,15 @@ func (worker *FetchEventsWorker) Start() {
 						}
 						continue
 					}
+
 					worker.Metrics.EventsReceived.Mark(1)
+					stateMeterName := event.OldState.String() + "_to_" + event.State.String()
+					stateMeter, found := worker.Metrics.EventsByState.GetRegisteredMeter(stateMeterName)
+					if !found {
+						stateMeter = worker.Metrics.EventsByState.RegisterMeter(stateMeterName, "events", "bystate", stateMeterName)
+					}
+					stateMeter.Mark(1)
+
 					if err := worker.processEvent(event); err != nil {
 						worker.Metrics.EventsProcessingFailed.Mark(1)
 						worker.Logger.Errorf("Failed processEvent. %s", err)


### PR DESCRIPTION
# PR Summary

Additional metrics to help analyzing spikes of delivered notifications.

Metric names: `...events.bystate.OK_to_NODATA`, etc.

Frankly, I don't understand why we have meters instead of counters here. I added these metrics as meters to maintain uniformity.