### PR TITLE
Add team subscriptions and contacts

### DIFF
--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -1,19 +1,19 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid"
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/api"
 	"github.com/moira-alert/moira/api/dto"
 	"github.com/moira-alert/moira/database"
 	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestGetAllContacts(t *testing.T) {
@@ -62,76 +62,159 @@ func TestCreateContact(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	defer mockCtrl.Finish()
-	userLogin := "user" //nolint
+	const userLogin = "user"
+	const teamID = "team"
 
-	Convey("Success create", t, func() {
-		contact := &dto.Contact{
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-		err := CreateContact(dataBase, contact, userLogin)
-		So(err, ShouldBeNil)
-		So(contact.User, ShouldResemble, userLogin)
-	})
-
-	Convey("Success create contact with id", t, func() {
-		contact := dto.Contact{
-			ID:    uuid.Must(uuid.NewV4()).String(),
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		expectedContact := moira.ContactData{
-			ID:    contact.ID,
-			Value: contact.Value,
-			Type:  contact.Type,
-			User:  userLogin,
-		}
-		dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
-		dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-		err := CreateContact(dataBase, &contact, userLogin)
-		So(err, ShouldBeNil)
-		So(contact.User, ShouldResemble, userLogin)
-		So(contact.ID, ShouldResemble, contact.ID)
-	})
-
-	Convey("Contact exists by id", t, func() {
-		contact := &dto.Contact{
-			ID:    uuid.Must(uuid.NewV4()).String(),
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-		err := CreateContact(dataBase, contact, userLogin)
-		So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
-	})
-
-	Convey("Error get contact", t, func() {
-		contact := &dto.Contact{
-			ID:    uuid.Must(uuid.NewV4()).String(),
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		err := fmt.Errorf("oooops! Can not write contact")
-		dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-		expected := CreateContact(dataBase, contact, userLogin)
-		So(expected, ShouldResemble, api.ErrorInternalServer(err))
-	})
-
-	Convey("Error save contact", t, func() {
-		contact := &dto.Contact{
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		err := fmt.Errorf("oooops! Can not write contact")
-		dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-		expected := CreateContact(dataBase, contact, userLogin)
-		So(expected, ShouldResemble, &api.ErrorResponse{
-			ErrorText:      err.Error(),
-			HTTPStatusCode: 500,
-			StatusText:     "Internal Server Error",
-			Err:            err,
+	Convey("Create for user", t, func() {
+		Convey("Success", func() {
+			contact := &dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
+			err := CreateContact(dataBase, contact, userLogin, "")
+			So(err, ShouldBeNil)
+			So(contact.User, ShouldResemble, userLogin)
 		})
+
+		Convey("Success with id", func() {
+			contact := dto.Contact{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			expectedContact := moira.ContactData{
+				ID:    contact.ID,
+				Value: contact.Value,
+				Type:  contact.Type,
+				User:  userLogin,
+			}
+			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
+			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
+			err := CreateContact(dataBase, &contact, userLogin, "")
+			So(err, ShouldBeNil)
+			So(contact.User, ShouldResemble, userLogin)
+			So(contact.ID, ShouldResemble, contact.ID)
+		})
+
+		Convey("Contact exists by id", func() {
+			contact := &dto.Contact{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
+			err := CreateContact(dataBase, contact, userLogin, "")
+			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
+		})
+
+		Convey("Error get contact", func() {
+			contact := &dto.Contact{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			err := fmt.Errorf("oooops! Can not write contact")
+			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
+			expected := CreateContact(dataBase, contact, userLogin, "")
+			So(expected, ShouldResemble, api.ErrorInternalServer(err))
+		})
+
+		Convey("Error save contact", func() {
+			contact := &dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			err := fmt.Errorf("oooops! Can not write contact")
+			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
+			expected := CreateContact(dataBase, contact, userLogin, "")
+			So(expected, ShouldResemble, &api.ErrorResponse{
+				ErrorText:      err.Error(),
+				HTTPStatusCode: 500,
+				StatusText:     "Internal Server Error",
+				Err:            err,
+			})
+		})
+	})
+
+	Convey("Create for team", t, func() {
+		Convey("Success", func() {
+			contact := &dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
+			err := CreateContact(dataBase, contact, "", teamID)
+			So(err, ShouldBeNil)
+			So(contact.TeamID, ShouldResemble, teamID)
+		})
+
+		Convey("Success with id", func() {
+			contact := dto.Contact{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			expectedContact := moira.ContactData{
+				ID:    contact.ID,
+				Value: contact.Value,
+				Type:  contact.Type,
+				Team:  teamID,
+			}
+			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
+			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
+			err := CreateContact(dataBase, &contact, "", teamID)
+			So(err, ShouldBeNil)
+			So(contact.TeamID, ShouldResemble, teamID)
+			So(contact.ID, ShouldResemble, contact.ID)
+		})
+
+		Convey("Contact exists by id", func() {
+			contact := &dto.Contact{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
+			err := CreateContact(dataBase, contact, "", teamID)
+			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
+		})
+
+		Convey("Error get contact", func() {
+			contact := &dto.Contact{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			err := fmt.Errorf("oooops! Can not write contact")
+			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
+			expected := CreateContact(dataBase, contact, "", teamID)
+			So(expected, ShouldResemble, api.ErrorInternalServer(err))
+		})
+
+		Convey("Error save contact", func() {
+			contact := &dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			err := fmt.Errorf("oooops! Can not write contact")
+			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
+			expected := CreateContact(dataBase, contact, "", teamID)
+			So(expected, ShouldResemble, &api.ErrorResponse{
+				ErrorText:      err.Error(),
+				HTTPStatusCode: 500,
+				StatusText:     "Internal Server Error",
+				Err:            err,
+			})
+		})
+	})
+	Convey("Error on create with both: userLogin and teamID specified", t, func() {
+		contact := &dto.Contact{
+			Value: "some@mail.com",
+			Type:  "mail",
+		}
+		err := CreateContact(dataBase, contact, userLogin, teamID)
+		So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("CreateContact: cannot create contact when both userLogin and teamID specified")))
 	})
 }
 
@@ -139,102 +222,203 @@ func TestUpdateContact(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	defer mockCtrl.Finish()
-	userLogin := "user"
+	const userLogin = "user"
+	const teamID = "team"
 
-	Convey("Success update", t, func() {
-		contactDTO := dto.Contact{
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		contactID := uuid.Must(uuid.NewV4()).String()
-		contact := moira.ContactData{
-			Value: contactDTO.Value,
-			Type:  contactDTO.Type,
-			ID:    contactID,
-			User:  userLogin,
-		}
-		dataBase.EXPECT().SaveContact(&contact).Return(nil)
-		expectedContact, err := UpdateContact(dataBase, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
-		So(err, ShouldBeNil)
-		So(expectedContact.User, ShouldResemble, userLogin)
-		So(expectedContact.ID, ShouldResemble, contactID)
+	Convey("User update", t, func() {
+		Convey("Success", func() {
+			contactDTO := dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				User:  userLogin,
+			}
+			dataBase.EXPECT().SaveContact(&contact).Return(nil)
+			expectedContact, err := UpdateContact(dataBase, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			So(err, ShouldBeNil)
+			So(expectedContact.User, ShouldResemble, userLogin)
+			So(expectedContact.ID, ShouldResemble, contactID)
+		})
+
+		Convey("Error save", func() {
+			contactDTO := dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				User:  userLogin,
+			}
+			err := fmt.Errorf("oooops")
+			dataBase.EXPECT().SaveContact(&contact).Return(err)
+			expectedContact, actual := UpdateContact(dataBase, contactDTO, contact)
+			So(actual, ShouldResemble, api.ErrorInternalServer(err))
+			So(expectedContact.User, ShouldResemble, contactDTO.User)
+			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
+		})
 	})
+	Convey("Team update", t, func() {
+		Convey("Success", func() {
+			contactDTO := dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				Team:  teamID,
+			}
+			dataBase.EXPECT().SaveContact(&contact).Return(nil)
+			expectedContact, err := UpdateContact(dataBase, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			So(err, ShouldBeNil)
+			So(expectedContact.TeamID, ShouldResemble, teamID)
+			So(expectedContact.ID, ShouldResemble, contactID)
+		})
 
-	Convey("Error save", t, func() {
-		contactDTO := dto.Contact{
-			Value: "some@mail.com",
-			Type:  "mail",
-		}
-		contactID := uuid.Must(uuid.NewV4()).String()
-		contact := moira.ContactData{
-			Value: contactDTO.Value,
-			Type:  contactDTO.Type,
-			ID:    contactID,
-			User:  userLogin,
-		}
-		err := fmt.Errorf("oooops")
-		dataBase.EXPECT().SaveContact(&contact).Return(err)
-		expectedContact, actual := UpdateContact(dataBase, contactDTO, contact)
-		So(actual, ShouldResemble, api.ErrorInternalServer(err))
-		So(expectedContact.User, ShouldResemble, contactDTO.User)
-		So(expectedContact.ID, ShouldResemble, contactDTO.ID)
+		Convey("Error save", func() {
+			contactDTO := dto.Contact{
+				Value: "some@mail.com",
+				Type:  "mail",
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				Team:  teamID,
+			}
+			err := fmt.Errorf("oooops")
+			dataBase.EXPECT().SaveContact(&contact).Return(err)
+			expectedContact, actual := UpdateContact(dataBase, contactDTO, contact)
+			So(actual, ShouldResemble, api.ErrorInternalServer(err))
+			So(expectedContact.TeamID, ShouldResemble, contactDTO.TeamID)
+			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
+		})
 	})
 }
 
 func TestRemoveContact(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
-	userLogin := "user"
+	const userLogin = "user"
+	const teamID = "team"
 	contactID := uuid.Must(uuid.NewV4()).String()
 
-	Convey("Delete contact without user subscriptions", t, func() {
-		dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return(make([]string, 0), nil)
-		dataBase.EXPECT().GetSubscriptions(make([]string, 0)).Return(make([]*moira.SubscriptionData, 0), nil)
-		dataBase.EXPECT().RemoveContact(contactID).Return(nil)
-		err := RemoveContact(dataBase, contactID, userLogin)
-		So(err, ShouldBeNil)
-	})
-
-	Convey("Delete contact without contact subscriptions", t, func() {
-		subscription := &moira.SubscriptionData{
-			Contacts: []string{uuid.Must(uuid.NewV4()).String()},
-			ID:       uuid.Must(uuid.NewV4()).String(),
-		}
-
-		dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return([]string{subscription.ID}, nil)
-		dataBase.EXPECT().GetSubscriptions([]string{subscription.ID}).Return([]*moira.SubscriptionData{subscription}, nil)
-		dataBase.EXPECT().RemoveContact(contactID).Return(nil)
-		err := RemoveContact(dataBase, contactID, userLogin)
-		So(err, ShouldBeNil)
-	})
-
-	Convey("Error tests", t, func() {
-		Convey("GetUserSubscriptionIDs", func() {
-			expectedError := fmt.Errorf("oooops! Can not read user subscription ids")
-			dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return(nil, expectedError)
-			err := RemoveContact(dataBase, contactID, userLogin)
-			So(err, ShouldResemble, api.ErrorInternalServer(expectedError))
-		})
-		Convey("GetSubscriptions", func() {
-			expectedError := fmt.Errorf("oooops! Can not read user subscriptions")
+	Convey("Delete user contact", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+		Convey("Without subscriptions", func() {
 			dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return(make([]string, 0), nil)
-			dataBase.EXPECT().GetSubscriptions(make([]string, 0)).Return(nil, expectedError)
-			err := RemoveContact(dataBase, contactID, userLogin)
-			So(err, ShouldResemble, api.ErrorInternalServer(expectedError))
+			dataBase.EXPECT().GetSubscriptions(make([]string, 0)).Return(make([]*moira.SubscriptionData, 0), nil)
+			dataBase.EXPECT().RemoveContact(contactID).Return(nil)
+			err := RemoveContact(dataBase, contactID, userLogin, "")
+			So(err, ShouldBeNil)
 		})
-		Convey("Subscription has contact", func() {
-			subscription := moira.SubscriptionData{
-				Contacts: []string{contactID},
+
+		Convey("Without contact subscriptions", func() {
+			subscription := &moira.SubscriptionData{
+				Contacts: []string{uuid.Must(uuid.NewV4()).String()},
 				ID:       uuid.Must(uuid.NewV4()).String(),
-				Tags:     []string{"Tag1", "Tag2"},
 			}
-			subscriptionSubstring := fmt.Sprintf("%s (tags: %s)", subscription.ID, strings.Join(subscription.Tags, ", "))
-			expectedError := fmt.Errorf("this contact is being used in following subscriptions: %s", subscriptionSubstring)
+
 			dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return([]string{subscription.ID}, nil)
-			dataBase.EXPECT().GetSubscriptions([]string{subscription.ID}).Return([]*moira.SubscriptionData{&subscription}, nil)
-			err := RemoveContact(dataBase, contactID, userLogin)
-			So(err, ShouldResemble, api.ErrorInvalidRequest(expectedError))
+			dataBase.EXPECT().GetSubscriptions([]string{subscription.ID}).Return([]*moira.SubscriptionData{subscription}, nil)
+			dataBase.EXPECT().RemoveContact(contactID).Return(nil)
+			err := RemoveContact(dataBase, contactID, userLogin, "")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Error tests", func() {
+			Convey("GetUserSubscriptionIDs", func() {
+				expectedError := fmt.Errorf("oooops! Can not read user subscription ids")
+				dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return(nil, expectedError)
+				err := RemoveContact(dataBase, contactID, userLogin, "")
+				So(err, ShouldResemble, api.ErrorInternalServer(expectedError))
+			})
+			Convey("GetSubscriptions", func() {
+				expectedError := fmt.Errorf("oooops! Can not read user subscriptions")
+				dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return(make([]string, 0), nil)
+				dataBase.EXPECT().GetSubscriptions(make([]string, 0)).Return(nil, expectedError)
+				err := RemoveContact(dataBase, contactID, userLogin, "")
+				So(err, ShouldResemble, api.ErrorInternalServer(expectedError))
+			})
+			Convey("Subscription has contact", func() {
+				subscription := moira.SubscriptionData{
+					Contacts: []string{contactID},
+					ID:       uuid.Must(uuid.NewV4()).String(),
+					Tags:     []string{"Tag1", "Tag2"},
+				}
+				subscriptionSubstring := fmt.Sprintf("%s (tags: %s)", subscription.ID, strings.Join(subscription.Tags, ", "))
+				expectedError := fmt.Errorf("this contact is being used in following subscriptions: %s", subscriptionSubstring)
+				dataBase.EXPECT().GetUserSubscriptionIDs(userLogin).Return([]string{subscription.ID}, nil)
+				dataBase.EXPECT().GetSubscriptions([]string{subscription.ID}).Return([]*moira.SubscriptionData{&subscription}, nil)
+				err := RemoveContact(dataBase, contactID, userLogin, "")
+				So(err, ShouldResemble, api.ErrorInvalidRequest(expectedError))
+			})
+		})
+	})
+
+	Convey("Delete team contact", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+		Convey("Without subscriptions", func() {
+			dataBase.EXPECT().GetTeamSubscriptionIDs(teamID).Return(make([]string, 0), nil)
+			dataBase.EXPECT().GetSubscriptions(make([]string, 0)).Return(make([]*moira.SubscriptionData, 0), nil)
+			dataBase.EXPECT().RemoveContact(contactID).Return(nil)
+			err := RemoveContact(dataBase, contactID, "", teamID)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Without contact subscriptions", func() {
+			subscription := &moira.SubscriptionData{
+				Contacts: []string{uuid.Must(uuid.NewV4()).String()},
+				ID:       uuid.Must(uuid.NewV4()).String(),
+			}
+
+			dataBase.EXPECT().GetTeamSubscriptionIDs(teamID).Return([]string{subscription.ID}, nil)
+			dataBase.EXPECT().GetSubscriptions([]string{subscription.ID}).Return([]*moira.SubscriptionData{subscription}, nil)
+			dataBase.EXPECT().RemoveContact(contactID).Return(nil)
+			err := RemoveContact(dataBase, contactID, "", teamID)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Error tests", func() {
+			Convey("GetTeamSubscriptionIDs", func() {
+				expectedError := fmt.Errorf("oooops! Can not read team subscription ids")
+				dataBase.EXPECT().GetTeamSubscriptionIDs(teamID).Return(nil, expectedError)
+				err := RemoveContact(dataBase, contactID, "", teamID)
+				So(err, ShouldResemble, api.ErrorInternalServer(expectedError))
+			})
+			Convey("GetSubscriptions", func() {
+				expectedError := fmt.Errorf("oooops! Can not read team subscriptions")
+				dataBase.EXPECT().GetTeamSubscriptionIDs(teamID).Return(make([]string, 0), nil)
+				dataBase.EXPECT().GetSubscriptions(make([]string, 0)).Return(nil, expectedError)
+				err := RemoveContact(dataBase, contactID, "", teamID)
+				So(err, ShouldResemble, api.ErrorInternalServer(expectedError))
+			})
+			Convey("Subscription has contact", func() {
+				subscription := moira.SubscriptionData{
+					Contacts: []string{contactID},
+					ID:       uuid.Must(uuid.NewV4()).String(),
+					Tags:     []string{"Tag1", "Tag2"},
+				}
+				subscriptionSubstring := fmt.Sprintf("%s (tags: %s)", subscription.ID, strings.Join(subscription.Tags, ", "))
+				expectedError := fmt.Errorf("this contact is being used in following subscriptions: %s", subscriptionSubstring)
+				dataBase.EXPECT().GetTeamSubscriptionIDs(teamID).Return([]string{subscription.ID}, nil)
+				dataBase.EXPECT().GetSubscriptions([]string{subscription.ID}).Return([]*moira.SubscriptionData{&subscription}, nil)
+				err := RemoveContact(dataBase, contactID, "", teamID)
+				So(err, ShouldResemble, api.ErrorInvalidRequest(expectedError))
+			})
 		})
 	})
 }
@@ -264,6 +448,7 @@ func TestCheckUserPermissionsForContact(t *testing.T) {
 	defer mockCtrl.Finish()
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	userLogin := uuid.Must(uuid.NewV4()).String()
+	teamID := uuid.Must(uuid.NewV4()).String()
 	id := uuid.Must(uuid.NewV4()).String()
 
 	Convey("No contact", t, func() {
@@ -277,7 +462,7 @@ func TestCheckUserPermissionsForContact(t *testing.T) {
 		dataBase.EXPECT().GetContact(id).Return(moira.ContactData{User: "diffUser"}, nil)
 		expectedContact, expected := CheckUserPermissionsForContact(dataBase, id, userLogin)
 		So(expected, ShouldResemble, api.ErrorForbidden("you are not permitted"))
-		So(expectedContact, ShouldResemble, moira.ContactData{User: "diffUser"})
+		So(expectedContact, ShouldResemble, moira.ContactData{})
 	})
 
 	Convey("Has contact", t, func() {
@@ -293,6 +478,63 @@ func TestCheckUserPermissionsForContact(t *testing.T) {
 		dataBase.EXPECT().GetContact(id).Return(moira.ContactData{User: userLogin}, err)
 		expectedContact, expected := CheckUserPermissionsForContact(dataBase, id, userLogin)
 		So(expected, ShouldResemble, api.ErrorInternalServer(err))
-		So(expectedContact, ShouldResemble, moira.ContactData{User: userLogin})
+		So(expectedContact, ShouldResemble, moira.ContactData{})
+	})
+
+	Convey("Team contact", t, func() {
+		Convey("User is in team", func() {
+			expectedSub := moira.ContactData{ID: id, Team: teamID}
+			dataBase.EXPECT().GetContact(id).Return(expectedSub, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userLogin).Return(true, nil)
+			actual, err := CheckUserPermissionsForContact(dataBase, id, userLogin)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, expectedSub)
+		})
+		Convey("User is not in team", func() {
+			dataBase.EXPECT().GetContact(id).Return(moira.ContactData{ID: id, Team: teamID}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userLogin).Return(false, nil)
+			actual, err := CheckUserPermissionsForContact(dataBase, id, userLogin)
+			So(err, ShouldResemble, api.ErrorForbidden("you are not permitted"))
+			So(actual, ShouldResemble, moira.ContactData{})
+		})
+		Convey("Error while checking user team", func() {
+			errReturned := errors.New("test error")
+			dataBase.EXPECT().GetContact(id).Return(moira.ContactData{ID: id, Team: teamID}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userLogin).Return(false, errReturned)
+			actual, err := CheckUserPermissionsForContact(dataBase, id, userLogin)
+			So(err, ShouldResemble, api.ErrorInternalServer(errReturned))
+			So(actual, ShouldResemble, moira.ContactData{})
+		})
+	})
+}
+
+func Test_isContactExists(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+	const contactID = "testContact"
+	contact := moira.ContactData{ID: contactID}
+
+	Convey("isContactExists", t, func() {
+		Convey("contact exists", func() {
+			dataBase.EXPECT().GetContact(contactID).Return(contact, nil)
+			actual, err := isContactExists(dataBase, contactID)
+			So(actual, ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+		Convey("contact is not exist", func() {
+			dataBase.EXPECT().GetContact(contactID).Return(moira.ContactData{}, database.ErrNil)
+			actual, err := isContactExists(dataBase, contactID)
+			So(actual, ShouldBeFalse)
+			So(err, ShouldBeNil)
+		})
+		Convey("error returned", func() {
+			errReturned := errors.New("some error")
+			dataBase.EXPECT().GetContact(contactID).Return(moira.ContactData{}, errReturned)
+			actual, err := isContactExists(dataBase, contactID)
+			So(actual, ShouldBeFalse)
+			So(err, ShouldResemble, errReturned)
+		})
 	})
 }

--- a/api/controller/subscription_test.go
+++ b/api/controller/subscription_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestGetUserSubscriptions(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	database := mock_moira_alert.NewMockDatabase(mockCtrl)
-	login := "user"
+	const login = "user"
 
 	Convey("Two subscriptions", t, func() {
 		subscriptionIDs := []string{uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String()}
@@ -62,38 +63,70 @@ func TestGetUserSubscriptions(t *testing.T) {
 }
 
 func TestUpdateSubscription(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
-	defer mockCtrl.Finish()
-	userLogin := "user"
+	Convey("UpdateSubscription", t, func() {
+		mockCtrl := gomock.NewController(t)
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+		defer mockCtrl.Finish()
+		userLogin := "user"
+		teamID := "team"
 
-	Convey("Success update", t, func() {
-		subscriptionDTO := &dto.Subscription{}
-		subscriptionID := uuid.Must(uuid.NewV4()).String()
-		subscription := moira.SubscriptionData{
-			ID:   subscriptionID,
-			User: userLogin,
-		}
-		dataBase.EXPECT().SaveSubscription(&subscription).Return(nil)
-		err := UpdateSubscription(dataBase, subscriptionID, userLogin, subscriptionDTO)
-		So(err, ShouldBeNil)
-		So(subscriptionDTO.User, ShouldResemble, userLogin)
-		So(subscriptionDTO.ID, ShouldResemble, subscriptionID)
-	})
+		Convey("Success update for user", func() {
+			subscriptionDTO := &dto.Subscription{}
+			subscriptionID := uuid.Must(uuid.NewV4()).String()
+			subscription := moira.SubscriptionData{
+				ID:   subscriptionID,
+				User: userLogin,
+			}
+			dataBase.EXPECT().SaveSubscription(&subscription).Return(nil)
+			err := UpdateSubscription(dataBase, subscriptionID, userLogin, subscriptionDTO)
+			So(err, ShouldBeNil)
+			So(subscriptionDTO.User, ShouldResemble, userLogin)
+			So(subscriptionDTO.ID, ShouldResemble, subscriptionID)
+		})
 
-	Convey("Error save", t, func() {
-		subscriptionDTO := &dto.Subscription{}
-		subscriptionID := uuid.Must(uuid.NewV4()).String()
-		subscription := moira.SubscriptionData{
-			ID:   subscriptionID,
-			User: userLogin,
-		}
-		err := fmt.Errorf("oooops")
-		dataBase.EXPECT().SaveSubscription(&subscription).Return(err)
-		actual := UpdateSubscription(dataBase, subscriptionID, userLogin, subscriptionDTO)
-		So(actual, ShouldResemble, api.ErrorInternalServer(err))
-		So(subscriptionDTO.User, ShouldResemble, userLogin)
-		So(subscriptionDTO.ID, ShouldResemble, subscriptionID)
+		Convey("Error save for user", func() {
+			subscriptionDTO := &dto.Subscription{}
+			subscriptionID := uuid.Must(uuid.NewV4()).String()
+			subscription := moira.SubscriptionData{
+				ID:   subscriptionID,
+				User: userLogin,
+			}
+			err := fmt.Errorf("oooops")
+			dataBase.EXPECT().SaveSubscription(&subscription).Return(err)
+			actual := UpdateSubscription(dataBase, subscriptionID, userLogin, subscriptionDTO)
+			So(actual, ShouldResemble, api.ErrorInternalServer(err))
+			So(subscriptionDTO.User, ShouldResemble, userLogin)
+			So(subscriptionDTO.ID, ShouldResemble, subscriptionID)
+		})
+
+		Convey("Success update for team", func() {
+			subscriptionDTO := &dto.Subscription{TeamID: teamID}
+			subscriptionID := uuid.Must(uuid.NewV4()).String()
+			subscription := moira.SubscriptionData{
+				ID:     subscriptionID,
+				TeamID: teamID,
+			}
+			dataBase.EXPECT().SaveSubscription(&subscription).Return(nil)
+			err := UpdateSubscription(dataBase, subscriptionID, userLogin, subscriptionDTO)
+			So(err, ShouldBeNil)
+			So(subscriptionDTO.TeamID, ShouldResemble, teamID)
+			So(subscriptionDTO.ID, ShouldResemble, subscriptionID)
+		})
+
+		Convey("Error save for team", func() {
+			subscriptionDTO := &dto.Subscription{TeamID: teamID}
+			subscriptionID := uuid.Must(uuid.NewV4()).String()
+			subscription := moira.SubscriptionData{
+				ID:     subscriptionID,
+				TeamID: teamID,
+			}
+			err := fmt.Errorf("oooops")
+			dataBase.EXPECT().SaveSubscription(&subscription).Return(err)
+			actual := UpdateSubscription(dataBase, subscriptionID, userLogin, subscriptionDTO)
+			So(actual, ShouldResemble, api.ErrorInternalServer(err))
+			So(subscriptionDTO.TeamID, ShouldResemble, teamID)
+			So(subscriptionDTO.ID, ShouldResemble, subscriptionID)
+		})
 	})
 }
 
@@ -141,52 +174,107 @@ func TestCreateSubscription(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
-	login := "user"
+	const login = "user"
+	const teamID = "testTeam"
 
-	Convey("Success create", t, func() {
-		subscription := dto.Subscription{ID: ""}
-		dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
-		err := CreateSubscription(dataBase, login, &subscription)
-		So(err, ShouldBeNil)
+	Convey("Create for user", t, func() {
+		Convey("Success create", func() {
+			subscription := dto.Subscription{ID: ""}
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, login, "", &subscription)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Success create subscription with id", func() {
+			sub := &dto.Subscription{
+				ID: uuid.Must(uuid.NewV4()).String(),
+			}
+			dataBase.EXPECT().GetSubscription(sub.ID).Return(moira.SubscriptionData{}, database.ErrNil)
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, login, "", sub)
+			So(err, ShouldBeNil)
+			So(sub.User, ShouldResemble, login)
+			So(sub.ID, ShouldResemble, sub.ID)
+		})
+
+		Convey("Subscription exists by id", func() {
+			subscription := &dto.Subscription{
+				ID: uuid.Must(uuid.NewV4()).String(),
+			}
+			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, nil)
+			err := CreateSubscription(dataBase, login, "", subscription)
+			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("subscription with this ID already exists")))
+		})
+
+		Convey("Error get subscription", func() {
+			subscription := &dto.Subscription{
+				ID: uuid.Must(uuid.NewV4()).String(),
+			}
+			err := fmt.Errorf("oooops! Can not write contact")
+			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, err)
+			expected := CreateSubscription(dataBase, login, "", subscription)
+			So(expected, ShouldResemble, api.ErrorInternalServer(err))
+		})
+
+		Convey("Error save subscription", func() {
+			subscription := dto.Subscription{ID: ""}
+			expected := fmt.Errorf("oooops! Can not create subscription")
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(expected)
+			err := CreateSubscription(dataBase, login, "", &subscription)
+			So(err, ShouldResemble, api.ErrorInternalServer(expected))
+		})
 	})
+	Convey("Create for team", t, func() {
+		Convey("Success create", func() {
+			subscription := dto.Subscription{ID: ""}
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, "", teamID, &subscription)
+			So(err, ShouldBeNil)
+		})
 
-	Convey("Success create subscription with id", t, func() {
-		sub := &dto.Subscription{
-			ID: uuid.Must(uuid.NewV4()).String(),
-		}
-		dataBase.EXPECT().GetSubscription(sub.ID).Return(moira.SubscriptionData{}, database.ErrNil)
-		dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
-		err := CreateSubscription(dataBase, login, sub)
-		So(err, ShouldBeNil)
-		So(sub.User, ShouldResemble, login)
-		So(sub.ID, ShouldResemble, sub.ID)
+		Convey("Success create subscription with id", func() {
+			sub := &dto.Subscription{
+				ID: uuid.Must(uuid.NewV4()).String(),
+			}
+			dataBase.EXPECT().GetSubscription(sub.ID).Return(moira.SubscriptionData{}, database.ErrNil)
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, "", teamID, sub)
+			So(err, ShouldBeNil)
+			So(sub.TeamID, ShouldResemble, teamID)
+			So(sub.ID, ShouldResemble, sub.ID)
+		})
+
+		Convey("Subscription exists by id", func() {
+			subscription := &dto.Subscription{
+				ID: uuid.Must(uuid.NewV4()).String(),
+			}
+			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, nil)
+			err := CreateSubscription(dataBase, "", teamID, subscription)
+			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("subscription with this ID already exists")))
+		})
+
+		Convey("Error get subscription", func() {
+			subscription := &dto.Subscription{
+				ID: uuid.Must(uuid.NewV4()).String(),
+			}
+			err := fmt.Errorf("oooops! Can not write contact")
+			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, err)
+			expected := CreateSubscription(dataBase, "", teamID, subscription)
+			So(expected, ShouldResemble, api.ErrorInternalServer(err))
+		})
+
+		Convey("Error save subscription", func() {
+			subscription := dto.Subscription{ID: ""}
+			expected := fmt.Errorf("oooops! Can not create subscription")
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(expected)
+			err := CreateSubscription(dataBase, "", teamID, &subscription)
+			So(err, ShouldResemble, api.ErrorInternalServer(expected))
+		})
 	})
-
-	Convey("Subscription exists by id", t, func() {
-		subscription := &dto.Subscription{
-			ID: uuid.Must(uuid.NewV4()).String(),
-		}
-		dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, nil)
-		err := CreateSubscription(dataBase, login, subscription)
-		So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("subscription with this ID already exists")))
-	})
-
-	Convey("Error get subscription", t, func() {
-		subscription := &dto.Subscription{
-			ID: uuid.Must(uuid.NewV4()).String(),
-		}
-		err := fmt.Errorf("oooops! Can not write contact")
-		dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, err)
-		expected := CreateSubscription(dataBase, login, subscription)
-		So(expected, ShouldResemble, api.ErrorInternalServer(err))
-	})
-
-	Convey("Error save subscription", t, func() {
-		subscription := dto.Subscription{ID: ""}
-		expected := fmt.Errorf("oooops! Can not create subscription")
-		dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(expected)
-		err := CreateSubscription(dataBase, login, &subscription)
-		So(err, ShouldResemble, api.ErrorInternalServer(expected))
+	Convey("Error on create with both: userLogin and teamID specified", t, func() {
+		subscription := &dto.Subscription{}
+		err := CreateSubscription(dataBase, login, teamID, subscription)
+		So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("CreateSubscription: cannot create subscription when both userLogin and teamID specified")))
 	})
 }
 
@@ -195,6 +283,7 @@ func TestCheckUserPermissionsForSubscription(t *testing.T) {
 	defer mockCtrl.Finish()
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	userLogin := uuid.Must(uuid.NewV4()).String()
+	teamID := uuid.Must(uuid.NewV4()).String()
 	id := uuid.Must(uuid.NewV4()).String()
 
 	Convey("No subscription", t, func() {
@@ -209,7 +298,7 @@ func TestCheckUserPermissionsForSubscription(t *testing.T) {
 		dataBase.EXPECT().GetSubscription(id).Return(actualSub, nil)
 		expectedSub, expected := CheckUserPermissionsForSubscription(dataBase, id, userLogin)
 		So(expected, ShouldResemble, api.ErrorForbidden("you are not permitted"))
-		So(expectedSub, ShouldResemble, actualSub)
+		So(expectedSub, ShouldResemble, moira.SubscriptionData{})
 	})
 
 	Convey("Has subscription", t, func() {
@@ -217,7 +306,7 @@ func TestCheckUserPermissionsForSubscription(t *testing.T) {
 		dataBase.EXPECT().GetSubscription(id).Return(actualSub, nil)
 		expectedSub, expected := CheckUserPermissionsForSubscription(dataBase, id, userLogin)
 		So(expected, ShouldBeNil)
-		So(expectedSub, ShouldResemble, actualSub)
+		So(expectedSub, ShouldResemble, moira.SubscriptionData{})
 	})
 
 	Convey("Error get contact", t, func() {
@@ -226,5 +315,62 @@ func TestCheckUserPermissionsForSubscription(t *testing.T) {
 		expectedSub, expected := CheckUserPermissionsForSubscription(dataBase, id, userLogin)
 		So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		So(expectedSub, ShouldResemble, moira.SubscriptionData{})
+	})
+
+	Convey("Team subscription", t, func() {
+		Convey("User is in team", func() {
+			expectedSub := moira.SubscriptionData{ID: id, TeamID: teamID}
+			dataBase.EXPECT().GetSubscription(id).Return(expectedSub, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userLogin).Return(true, nil)
+			actual, err := CheckUserPermissionsForSubscription(dataBase, id, userLogin)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, expectedSub)
+		})
+		Convey("User is not in team", func() {
+			dataBase.EXPECT().GetSubscription(id).Return(moira.SubscriptionData{ID: id, TeamID: teamID}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userLogin).Return(false, nil)
+			actual, err := CheckUserPermissionsForSubscription(dataBase, id, userLogin)
+			So(err, ShouldResemble, api.ErrorForbidden("you are not permitted"))
+			So(actual, ShouldResemble, moira.SubscriptionData{})
+		})
+		Convey("Error while checking user team", func() {
+			errReturned := errors.New("test error")
+			dataBase.EXPECT().GetSubscription(id).Return(moira.SubscriptionData{ID: id, TeamID: teamID}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userLogin).Return(false, errReturned)
+			actual, err := CheckUserPermissionsForSubscription(dataBase, id, userLogin)
+			So(err, ShouldResemble, api.ErrorInternalServer(errReturned))
+			So(actual, ShouldResemble, moira.SubscriptionData{})
+		})
+	})
+}
+
+func Test_isSubscriptionExists(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+	subscriptionID := "testSubscription"
+	subscription := moira.SubscriptionData{ID: subscriptionID}
+
+	Convey("isSubscriptionExists", t, func() {
+		Convey("subscription exists", func() {
+			dataBase.EXPECT().GetSubscription(subscriptionID).Return(subscription, nil)
+			actual, err := isSubscriptionExists(dataBase, subscriptionID)
+			So(actual, ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+		Convey("subscription is not exist", func() {
+			dataBase.EXPECT().GetSubscription(subscriptionID).Return(moira.SubscriptionData{}, database.ErrNil)
+			actual, err := isSubscriptionExists(dataBase, subscriptionID)
+			So(actual, ShouldBeFalse)
+			So(err, ShouldBeNil)
+		})
+		Convey("error returned", func() {
+			errReturned := errors.New("some error")
+			dataBase.EXPECT().GetSubscription(subscriptionID).Return(moira.SubscriptionData{}, errReturned)
+			actual, err := isSubscriptionExists(dataBase, subscriptionID)
+			So(actual, ShouldBeFalse)
+			So(err, ShouldResemble, errReturned)
+		})
 	})
 }

--- a/api/controller/team.go
+++ b/api/controller/team.go
@@ -1,0 +1,387 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/gofrs/uuid"
+	"github.com/gomodule/redigo/redis"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/dto"
+	"github.com/moira-alert/moira/database"
+)
+
+const teamIDCreateRetries = 3
+
+// CreateTeam is a controller function that creates a new team in Moira
+func CreateTeam(dataBase moira.Database, team dto.TeamModel, userID string) (dto.SaveTeamResponse, *api.ErrorResponse) {
+	var teamID string
+	if team.ID != "" { // if teamID is specified in request data then check that team with this id is not exist
+		teamID = team.ID
+		_, err := dataBase.GetTeam(teamID)
+		if err == nil {
+			return dto.SaveTeamResponse{}, api.ErrorInvalidRequest(fmt.Errorf("team with ID you specified already exists %s", teamID))
+		}
+		if err != nil && err != database.ErrNil {
+			return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot check id for team: %w", err))
+		}
+	} else { // on the other hand try to create an UUID for teamID
+		createdSuccessfully := false
+		for i := 0; i < teamIDCreateRetries; i++ { // trying three times to create an UUID and check if it exists
+			generatedUUID, err := uuid.NewV4()
+			if err != nil {
+				return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot generate id for team: %w", err))
+			}
+			teamID = generatedUUID.String()
+			_, err = dataBase.GetTeam(teamID)
+			if err == database.ErrNil {
+				createdSuccessfully = true
+				break
+			}
+			if err != nil {
+				return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot check id for team: %w", err))
+			}
+		}
+		if !createdSuccessfully {
+			return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot generate unique id for team"))
+		}
+	}
+	err := dataBase.SaveTeam(teamID, team.ToMoiraTeam())
+	if err != nil {
+		return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot save team: %w", err))
+	}
+
+	teamsMap, apiErr := addTeamsForNewUsers(dataBase, teamID, map[string]bool{userID: true}, map[string][]string{})
+	if err != nil {
+		return dto.SaveTeamResponse{}, apiErr
+	}
+
+	err = dataBase.SaveTeamsAndUsers(teamID, []string{userID}, teamsMap)
+	if err != nil {
+		return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot save team users: %w", err))
+	}
+
+	return dto.SaveTeamResponse{ID: teamID}, nil
+}
+
+// GetTeam is a controller function that returns a team by it's ID
+func GetTeam(dataBase moira.Database, teamID string) (dto.TeamModel, *api.ErrorResponse) {
+	team, err := dataBase.GetTeam(teamID)
+
+	if err != nil {
+		if err == database.ErrNil {
+			return dto.TeamModel{}, api.ErrorNotFound(fmt.Sprintf("cannot find team: %s", teamID))
+		}
+		return dto.TeamModel{}, api.ErrorInternalServer(fmt.Errorf("cannot get team from database: %w", err))
+	}
+
+	teamModel := dto.NewTeamModel(team)
+	return teamModel, nil
+}
+
+// GetUserTeams is a controller function that returns a teams in which user is a member bu user ID
+func GetUserTeams(dataBase moira.Database, userID string) (dto.UserTeams, *api.ErrorResponse) {
+	teams, err := dataBase.GetUserTeams(userID)
+
+	result := []dto.TeamModel{}
+	if err != nil && err != database.ErrNil {
+		return dto.UserTeams{}, api.ErrorInternalServer(fmt.Errorf("cannot get user teams from database: %w", err))
+	}
+
+	for _, teamID := range teams {
+		team, err := dataBase.GetTeam(teamID)
+		if err != nil {
+			return dto.UserTeams{}, api.ErrorInternalServer(fmt.Errorf("cannot retrieve team from database: %w", err))
+		}
+		teamModel := dto.NewTeamModel(team)
+		result = append(result, teamModel)
+	}
+
+	return dto.UserTeams{Teams: result}, nil
+}
+
+// GetTeamUsers is a controller function that returns a users of team by team ID
+func GetTeamUsers(dataBase moira.Database, teamID string) (dto.TeamMembers, *api.ErrorResponse) {
+	users, err := dataBase.GetTeamUsers(teamID)
+
+	if err != nil {
+		if err == database.ErrNil {
+			return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("cannot find team users: %s", teamID))
+		}
+		return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", err))
+	}
+
+	result := dto.TeamMembers{
+		Usernames: users,
+	}
+	return result, nil
+}
+
+func fillCurrentUsersTeamsMap(dataBase moira.Database, existingUsers []string) (map[string][]string, *api.ErrorResponse) {
+	result := map[string][]string{}
+	for _, userID := range existingUsers {
+		fetchedUserTeams, err := dataBase.GetUserTeams(userID)
+		if err != nil {
+			return nil, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", err))
+		}
+		result[userID] = fetchedUserTeams
+	}
+	return result, nil
+}
+
+func removeDeletedUsers(teamID string, existingUsers []string, newUsers map[string]bool, teamsMap map[string][]string) (map[string][]string, *api.ErrorResponse) {
+	for _, userID := range existingUsers {
+		if newUsers[userID] {
+			continue
+		}
+		userRemovedTeams, err := removeUserTeam(teamsMap[userID], teamID)
+		if err != nil {
+			return nil, api.ErrorInternalServer(fmt.Errorf("cannot remove team from user: %w", err))
+		}
+		teamsMap[userID] = userRemovedTeams
+	}
+	return teamsMap, nil
+}
+
+func addTeamsForNewUsers(dataBase moira.Database, teamID string, newUsers map[string]bool, teamsMap map[string][]string) (map[string][]string, *api.ErrorResponse) {
+	for userID := range newUsers {
+		// Skip users that already were in this team
+		if _, ok := teamsMap[userID]; ok {
+			continue
+		}
+		fetchedUserTeams, err := dataBase.GetUserTeams(userID) //nolint: shadow
+		if err != nil && err != database.ErrNil {
+			return nil, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", err))
+		}
+		fetchedUserTeams = append(fetchedUserTeams, teamID)
+		teamsMap[userID] = fetchedUserTeams
+	}
+	return teamsMap, nil
+}
+
+// SetTeamUsers is a controller function that sets all users for team
+func SetTeamUsers(dataBase moira.Database, teamID string, allUsers []string) (dto.TeamMembers, *api.ErrorResponse) {
+	existingUsers, err := dataBase.GetTeamUsers(teamID)
+	if err != nil {
+		if err == database.ErrNil {
+			return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("cannot find team users: %s", teamID))
+		}
+		return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", err))
+	}
+	/*
+		This map will contain final list of all users and all teams of each user that were affected by this update.
+		After we will have a map like
+		{
+			"existingUser1": {"currentTeam", "team1", "team2"},
+			"userThatWillBeDeleted": {"currentTeam", "team2"}
+		}
+	*/
+	teamsMap, apiError := fillCurrentUsersTeamsMap(dataBase, existingUsers)
+	if apiError != nil {
+		return dto.TeamMembers{}, apiError
+	}
+
+	allUsersMap := map[string]bool{}
+
+	// Collect a set of all new users
+	for _, userID := range allUsers {
+		allUsersMap[userID] = true
+	}
+
+	/* Here we will find a users that do not exist in new users list
+	and remove their teams from
+	after that our teams map will be like this:
+	{
+		"existingUser1": {"currentTeam", "team1", "team2"},
+		"userThatWillBeDeleted": {"team2"}
+	}
+	*/
+	teamsMap, apiError = removeDeletedUsers(teamID, existingUsers, allUsersMap, teamsMap)
+	if apiError != nil {
+		return dto.TeamMembers{}, apiError
+	}
+
+	/*
+		For all new users we need to retrieve their actual teams and add current team after thi teams map will look like this:
+			{
+			"existingUser1": {"currentTeam", "team1", "team2"},
+			"userThatWillBeDeleted": {"team2"},
+			"newUser": {"existingTeam", "currentTeam"}
+		}
+	*/
+	teamsMap, apiError = addTeamsForNewUsers(dataBase, teamID, allUsersMap, teamsMap)
+	if apiError != nil {
+		return dto.TeamMembers{}, apiError
+	}
+
+	err = dataBase.SaveTeamsAndUsers(teamID, allUsers, teamsMap)
+	if err != nil {
+		api.ErrorInternalServer(fmt.Errorf("cannot save users for team: %s %w", teamID, err))
+	}
+
+	result := dto.TeamMembers{
+		Usernames: allUsers,
+	}
+	return result, nil
+}
+
+func addUserTeam(teamID string, teams []string) ([]string, error) {
+	for _, currentTeamID := range teams {
+		if teamID == currentTeamID {
+			return []string{}, fmt.Errorf("team already exist in user teams: %s", teamID)
+		}
+	}
+	teams = append(teams, teamID)
+	return teams, nil
+}
+
+// AddTeamUsers is a controller function that adds a users to certain team
+func AddTeamUsers(dataBase moira.Database, teamID string, newUsers []string) (dto.TeamMembers, *api.ErrorResponse) {
+	existingUsers, err := dataBase.GetTeamUsers(teamID)
+	if err != nil {
+		if err == database.ErrNil {
+			return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("cannot find team users: %s", teamID))
+		}
+		return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", err))
+	}
+
+	teamsMap := map[string][]string{}
+	finalUsers := []string{}
+
+	for _, userID := range existingUsers {
+		userTeams, err := dataBase.GetUserTeams(userID) //nolint:shadow
+		if err != nil {
+			if err == database.ErrNil {
+				return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("cannot find user teams: %s", userID))
+			}
+			return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get user teams from database: %w", err))
+		}
+		teamsMap[userID] = userTeams
+		finalUsers = append(finalUsers, userID)
+	}
+
+	for _, userID := range newUsers {
+		if _, ok := teamsMap[userID]; ok {
+			return dto.TeamMembers{}, api.ErrorInvalidRequest(fmt.Errorf("one ore many users you specified are already exist in this team: %s", userID))
+		}
+
+		userTeams, err := dataBase.GetUserTeams(userID) //nolint:shadow
+		if err != nil && err != redis.ErrNil {
+			return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get user teams from database: %w", err))
+		}
+
+		userTeams, err = addUserTeam(teamID, userTeams)
+		if err != nil {
+			return dto.TeamMembers{}, api.ErrorInvalidRequest(fmt.Errorf("cannot save new team for user: %s, %w", userID, err))
+		}
+
+		teamsMap[userID] = userTeams
+		finalUsers = append(finalUsers, userID)
+	}
+
+	err = dataBase.SaveTeamsAndUsers(teamID, finalUsers, teamsMap)
+	if err != nil {
+		api.ErrorInternalServer(fmt.Errorf("cannot save users for team: %s %w", teamID, err))
+	}
+
+	result := dto.TeamMembers{
+		Usernames: finalUsers,
+	}
+	return result, nil
+}
+
+// UpdateTeam is a controller function that updates an existing team in Moira
+func UpdateTeam(dataBase moira.Database, teamID string, team dto.TeamModel) (dto.SaveTeamResponse, *api.ErrorResponse) {
+	err := dataBase.SaveTeam(teamID, team.ToMoiraTeam())
+	if err != nil {
+		return dto.SaveTeamResponse{}, api.ErrorInternalServer(fmt.Errorf("cannot save team: %w", err))
+	}
+	return dto.SaveTeamResponse{ID: teamID}, nil
+}
+
+// DeleteTeamUser is a controller function that removes a user from certain team
+func DeleteTeamUser(dataBase moira.Database, teamID string, removeUserID string) (dto.TeamMembers, *api.ErrorResponse) {
+	existingUsers, err := dataBase.GetTeamUsers(teamID)
+	if err != nil {
+		if err == database.ErrNil {
+			return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("cannot find team users: %s", teamID))
+		}
+		return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", err))
+	}
+
+	if len(existingUsers) <= 1 {
+		return dto.TeamMembers{}, api.ErrorInvalidRequest(fmt.Errorf("cannot remove last member of team"))
+	}
+
+	userFound := false
+	for _, userID := range existingUsers {
+		if userID == removeUserID {
+			userFound = true
+		}
+	}
+	if !userFound {
+		return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("user that you specified not found in this team: %s", removeUserID))
+	}
+
+	teamsMap := map[string][]string{}
+	finalUsers := []string{}
+
+	for _, userID := range existingUsers {
+		userTeams, err := dataBase.GetUserTeams(userID) //nolint:shadow
+		if err != nil {
+			if err == database.ErrNil {
+				return dto.TeamMembers{}, api.ErrorNotFound(fmt.Sprintf("cannot find user teams: %s", userID))
+			}
+			return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot get user teams from database: %w", err))
+		}
+		if userID == removeUserID {
+			userTeams, err = removeUserTeam(userTeams, teamID)
+			if err != nil {
+				return dto.TeamMembers{}, api.ErrorInternalServer(fmt.Errorf("cannot remove team from user: %w", err))
+			}
+		} else {
+			finalUsers = append(finalUsers, userID)
+		}
+		teamsMap[userID] = userTeams
+	}
+
+	err = dataBase.SaveTeamsAndUsers(teamID, finalUsers, teamsMap)
+	if err != nil {
+		api.ErrorInternalServer(fmt.Errorf("cannot save users for team: %s %w", teamID, err))
+	}
+
+	result := dto.TeamMembers{
+		Usernames: finalUsers,
+	}
+	return result, nil
+}
+
+func removeUserTeam(teams []string, teamID string) ([]string, error) {
+	for i, currentTeamID := range teams {
+		if teamID == currentTeamID {
+			teams[i] = teams[len(teams)-1]   // Copy last element to index i.
+			teams[len(teams)-1] = ""         // Erase last element (write zero value).
+			return teams[:len(teams)-1], nil // Truncate slice.
+		}
+	}
+	return []string{}, fmt.Errorf("cannot find team in user teams: %s", teamID)
+}
+
+func CheckUserPermissionsForTeam(dataBase moira.Database, teamID, userID string) *api.ErrorResponse {
+	_, err := dataBase.GetTeam(teamID)
+	if err != nil {
+		if err == database.ErrNil {
+			return api.ErrorNotFound(fmt.Sprintf("team with ID '%s' does not exists", teamID))
+		}
+		return api.ErrorInternalServer(err)
+	}
+
+	userIsTeamMember, err := dataBase.IsTeamContainUser(teamID, userID)
+	if err != nil {
+		return api.ErrorInternalServer(err)
+	}
+	if !userIsTeamMember {
+		return api.ErrorForbidden("you are not permitted to manipulate with this team")
+	}
+	return nil
+}

--- a/api/controller/team_test.go
+++ b/api/controller/team_test.go
@@ -1,0 +1,555 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/dto"
+	"github.com/moira-alert/moira/database"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCreateTeam(t *testing.T) {
+	Convey("CreateTeam", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const user = "userID"
+		team := dto.TeamModel{Name: "testTeam", Description: "test team description"}
+
+		Convey("create successfully", func() {
+			ID := ""
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, database.ErrNil)
+			dataBase.EXPECT().SaveTeam(gomock.Any(), team.ToMoiraTeam()).DoAndReturn(func(teamID string, moiraTeam moira.Team) error {
+				ID = teamID
+				return nil
+			})
+			dataBase.EXPECT().GetUserTeams(user).Return([]string{ID}, nil)
+			dataBase.EXPECT().SaveTeamsAndUsers(gomock.Any(), []string{user}, gomock.Any()).Return(nil)
+			response, err := CreateTeam(dataBase, team, user)
+			So(response.ID, ShouldResemble, ID)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("create successfully with ID", func() {
+			teamID := "teamID"
+			team.ID = teamID
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, database.ErrNil)
+			dataBase.EXPECT().SaveTeam(teamID, team.ToMoiraTeam()).Return(nil)
+			dataBase.EXPECT().GetUserTeams(user).Return([]string{}, nil)
+			dataBase.EXPECT().SaveTeamsAndUsers(teamID, []string{user}, map[string][]string{user: {teamID}}).Return(nil)
+			response, err := CreateTeam(dataBase, team, user)
+			So(response.ID, ShouldResemble, teamID)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("team with this UUID exists", func() {
+			ID := ""
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, nil)
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, database.ErrNil)
+			dataBase.EXPECT().SaveTeam(gomock.Any(), team.ToMoiraTeam()).DoAndReturn(func(teamID string, moiraTeam moira.Team) error {
+				ID = teamID
+				return nil
+			})
+			dataBase.EXPECT().GetUserTeams(user).Return([]string{ID}, nil)
+			dataBase.EXPECT().SaveTeamsAndUsers(gomock.Any(), []string{user}, gomock.Any()).Return(nil)
+			response, err := CreateTeam(dataBase, team, user)
+			So(response.ID, ShouldResemble, ID)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("team with this UUID exists and all retries failed", func() {
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, nil)
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, nil)
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, nil)
+			response, err := CreateTeam(dataBase, team, user)
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot generate unique id for team")))
+			So(response, ShouldResemble, dto.SaveTeamResponse{})
+		})
+
+		Convey("save error", func() {
+			returnErr := fmt.Errorf("unexpected error")
+			dataBase.EXPECT().GetTeam(gomock.Any()).Return(moira.Team{}, database.ErrNil)
+			dataBase.EXPECT().SaveTeam(gomock.Any(), team.ToMoiraTeam()).Return(returnErr)
+			response, err := CreateTeam(dataBase, team, user)
+			So(response, ShouldResemble, dto.SaveTeamResponse{})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot save team: %w", returnErr)))
+		})
+	})
+}
+
+func TestGetTeam(t *testing.T) {
+	Convey("GetTeam", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		team := moira.Team{Name: "testTeam", Description: "test team description"}
+
+		Convey("get successfully", func() {
+			dataBase.EXPECT().GetTeam(teamID).Return(team, nil)
+			response, err := GetTeam(dataBase, teamID)
+			So(response, ShouldResemble, dto.NewTeamModel(team))
+			So(err, ShouldBeNil)
+		})
+
+		Convey("team not found", func() {
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, database.ErrNil)
+			response, err := GetTeam(dataBase, teamID)
+			So(response, ShouldResemble, dto.TeamModel{})
+			So(err, ShouldResemble, api.ErrorNotFound("cannot find team: testTeam"))
+		})
+
+		Convey("database error", func() {
+			returnErr := fmt.Errorf("unexpected error")
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, returnErr)
+			response, err := GetTeam(dataBase, teamID)
+			So(response, ShouldResemble, dto.TeamModel{})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot get team from database: %w", returnErr)))
+		})
+	})
+}
+
+func TestGetUserTeams(t *testing.T) {
+	Convey("GetUserTeams", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const userID = "userID"
+		const teamID = "team1"
+		const teamID2 = "team2"
+		teamsIDs := []string{teamID, teamID2}
+		teams := []dto.TeamModel{
+			{
+				ID:          teamID,
+				Name:        "team 1 name",
+				Description: "team 1 Description",
+			},
+			{
+				ID:          teamID2,
+				Name:        "team 2 name",
+				Description: "team 2 Description",
+			},
+		}
+
+		Convey("get successfully", func() {
+			dataBase.EXPECT().GetUserTeams(userID).Return(teamsIDs, nil)
+			dataBase.EXPECT().GetTeam(teamID).Return(teams[0].ToMoiraTeam(), nil)
+			dataBase.EXPECT().GetTeam(teamID2).Return(teams[1].ToMoiraTeam(), nil)
+			response, err := GetUserTeams(dataBase, userID)
+			So(response, ShouldResemble, dto.UserTeams{Teams: teams})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("teams not found", func() {
+			dataBase.EXPECT().GetUserTeams(userID).Return([]string{}, database.ErrNil)
+			response, err := GetUserTeams(dataBase, userID)
+			So(response, ShouldResemble, dto.UserTeams{Teams: []dto.TeamModel{}})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("database error", func() {
+			returnErr := fmt.Errorf("unexpected error")
+			dataBase.EXPECT().GetUserTeams(userID).Return([]string{}, returnErr)
+			response, err := GetUserTeams(dataBase, userID)
+			So(response, ShouldResemble, dto.UserTeams{})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot get user teams from database: %w", returnErr)))
+		})
+	})
+}
+
+func TestGetTeamUsers(t *testing.T) {
+	Convey("GetTeamUsers", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		users := []string{"userID1", "userID2"}
+
+		Convey("get successfully", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return(users, nil)
+			response, err := GetTeamUsers(dataBase, teamID)
+			So(response, ShouldResemble, dto.TeamMembers{Usernames: users})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("users not found", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{}, database.ErrNil)
+			response, err := GetTeamUsers(dataBase, teamID)
+			So(response, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorNotFound("cannot find team users: testTeam"))
+		})
+
+		Convey("database error", func() {
+			returnErr := fmt.Errorf("unexpected error")
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{}, returnErr)
+			response, err := GetTeamUsers(dataBase, teamID)
+			So(response, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", returnErr)))
+		})
+	})
+}
+
+func TestAddTeamUsers(t *testing.T) {
+	Convey("AddTeamUsers", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		const userID = "userID"
+		const userID2 = "userID2"
+		const userID3 = "userID3"
+
+		Convey("add successfully", func() {
+			gomock.InOrder(
+				dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID, userID2}, nil),
+				dataBase.EXPECT().GetUserTeams(userID).Return([]string{teamID}, nil),
+				dataBase.EXPECT().GetUserTeams(userID2).Return([]string{teamID}, nil),
+				dataBase.EXPECT().GetUserTeams(userID3).Return([]string{}, nil),
+				dataBase.EXPECT().SaveTeamsAndUsers(teamID,
+					[]string{userID, userID2, userID3},
+					map[string][]string{
+						userID:  {teamID},
+						userID2: {teamID},
+						userID3: {teamID},
+					},
+				).Return(nil),
+			)
+			response, err := AddTeamUsers(dataBase, teamID, []string{userID3})
+			So(response, ShouldResemble, dto.TeamMembers{Usernames: []string{userID, userID2, userID3}})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("team users not found", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{}, database.ErrNil)
+			response, err := AddTeamUsers(dataBase, teamID, []string{userID3})
+			So(response, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorNotFound("cannot find team users: testTeam"))
+		})
+
+		Convey("user teams not found", func() {
+			gomock.InOrder(
+				dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID, userID2}, nil),
+				dataBase.EXPECT().GetUserTeams(userID).Return([]string{}, database.ErrNil),
+			)
+			response, err := AddTeamUsers(dataBase, teamID, []string{userID3})
+			So(response, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorNotFound("cannot find user teams: userID"))
+		})
+
+		Convey("user already exists", func() {
+			gomock.InOrder(
+				dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID, userID2, userID3}, nil),
+				dataBase.EXPECT().GetUserTeams(userID).Return([]string{teamID}, nil),
+				dataBase.EXPECT().GetUserTeams(userID2).Return([]string{teamID}, nil),
+				dataBase.EXPECT().GetUserTeams(userID3).Return([]string{teamID}, nil),
+			)
+			response, err := AddTeamUsers(dataBase, teamID, []string{userID3})
+			So(response, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("one ore many users you specified are already exist in this team: userID3")))
+		})
+	})
+}
+
+func Test_addUserTeam(t *testing.T) {
+	Convey("addUserTeam", t, func() {
+		Convey("add successfully", func() {
+			actual, err := addUserTeam("testTeam3", []string{"testTeam", "testTeam2"})
+			So(actual, ShouldResemble, []string{"testTeam", "testTeam2", "testTeam3"})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("team already exists", func() {
+			actual, err := addUserTeam("testTeam", []string{"testTeam", "testTeam2"})
+			So(actual, ShouldResemble, []string{})
+			So(err, ShouldResemble, fmt.Errorf("team already exist in user teams: testTeam"))
+		})
+	})
+}
+
+func TestUpdateTeam(t *testing.T) {
+	Convey("UpdateTeam", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		team := dto.TeamModel{Name: "testTeam", Description: "test team description"}
+
+		Convey("update successfully", func() {
+			dataBase.EXPECT().SaveTeam(teamID, team.ToMoiraTeam()).Return(nil)
+			response, err := UpdateTeam(dataBase, teamID, team)
+			So(response.ID, ShouldResemble, teamID)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestDeleteTeamUser(t *testing.T) {
+	Convey("DeleteTeamUser", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		const userID = "userID"
+		const userID2 = "userID2"
+		const userID3 = "userID3"
+
+		Convey("user exists", func() {
+			gomock.InOrder(
+				dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID, userID2, userID3}, nil),
+				dataBase.EXPECT().GetUserTeams(userID).Return([]string{teamID}, nil),
+				dataBase.EXPECT().GetUserTeams(userID2).Return([]string{teamID}, nil),
+				dataBase.EXPECT().GetUserTeams(userID3).Return([]string{teamID}, nil),
+				dataBase.EXPECT().SaveTeamsAndUsers(teamID, []string{userID2, userID3}, map[string][]string{
+					userID:  {},
+					userID2: {teamID},
+					userID3: {teamID},
+				}).Return(nil),
+			)
+			reply, err := DeleteTeamUser(dataBase, teamID, userID)
+			So(reply, ShouldResemble, dto.TeamMembers{Usernames: []string{userID2, userID3}})
+			So(err, ShouldBeNil)
+		})
+		Convey("team does not have any users", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{}, database.ErrNil)
+			reply, err := DeleteTeamUser(dataBase, teamID, userID)
+			So(reply, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorNotFound("cannot find team users: testTeam"))
+		})
+		Convey("removal of last user", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID}, nil)
+			reply, err := DeleteTeamUser(dataBase, teamID, userID)
+			So(reply, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("cannot remove last member of team")))
+		})
+		Convey("team does not contain user", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID2, userID3}, nil)
+			reply, err := DeleteTeamUser(dataBase, teamID, userID)
+			So(reply, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorNotFound("user that you specified not found in this team: userID"))
+		})
+		Convey("one user do not have teams", func() {
+			gomock.InOrder(
+				dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID, userID2, userID3}, nil),
+				dataBase.EXPECT().GetUserTeams(userID).Return([]string{}, database.ErrNil),
+			)
+			reply, err := DeleteTeamUser(dataBase, teamID, userID)
+			So(reply, ShouldResemble, dto.TeamMembers{})
+			So(err, ShouldResemble, api.ErrorNotFound("cannot find user teams: userID"))
+		})
+	})
+}
+
+func Test_removeUserTeam(t *testing.T) {
+	Convey("removeUserTeam", t, func() {
+		Convey("remove successfully", func() {
+			actual, err := removeUserTeam([]string{"testTeam", "testTeam2"}, "testTeam")
+			So(actual, ShouldResemble, []string{"testTeam2"})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("team not found", func() {
+			actual, err := removeUserTeam([]string{"testTeam1", "testTeam2"}, "testTeam")
+			So(actual, ShouldResemble, []string{})
+			So(err, ShouldResemble, fmt.Errorf("cannot find team in user teams: testTeam"))
+		})
+	})
+}
+
+func Test_fillCurrentUsersTeamsMap(t *testing.T) {
+	Convey("fillCurrentUsersTeamsMap", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		const userID1 = "userID1"
+		const userID2 = "userID2"
+
+		Convey("without error", func() {
+			dataBase.EXPECT().GetUserTeams(userID1).Return([]string{teamID, "team2"}, nil)
+			dataBase.EXPECT().GetUserTeams(userID2).Return([]string{teamID}, nil)
+			usersMap, err := fillCurrentUsersTeamsMap(dataBase, []string{userID1, userID2})
+			So(err, ShouldBeNil)
+			So(usersMap, ShouldHaveLength, 2)
+			So(usersMap, ShouldContainKey, userID1)
+			So(usersMap, ShouldContainKey, userID2)
+			So(usersMap[userID1], ShouldHaveLength, 2)
+			So(usersMap[userID2], ShouldHaveLength, 1)
+		})
+		Convey("with error", func() {
+			errorReturned := errors.New("empty error")
+			dataBase.EXPECT().GetUserTeams(userID1).Return([]string{}, errorReturned)
+			usersMap, err := fillCurrentUsersTeamsMap(dataBase, []string{userID1, userID2})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", errorReturned)))
+			So(usersMap, ShouldHaveLength, 0)
+		})
+	})
+}
+
+func Test_removeDeletedUsers(t *testing.T) {
+	Convey("removeDeletedUsers", t, func() {
+		const teamID = "testTeam"
+		const userID1 = "userID1"
+		const userID2 = "userID2"
+		const userID3 = "userID3"
+		Convey("remove successful", func() {
+			actual, err := removeDeletedUsers(
+				teamID,
+				[]string{userID1, userID2},
+				map[string]bool{userID1: true, userID3: true},
+				map[string][]string{
+					userID1: {teamID, "otherTeam"},
+					userID2: {teamID, "otherTeam"},
+				})
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, map[string][]string{
+				userID1: {teamID, "otherTeam"},
+				userID2: {"otherTeam"},
+			})
+		})
+		Convey("with error", func() {
+			actual, err := removeDeletedUsers(
+				teamID,
+				[]string{userID1, userID2},
+				map[string]bool{userID1: true, userID3: true},
+				map[string][]string{
+					userID1: {teamID, "otherTeam"},
+					userID2: {"otherTeam"},
+				})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot remove team from user: %w", fmt.Errorf("cannot find team in user teams: %s", teamID))))
+			So(actual, ShouldBeNil)
+		})
+	})
+}
+
+func Test_addTeamsForNewUsers(t *testing.T) {
+	Convey("addTeamsForNewUsers", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		const teamID = "testTeam"
+		const userID1 = "userID1"
+		const userID2 = "userID2"
+
+		Convey("without error", func() {
+			dataBase.EXPECT().GetUserTeams(userID2).Return([]string{"otherTeam2"}, nil)
+			actual, err := addTeamsForNewUsers(
+				dataBase,
+				teamID,
+				map[string]bool{
+					userID1: true,
+					userID2: true,
+				},
+				map[string][]string{
+					userID1: {teamID, "otherTeam"},
+				})
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, map[string][]string{
+				userID1: {teamID, "otherTeam"},
+				userID2: {"otherTeam2", teamID},
+			})
+		})
+		Convey("with db error", func() {
+			errReturned := errors.New("test")
+			dataBase.EXPECT().GetUserTeams(userID2).Return(nil, errReturned)
+			actual, err := addTeamsForNewUsers(
+				dataBase,
+				teamID,
+				map[string]bool{
+					userID1: true,
+					userID2: true,
+				},
+				map[string][]string{
+					userID1: {teamID, "otherTeam"},
+				})
+			So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("cannot get team users from database: %w", errReturned)))
+			So(actual, ShouldBeNil)
+		})
+	})
+}
+
+func TestSetTeamUsers(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+	const teamID = "testTeam"
+	const userID1 = "userID1"
+	const userID2 = "userID2"
+
+	Convey("SetTeamUsers", t, func() {
+		Convey("Set to empty team", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{}, nil)
+			dataBase.EXPECT().GetUserTeams(userID1).Return(nil, database.ErrNil)
+			dataBase.EXPECT().SaveTeamsAndUsers(teamID, []string{userID1}, map[string][]string{userID1: {teamID}})
+			actual, err := SetTeamUsers(dataBase, teamID, []string{userID1})
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, dto.TeamMembers{Usernames: []string{userID1}})
+		})
+		Convey("Set to team with members", func() {
+			dataBase.EXPECT().GetTeamUsers(teamID).Return([]string{userID1}, nil)
+			dataBase.EXPECT().GetUserTeams(userID1).Return([]string{teamID}, nil)
+			dataBase.EXPECT().GetUserTeams(userID2).Return(nil, database.ErrNil)
+			dataBase.EXPECT().SaveTeamsAndUsers(teamID, []string{userID1, userID2}, map[string][]string{userID1: {teamID}, userID2: {teamID}})
+			actual, err := SetTeamUsers(dataBase, teamID, []string{userID1, userID2})
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, dto.TeamMembers{Usernames: []string{userID1, userID2}})
+		})
+	})
+}
+
+func TestCheckUserPermissionsForTeam(t *testing.T) {
+	const teamID = "testTeam"
+	const userID = "userID"
+
+	Convey("CheckUserPermissionsForTeam", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		Convey("user in team", func() {
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userID).Return(true, nil)
+			err := CheckUserPermissionsForTeam(dataBase, teamID, userID)
+			So(err, ShouldBeNil)
+		})
+		Convey("user is not in team", func() {
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userID).Return(false, nil)
+			err := CheckUserPermissionsForTeam(dataBase, teamID, userID)
+			So(err, ShouldResemble, api.ErrorForbidden("you are not permitted to manipulate with this team"))
+		})
+		Convey("error while checking user", func() {
+			returnErr := errors.New("returning error")
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, nil)
+			dataBase.EXPECT().IsTeamContainUser(teamID, userID).Return(false, returnErr)
+			err := CheckUserPermissionsForTeam(dataBase, teamID, userID)
+			So(err, ShouldResemble, api.ErrorInternalServer(returnErr))
+		})
+		Convey("error while getting team", func() {
+			returnErr := errors.New("returning error")
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, returnErr)
+			err := CheckUserPermissionsForTeam(dataBase, teamID, userID)
+			So(err, ShouldResemble, api.ErrorInternalServer(returnErr))
+		})
+		Convey("team is not exist", func() {
+			dataBase.EXPECT().GetTeam(teamID).Return(moira.Team{}, database.ErrNil)
+			err := CheckUserPermissionsForTeam(dataBase, teamID, userID)
+			So(err, ShouldResemble, api.ErrorNotFound("team with ID 'testTeam' does not exists"))
+		})
+	})
+}

--- a/api/dto/contact.go
+++ b/api/dto/contact.go
@@ -17,10 +17,11 @@ func (*ContactList) Render(w http.ResponseWriter, r *http.Request) error {
 }
 
 type Contact struct {
-	Type  string `json:"type"`
-	Value string `json:"value"`
-	ID    string `json:"id,omitempty"`
-	User  string `json:"user,omitempty"`
+	Type   string `json:"type"`
+	Value  string `json:"value"`
+	ID     string `json:"id,omitempty"`
+	User   string `json:"user,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
 }
 
 func (*Contact) Render(w http.ResponseWriter, r *http.Request) error {

--- a/api/dto/subscription_test.go
+++ b/api/dto/subscription_test.go
@@ -1,0 +1,100 @@
+// nolint
+package dto
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api/middleware"
+	mock "github.com/moira-alert/moira/mock/moira-alert"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSubscription_checkContacts(t *testing.T) {
+	Convey("checkContacts", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		dataBase := mock.NewMockDatabase(mockCtrl)
+
+		subscription := Subscription{}
+		const userID = "userID"
+		const teamID = "teamID"
+		const contactID = "contactID"
+		const contactID2 = "contactID2"
+		responseWriter := httptest.NewRecorder()
+
+		Convey("For user", func() {
+			request := httptest.NewRequest(http.MethodPost, "/api/subscriptions", strings.NewReader(""))
+			middleware.DatabaseContext(dataBase)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				request = req
+			})).ServeHTTP(responseWriter, request)
+
+			request.Header.Add("x-webauth-user", userID)
+			middleware.UserContext(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				request = req
+			})).ServeHTTP(responseWriter, request)
+
+			Convey("All subscription contacts are for user", func() {
+				subscription.Contacts = []string{contactID}
+				dataBase.EXPECT().GetUserContactIDs(userID).Return([]string{contactID, contactID2}, nil)
+				err := subscription.checkContacts(request)
+				So(err, ShouldBeNil)
+			})
+			Convey("Subscription contact is another user contact", func() {
+				subscription.Contacts = []string{contactID}
+				dataBase.EXPECT().GetUserContactIDs(userID).Return([]string{contactID2}, nil)
+				dataBase.EXPECT().GetContacts([]string{contactID}).Return([]*moira.ContactData{{ID: contactID, Value: "test value"}}, nil)
+				err := subscription.checkContacts(request)
+				So(err, ShouldResemble, ErrProvidedContactsForbidden{contactNames: []string{"test value"}, contactIds: []string{contactID}})
+			})
+		})
+
+		Convey("For team", func() {
+			request := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/teams/%s/subscriptions", teamID), strings.NewReader(""))
+			middleware.DatabaseContext(dataBase)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				request = req
+			})).ServeHTTP(responseWriter, request)
+			request.Header.Add("x-webauth-user", userID)
+			middleware.UserContext(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				request = req
+			})).ServeHTTP(responseWriter, request)
+
+			Convey("All subscription contacts are for current team", func() {
+				subscription.Contacts = []string{contactID}
+				request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "teamID", teamID))
+				dataBase.EXPECT().GetTeamContactIDs(teamID).Return([]string{contactID, contactID2}, nil)
+				err := subscription.checkContacts(request)
+				So(err, ShouldBeNil)
+			})
+			Convey("All subscription contacts are for current team, but teamID placed in subscription JSON(subscription update case)", func() {
+				subscription.TeamID = teamID
+				subscription.Contacts = []string{contactID}
+				dataBase.EXPECT().GetTeamContactIDs(teamID).Return([]string{contactID, contactID2}, nil)
+				err := subscription.checkContacts(request)
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("Error bot teamID and userID specified in JSON", func() {
+			request := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/teams/%s/subscriptions", teamID), strings.NewReader(""))
+			middleware.DatabaseContext(dataBase)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				request = req
+			})).ServeHTTP(responseWriter, request)
+			request.Header.Add("x-webauth-user", userID)
+			middleware.UserContext(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				request = req
+			})).ServeHTTP(responseWriter, request)
+			subscription.Contacts = []string{contactID}
+			subscription.TeamID = teamID
+			subscription.User = userID
+
+			err := subscription.checkContacts(request)
+			So(err, ShouldResemble, ErrSubscriptionContainsTeamAndUser{})
+		})
+	})
+}

--- a/api/dto/team.go
+++ b/api/dto/team.go
@@ -94,3 +94,13 @@ func (m TeamMembers) Bind(request *http.Request) error {
 func (TeamMembers) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
+
+type TeamSettings struct {
+	TeamID        string                   `json:"team_id"`
+	Contacts      []moira.ContactData      `json:"contacts"`
+	Subscriptions []moira.SubscriptionData `json:"subscriptions"`
+}
+
+func (TeamSettings) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}

--- a/api/dto/team.go
+++ b/api/dto/team.go
@@ -1,0 +1,96 @@
+package dto
+
+import (
+	"fmt"
+	"net/http"
+	"unicode/utf8"
+
+	"github.com/moira-alert/moira"
+)
+
+const (
+	teamNameLimit        = 100
+	teamDescriptionLimit = 1000
+)
+
+// TeamModel is a structure that represents team entity in HTTP transfer
+type TeamModel struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// NewTeamModel is a constructor function that creates a new TeamModel using moira.Team
+func NewTeamModel(team moira.Team) TeamModel {
+	return TeamModel{
+		ID:          team.ID,
+		Name:        team.Name,
+		Description: team.Description,
+	}
+}
+
+// Bind is a method that implements Binder interface from chi and checks that validity of data in request
+func (t TeamModel) Bind(request *http.Request) error {
+	if t.Name == "" {
+		return fmt.Errorf("team name cannot be empty")
+	}
+	if utf8.RuneCountInString(t.Name) > teamNameLimit {
+		return fmt.Errorf("team name cannot be longer than %d characters", teamNameLimit)
+	}
+	if utf8.RuneCountInString(t.Description) > teamDescriptionLimit {
+		return fmt.Errorf("team description cannot be longer than %d characters", teamNameLimit)
+	}
+	return nil
+}
+
+// Render is a function that implements chi Renderer interface for TeamModel
+func (TeamModel) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+// ToMoiraTeam is a method that converts dto.Team to general moira.Team datatype
+func (t TeamModel) ToMoiraTeam() moira.Team {
+	return moira.Team{
+		ID:          t.ID,
+		Name:        t.Name,
+		Description: t.Description,
+	}
+}
+
+// SaveTeamResponse is a structure to return team creation result in HTTP response
+type SaveTeamResponse struct {
+	ID string `json:"id"`
+}
+
+// Render is a function that implements chi Renderer interface for SaveTeamResponse
+func (SaveTeamResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+// UserTeams is a structure that represents a set of teams of user
+type UserTeams struct {
+	Teams []TeamModel `json:"teams"`
+}
+
+// Render is a function that implements chi Renderer interface for UserTeams
+func (UserTeams) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+// TeamMembers is a structure that represents a team members in HTTP transfer
+type TeamMembers struct {
+	Usernames []string `json:"usernames"`
+}
+
+// Bind is a method that implements Binder interface from chi and checks that validity of data in request
+func (m TeamMembers) Bind(request *http.Request) error {
+	if len(m.Usernames) == 0 {
+		return fmt.Errorf("at least one user should be specified")
+	}
+	return nil
+}
+
+// Render is a function that implements chi Renderer interface for TeamMembers
+func (TeamMembers) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}

--- a/api/handler/contact.go
+++ b/api/handler/contact.go
@@ -47,7 +47,7 @@ func createNewContact(writer http.ResponseWriter, request *http.Request) {
 	}
 	userLogin := middleware.GetLogin(request)
 
-	if err := controller.CreateContact(database, contact, userLogin); err != nil {
+	if err := controller.CreateContact(database, contact, userLogin, ""); err != nil {
 		render.Render(writer, request, err) //nolint
 		return
 	}
@@ -93,7 +93,7 @@ func updateContact(writer http.ResponseWriter, request *http.Request) {
 
 func removeContact(writer http.ResponseWriter, request *http.Request) {
 	contactData := request.Context().Value(contactKey).(moira.ContactData)
-	err := controller.RemoveContact(database, contactData.ID, contactData.User)
+	err := controller.RemoveContact(database, contactData.ID, contactData.User, "")
 	if err != nil {
 		render.Render(writer, request, err) //nolint
 	}

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -45,6 +45,7 @@ func NewHandler(db moira.Database, log moira.Logger, index moira.Searcher, confi
 		router.Route("/subscription", subscription)
 		router.Route("/notification", notification)
 		router.Route("/health", health)
+		router.Route("/teams", teams)
 	})
 	if config.EnableCORS {
 		return cors.AllowAll().Handler(router)

--- a/api/handler/subscription.go
+++ b/api/handler/subscription.go
@@ -53,7 +53,7 @@ func createSubscription(writer http.ResponseWriter, request *http.Request) {
 			errors.New("if any_tags is true, then the tags must be empty")))
 		return
 	}
-	if err := controller.CreateSubscription(database, userLogin, subscription); err != nil {
+	if err := controller.CreateSubscription(database, userLogin, "", subscription); err != nil {
 		render.Render(writer, request, err) //nolint
 		return
 	}

--- a/api/handler/team.go
+++ b/api/handler/team.go
@@ -4,6 +4,10 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/controller"
+	"github.com/moira-alert/moira/api/dto"
 	"github.com/moira-alert/moira/api/middleware"
 )
 
@@ -12,45 +16,171 @@ func teams(router chi.Router) {
 	router.Post("/", createTeam)
 	router.Route("/{teamId}", func(router chi.Router) {
 		router.Use(middleware.TeamContext)
+		router.Use(usersFilterForTeams)
 		router.Get("/", getTeam)
 		router.Patch("/", updateTeam)
 		router.Route("/users", func(router chi.Router) {
 			router.Get("/", getTeamUsers)
 			router.Put("/", setTeamUsers)
-			router.Post("/", addTeamUser)
+			router.Post("/", addTeamUsers)
 			router.With(middleware.TeamUserIDContext).Delete("/{teamUserId}", deleteTeamUser)
 		})
 	})
 }
 
-func createTeam(writer http.ResponseWriter, request *http.Request) {
+// usersFilterForTeams is middleware that checks that user exists in this
+func usersFilterForTeams(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		userID := middleware.GetLogin(request)
+		teamID := middleware.GetTeamID(request)
+		err := controller.CheckUserPermissionsForTeam(database, teamID, userID)
+		if err != nil {
+			render.Render(writer, request, err) //nolint
+			return
+		}
+		next.ServeHTTP(writer, request)
+	})
+}
 
+func createTeam(writer http.ResponseWriter, request *http.Request) {
+	user := middleware.GetLogin(request)
+	team := dto.TeamModel{}
+	err := render.Bind(request, &team)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint:errcheck
+		return
+	}
+	response, apiErr := controller.CreateTeam(database, team, user)
+	if apiErr != nil {
+		render.Render(writer, request, apiErr) //nolint:errcheck
+		return
+	}
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) //nolint:errcheck
+		return
+	}
 }
 
 func getAllTeams(writer http.ResponseWriter, request *http.Request) {
+	user := middleware.GetLogin(request)
+	response, err := controller.GetUserTeams(database, user)
+	if err != nil {
+		render.Render(writer, request, err) //nolint:errcheck
+		return
+	}
 
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) //nolint:errcheck
+		return
+	}
 }
 
 func getTeam(writer http.ResponseWriter, request *http.Request) {
+	teamID := middleware.GetTeamID(request)
 
+	response, err := controller.GetTeam(database, teamID)
+	if err != nil {
+		render.Render(writer, request, err) //nolint:errcheck
+		return
+	}
+
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) //nolint:errcheck
+		return
+	}
 }
 
 func updateTeam(writer http.ResponseWriter, request *http.Request) {
+	team := dto.TeamModel{}
+	err := render.Bind(request, &team)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint:errcheck
+		return
+	}
 
+	teamID := middleware.GetTeamID(request)
+
+	response, apiErr := controller.UpdateTeam(database, teamID, team)
+	if apiErr != nil {
+		render.Render(writer, request, apiErr) //nolint:errcheck
+		return
+	}
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) //nolint:errcheck
+		return
+	}
 }
 
 func getTeamUsers(writer http.ResponseWriter, request *http.Request) {
+	teamID := middleware.GetTeamID(request)
 
+	response, err := controller.GetTeamUsers(database, teamID)
+	if err != nil {
+		render.Render(writer, request, err) // nolint:errcheck
+		return
+	}
+
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) // nolint:errcheck
+		return
+	}
 }
 
 func setTeamUsers(writer http.ResponseWriter, request *http.Request) {
+	members := dto.TeamMembers{}
+	err := render.Bind(request, &members)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) // nolint:errcheck
+		return
+	}
 
+	teamID := middleware.GetTeamID(request)
+
+	response, apiErr := controller.SetTeamUsers(database, teamID, members.Usernames)
+	if err != nil {
+		render.Render(writer, request, apiErr) // nolint:errcheck
+		return
+	}
+
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) // nolint:errcheck
+		return
+	}
 }
 
-func addTeamUser(writer http.ResponseWriter, request *http.Request) {
+func addTeamUsers(writer http.ResponseWriter, request *http.Request) {
+	members := dto.TeamMembers{}
+	err := render.Bind(request, &members)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) // nolint:errcheck
+		return
+	}
+	teamID := middleware.GetTeamID(request)
 
+	response, apiErr := controller.AddTeamUsers(database, teamID, members.Usernames)
+	if err != nil {
+		render.Render(writer, request, apiErr) // nolint:errcheck
+		return
+	}
+
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) // nolint:errcheck
+		return
+	}
 }
 
 func deleteTeamUser(writer http.ResponseWriter, request *http.Request) {
+	teamID := middleware.GetTeamID(request)
+	userID := middleware.GetTeamUserID(request)
 
+	response, err := controller.DeleteTeamUser(database, teamID, userID)
+	if err != nil {
+		render.Render(writer, request, err) // nolint:errcheck
+		return
+	}
+
+	if err := render.Render(writer, request, response); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) // nolint:errcheck
+		return
+	}
 }

--- a/api/handler/team.go
+++ b/api/handler/team.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/moira-alert/moira/api/middleware"
+)
+
+func teams(router chi.Router) {
+	router.Get("/", getAllTeams)
+	router.Post("/", createTeam)
+	router.Route("/{teamId}", func(router chi.Router) {
+		router.Use(middleware.TeamContext)
+		router.Get("/", getTeam)
+		router.Patch("/", updateTeam)
+		router.Route("/users", func(router chi.Router) {
+			router.Get("/", getTeamUsers)
+			router.Put("/", setTeamUsers)
+			router.Post("/", addTeamUser)
+			router.With(middleware.TeamUserIDContext).Delete("/{teamUserId}", deleteTeamUser)
+		})
+	})
+}
+
+func createTeam(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func getAllTeams(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func getTeam(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func updateTeam(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func getTeamUsers(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func setTeamUsers(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func addTeamUser(writer http.ResponseWriter, request *http.Request) {
+
+}
+
+func deleteTeamUser(writer http.ResponseWriter, request *http.Request) {
+
+}

--- a/api/handler/team_contact.go
+++ b/api/handler/team_contact.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/controller"
+	"github.com/moira-alert/moira/api/dto"
+	"github.com/moira-alert/moira/api/middleware"
+)
+
+func teamContact(router chi.Router) {
+	router.Post("/", createNewTeamContact)
+}
+
+func createNewTeamContact(writer http.ResponseWriter, request *http.Request) {
+	contact := &dto.Contact{}
+	if err := render.Bind(request, contact); err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint:errcheck
+		return
+	}
+	teamID := middleware.GetTeamID(request)
+
+	if err := controller.CreateContact(database, contact, "", teamID); err != nil {
+		render.Render(writer, request, err) //nolint:errcheck
+		return
+	}
+
+	if err := render.Render(writer, request, contact); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) //nolint:errcheck
+		return
+	}
+}

--- a/api/handler/team_subscription.go
+++ b/api/handler/team_subscription.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/render"
+	"github.com/moira-alert/moira/api"
+	"github.com/moira-alert/moira/api/controller"
+	"github.com/moira-alert/moira/api/dto"
+	"github.com/moira-alert/moira/api/middleware"
+)
+
+func teamSubscription(router chi.Router) {
+	router.Post("/", createTeamSubscription)
+}
+
+func createTeamSubscription(writer http.ResponseWriter, request *http.Request) {
+	subscription := &dto.Subscription{}
+	if err := render.Bind(request, subscription); err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint:errcheck
+		return
+	}
+	teamID := middleware.GetTeamID(request)
+
+	if subscription.AnyTags && len(subscription.Tags) > 0 {
+		writer.WriteHeader(http.StatusBadRequest)
+		render.Render(writer, request, api.ErrorInvalidRequest( //nolint:errcheck
+			errors.New("if any_tags is true, then the tags must be empty")))
+		return
+	}
+	if err := controller.CreateSubscription(database, "", teamID, subscription); err != nil {
+		render.Render(writer, request, err) //nolint:errcheck
+		return
+	}
+	if err := render.Render(writer, request, subscription); err != nil {
+		render.Render(writer, request, api.ErrorRender(err)) //nolint:errcheck
+		return
+	}
+}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -205,3 +205,29 @@ func TargetName(defaultTargetName string) func(next http.Handler) http.Handler {
 		})
 	}
 }
+
+// TeamContext gets teamId from parsed URI corresponding to team routes and set it to request context
+func TeamContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		teamID := chi.URLParam(request, "teamId")
+		if teamID == "" {
+			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("teamId must be set")))
+			return
+		}
+		ctx := context.WithValue(request.Context(), teamIDKey, teamID)
+		next.ServeHTTP(writer, request.WithContext(ctx))
+	})
+}
+
+// TeamUserIDContext gets userId from parsed URI corresponding to team routes and set it to request context
+func TeamUserIDContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		userID := chi.URLParam(request, "userId")
+		if userID == "" {
+			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("userId must be set")))
+			return
+		}
+		ctx := context.WithValue(request.Context(), teamUserIDKey, userID)
+		next.ServeHTTP(writer, request.WithContext(ctx))
+	})
+}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -222,7 +222,7 @@ func TeamContext(next http.Handler) http.Handler {
 // TeamUserIDContext gets userId from parsed URI corresponding to team routes and set it to request context
 func TeamUserIDContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		userID := chi.URLParam(request, "userId")
+		userID := chi.URLParam(request, "teamUserId")
 		if userID == "" {
 			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("userId must be set"))) //nolint:errcheck
 			return

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -211,7 +211,7 @@ func TeamContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		teamID := chi.URLParam(request, "teamId")
 		if teamID == "" {
-			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("teamId must be set")))
+			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("teamId must be set"))) //nolint:errcheck
 			return
 		}
 		ctx := context.WithValue(request.Context(), teamIDKey, teamID)
@@ -224,7 +224,7 @@ func TeamUserIDContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		userID := chi.URLParam(request, "userId")
 		if userID == "" {
-			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("userId must be set")))
+			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("userId must be set"))) //nolint:errcheck
 			return
 		}
 		ctx := context.WithValue(request.Context(), teamUserIDKey, userID)

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -138,10 +138,19 @@ func GetTargetName(request *http.Request) string {
 
 // GetTeamID gets team id
 func GetTeamID(request *http.Request) string {
-	return request.Context().Value(teamIDKey).(string)
+	teamID := request.Context().Value(teamIDKey)
+	if teamID == nil {
+		return ""
+	}
+	return teamID.(string)
 }
 
 // GetTeamUserID gets team user id
 func GetTeamUserID(request *http.Request) string {
 	return request.Context().Value(teamUserIDKey).(string)
+}
+
+// SetContextValueForTest is a helper function that is needed for testing purposes and sets context values with local ContextKey type
+func SetContextValueForTest(ctx context.Context, key string, value interface{}) context.Context {
+	return context.WithValue(ctx, ContextKey(key), value)
 }

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -36,6 +36,8 @@ var (
 	timeSeriesNamesKey   ContextKey = "timeSeriesNames"
 	metricSourceProvider ContextKey = "metricSourceProvider"
 	targetNameKey        ContextKey = "target"
+	teamIDKey            ContextKey = "teamID"
+	teamUserIDKey        ContextKey = "teamUserIDKey"
 )
 
 // GetDatabase gets moira.Database realization from request context
@@ -132,4 +134,14 @@ func GetTriggerTargetsSourceProvider(request *http.Request) *metricSource.Source
 // GetTargetName gets target name
 func GetTargetName(request *http.Request) string {
 	return request.Context().Value(targetNameKey).(string)
+}
+
+// GetTeamID gets team id
+func GetTeamID(request *http.Request) string {
+	return request.Context().Value(teamIDKey).(string)
+}
+
+// GetTeamUserID gets team user id
+func GetTeamUserID(request *http.Request) string {
+	return request.Context().Value(teamUserIDKey).(string)
 }

--- a/database/redis/reply/team.go
+++ b/database/redis/reply/team.go
@@ -1,0 +1,57 @@
+package reply
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/database"
+)
+
+// teamStorageElement is a representation of team in database
+type teamStorageElement struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func newTeamStorageElement(team moira.Team) teamStorageElement {
+	return teamStorageElement{
+		Name:        team.Name,
+		Description: team.Description,
+	}
+}
+
+func (t *teamStorageElement) toTeam() moira.Team {
+	return moira.Team{
+		Name:        t.Name,
+		Description: t.Description,
+	}
+}
+
+// MarshallTeam is a function that converts team to the bytes that can be held in database
+func MarshallTeam(team moira.Team) ([]byte, error) {
+	teamSE := newTeamStorageElement(team)
+	bytes, err := json.Marshal(teamSE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal team: %w", err)
+	}
+	return bytes, nil
+}
+
+// NewTeam is a function that creates a team entity from a bytes received from database
+func NewTeam(rep interface{}, err error) (moira.Team, error) {
+	bytes, err := redis.Bytes(rep, err)
+	if err != nil {
+		if err == redis.ErrNil {
+			return moira.Team{}, database.ErrNil
+		}
+		return moira.Team{}, fmt.Errorf("failed to read team: %w", err)
+	}
+	teamSE := teamStorageElement{}
+	err = json.Unmarshal(bytes, &teamSE)
+	if err != nil {
+		return moira.Team{}, fmt.Errorf("failed to parse team json %s: %w", string(bytes), err)
+	}
+	return teamSE.toTeam(), nil
+}

--- a/database/redis/subscription_test.go
+++ b/database/redis/subscription_test.go
@@ -116,6 +116,26 @@ func TestSubscriptionAnyTags(t *testing.T) {
 			err = dataBase.RemoveSubscription(subAnyTagWithTags.ID)
 			So(err, ShouldBeNil)
 		})
+
+		Convey("Save Subscription for team", func() {
+			err := dataBase.SaveSubscription(subscriptions[8])
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Get Subscription by team", func() {
+			actual, err := dataBase.GetTeamSubscriptionIDs(team1)
+			So(err, ShouldBeNil)
+			So(actual, ShouldResemble, []string{subscriptions[8].ID})
+		})
+
+		Convey("Remove Subscription for team", func() {
+			err := dataBase.RemoveSubscription(subscriptions[8].ID)
+			So(err, ShouldBeNil)
+			actual, err := dataBase.GetTeamSubscriptionIDs(team1)
+			So(err, ShouldBeNil)
+			sort.Strings(actual)
+			So(actual, ShouldResemble, []string{})
+		})
 	})
 }
 
@@ -202,7 +222,7 @@ func TestSubscriptionData(t *testing.T) {
 
 			actual1, err := dataBase.GetUserSubscriptionIDs(user1)
 			So(err, ShouldBeNil)
-			So(actual1, ShouldHaveLength, len(ids))
+			So(actual1, ShouldHaveLength, len(ids)-1) // except the team subscription
 
 			err = dataBase.RemoveSubscription(ids[0])
 			So(err, ShouldBeNil)
@@ -213,7 +233,7 @@ func TestSubscriptionData(t *testing.T) {
 
 			actual1, err = dataBase.GetUserSubscriptionIDs(user1)
 			So(err, ShouldBeNil)
-			So(actual1, ShouldHaveLength, len(ids)-1)
+			So(actual1, ShouldHaveLength, len(ids)-2) // except the team subscription and removed subscrition
 		})
 
 		Convey("Test rewrite subscription", func() {
@@ -428,5 +448,13 @@ var subscriptions = []*moira.SubscriptionData{
 		ThrottlingEnabled: true,
 		AnyTags:           true,
 		User:              user1,
+	},
+	{
+		ID:                "teamSubscriptionID-00000000000001",
+		Enabled:           true,
+		Tags:              []string{tag1},
+		Contacts:          []string{uuid.Must(uuid.NewV4()).String()},
+		TeamID:            team1,
+		ThrottlingEnabled: true,
 	},
 }

--- a/database/redis/teams.go
+++ b/database/redis/teams.go
@@ -1,29 +1,132 @@
 package redis
 
 import (
-	"errors"
+	"fmt"
 
+	"github.com/gomodule/redigo/redis"
 	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/database/redis/reply"
 )
 
+// SaveTeam saves team into redis
 func (connector *DbConnector) SaveTeam(teamID string, team moira.Team) error {
-	return errors.New("not implemented")
+	c := connector.pool.Get()
+	defer c.Close()
+
+	teamBytes, err := reply.MarshallTeam(team)
+	if err != nil {
+		return fmt.Errorf("save team error: %w", err)
+	}
+
+	_, err = c.Do("HSET", teamsKey, teamID, teamBytes)
+	if err != nil {
+		return fmt.Errorf("save team redis error: %w", err)
+	}
+	return nil
 }
 
+// GetTeam retrieves team from redis by it's id
 func (connector *DbConnector) GetTeam(teamID string) (moira.Team, error) {
-	return moira.Team{}, errors.New("not implemented")
+	c := connector.pool.Get()
+	defer c.Close()
+
+	response, err := c.Do("HGET", teamsKey, teamID)
+	if err != nil {
+		return moira.Team{}, fmt.Errorf("failed to retrieve team: %w", err)
+	}
+
+	team, err := reply.NewTeam(response, err)
+	if err != nil {
+		return moira.Team{}, err
+	}
+	team.ID = teamID
+
+	return team, nil
 }
-func (connector *DbConnector) SaveTeamsAndUsers(teamID string, users []string, usersTeams map[string][]string) error {
-	return errors.New("not implemented")
+
+// SaveTeamsAndUsers is a function that saves users for one team and teams for bunch of users in one transaction.
+func (connector *DbConnector) SaveTeamsAndUsers(teamID string, users []string, teams map[string][]string) error {
+	c := connector.pool.Get()
+	defer c.Close()
+
+	err := c.Send("MULTI")
+	if err != nil {
+		return fmt.Errorf("cannot open transaction %w", err)
+	}
+
+	err = c.Send("DEL", teamUsersKey(teamID))
+	if err != nil {
+		return fmt.Errorf("cannot clear users set for team: %s, %w", teamID, err)
+	}
+	for _, userID := range users {
+		err = c.Send("SADD", teamUsersKey(teamID), userID)
+		if err != nil {
+			return fmt.Errorf("cannot save users for team: %s, %w", teamID, err)
+		}
+	}
+
+	for userID, userTeams := range teams {
+		err = c.Send("DEL", userTeamsKey(userID))
+		if err != nil {
+			return fmt.Errorf("cannot clear teams set for user: %s, %w", userID, err)
+		}
+		for _, teamID := range userTeams {
+			err = c.Send("SADD", userTeamsKey(userID), teamID)
+			if err != nil {
+				return fmt.Errorf("cannot save teams for user: %s, %w", userID, err)
+			}
+		}
+	}
+
+	_, err = c.Do("EXEC")
+	if err != nil {
+		return fmt.Errorf("cannot commit transaction and save team: %w", err)
+	}
+
+	return nil
 }
 
 func (connector *DbConnector) GetUserTeams(userID string) ([]string, error) {
-	return []string{}, errors.New("not implemented")
+	c := connector.pool.Get()
+	defer c.Close()
+
+	teams, err := redis.Strings(c.Do("SMEMBERS", userTeamsKey(userID)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve user teams: %w", err)
+	}
+	return teams, nil
 }
+
+// GetTeamUsers returns all users of certain team
 func (connector *DbConnector) GetTeamUsers(teamID string) ([]string, error) {
-	return []string{}, errors.New("not implemented")
+	c := connector.pool.Get()
+	defer c.Close()
+
+	teams, err := redis.Strings(c.Do("SMEMBERS", teamUsersKey(teamID)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve user teams: %w", err)
+	}
+	return teams, nil
 }
 
 func (connector *DbConnector) IsTeamContainUser(teamID, userID string) (bool, error) {
-	return false, errors.New("not implemented")
+	c := connector.pool.Get()
+	defer c.Close()
+
+	reply, err := c.Do("SISMEMBER", teamUsersKey(teamID), userID)
+	result, err := redis.Bool(reply, err)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if team contains user: %w", err)
+	}
+	return result, nil
+}
+
+const teamsKey = "moira-teams"
+
+func userTeamsKey(userID string) string {
+	return fmt.Sprintf("moira-userTeams:%s", userID)
+}
+
+func teamUsersKey(teamID string) string {
+	return fmt.Sprintf("moira-teamUsers:%s", teamID)
 }

--- a/database/redis/teams.go
+++ b/database/redis/teams.go
@@ -1,0 +1,29 @@
+package redis
+
+import (
+	"errors"
+
+	"github.com/moira-alert/moira"
+)
+
+func (connector *DbConnector) SaveTeam(teamID string, team moira.Team) error {
+	return errors.New("not implemented")
+}
+
+func (connector *DbConnector) GetTeam(teamID string) (moira.Team, error) {
+	return moira.Team{}, errors.New("not implemented")
+}
+func (connector *DbConnector) SaveTeamsAndUsers(teamID string, users []string, usersTeams map[string][]string) error {
+	return errors.New("not implemented")
+}
+
+func (connector *DbConnector) GetUserTeams(userID string) ([]string, error) {
+	return []string{}, errors.New("not implemented")
+}
+func (connector *DbConnector) GetTeamUsers(teamID string) ([]string, error) {
+	return []string{}, errors.New("not implemented")
+}
+
+func (connector *DbConnector) IsTeamContainUser(teamID, userID string) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/database/redis/teams_test.go
+++ b/database/redis/teams_test.go
@@ -67,7 +67,7 @@ func TestTeamStoring(t *testing.T) {
 		So(actualTeams, ShouldHaveLength, 1)
 		So(actualTeams, ShouldContain, teamID)
 
-		// Remove user 2from team 1
+		// Remove user 2 from team 1
 		err = dataBase.SaveTeamsAndUsers(
 			teamID,
 			[]string{userID},
@@ -122,5 +122,28 @@ func TestTeamStoring(t *testing.T) {
 		actualTeams, err = dataBase.GetUserTeams("nonexistentUser")
 		So(err, ShouldBeNil)
 		So(actualTeams, ShouldResemble, []string{})
+
+		// Add user to new team and delete this team
+		const teamToDeleteID = "teamToDeleteID"
+		const userOfTeamToDeleteID = "userOfTeamToDeleteID"
+		teamToDelete := moira.Team{
+			Name:        "TeamName",
+			Description: "Team Description",
+		}
+		err = dataBase.SaveTeam(teamToDeleteID, teamToDelete)
+		So(err, ShouldBeNil)
+		err = dataBase.SaveTeamsAndUsers(teamToDeleteID, []string{userOfTeamToDeleteID}, map[string][]string{teamToDeleteID: {userOfTeamToDeleteID}})
+		So(err, ShouldBeNil)
+		err = dataBase.DeleteTeam(teamToDeleteID, userOfTeamToDeleteID)
+		So(err, ShouldBeNil)
+		actualTeam, err = dataBase.GetTeam(teamToDeleteID)
+		So(err, ShouldResemble, database.ErrNil)
+		So(actualTeam, ShouldResemble, moira.Team{})
+		actualTeams, err = dataBase.GetUserTeams(userOfTeamToDeleteID)
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldHaveLength, 0)
+		actualUsers, err = dataBase.GetTeamUsers(teamToDeleteID)
+		So(err, ShouldBeNil)
+		So(actualUsers, ShouldHaveLength, 0)
 	})
 }

--- a/database/redis/teams_test.go
+++ b/database/redis/teams_test.go
@@ -1,0 +1,126 @@
+package redis
+
+import (
+	"testing"
+
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/database"
+	logging "github.com/moira-alert/moira/logging/zerolog_adapter"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestTeamStoring(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database test in short mode")
+	}
+	logger, _ := logging.GetLogger("dataBase")
+	dataBase := newTestDatabase(logger, config)
+	dataBase.flush()
+	defer dataBase.flush()
+
+	teamID := "testTeam"
+	teamID2 := "testTeam2"
+	userID := "userID"
+	userID2 := "userID2"
+	userID3 := "userID3"
+	team := moira.Team{
+		ID:          teamID,
+		Name:        "Test team",
+		Description: "Test team description",
+	}
+	Convey("Teams Manipulation", t, func() {
+		err := dataBase.SaveTeam(teamID, team)
+		So(err, ShouldBeNil)
+
+		actualTeam, err := dataBase.GetTeam(teamID)
+		So(err, ShouldBeNil)
+		So(actualTeam, ShouldResemble, team)
+
+		actualTeam, err = dataBase.GetTeam("nonExistentTeam")
+		So(err, ShouldResemble, database.ErrNil)
+		So(actualTeam, ShouldResemble, moira.Team{})
+
+		// Add two users for team 1
+		err = dataBase.SaveTeamsAndUsers(
+			teamID,
+			[]string{userID, userID2},
+			map[string][]string{
+				userID:  {teamID},
+				userID2: {teamID},
+			},
+		)
+		So(err, ShouldBeNil)
+
+		actualUsers, err := dataBase.GetTeamUsers(teamID)
+		So(err, ShouldBeNil)
+		So(len(actualUsers), ShouldResemble, 2)
+		So(actualUsers, ShouldContain, userID)
+		So(actualUsers, ShouldContain, userID2)
+
+		actualTeams, err := dataBase.GetUserTeams(userID)
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldHaveLength, 1)
+		So(actualTeams, ShouldContain, teamID)
+
+		actualTeams, err = dataBase.GetUserTeams(userID2)
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldHaveLength, 1)
+		So(actualTeams, ShouldContain, teamID)
+
+		// Remove user 2from team 1
+		err = dataBase.SaveTeamsAndUsers(
+			teamID,
+			[]string{userID},
+			map[string][]string{
+				userID:  {teamID},
+				userID2: {},
+			},
+		)
+		So(err, ShouldBeNil)
+
+		actualUsers, err = dataBase.GetTeamUsers(teamID)
+		So(err, ShouldBeNil)
+		So(len(actualUsers), ShouldResemble, 1)
+		So(actualUsers, ShouldContain, userID)
+
+		actualTeams, err = dataBase.GetUserTeams(userID)
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldHaveLength, 1)
+		So(actualTeams, ShouldContain, teamID)
+
+		actualTeams, err = dataBase.GetUserTeams(userID2)
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldHaveLength, 0)
+
+		// Saving some users for team to check users existence in team later
+		err = dataBase.SaveTeamsAndUsers(
+			teamID2,
+			[]string{userID, userID3},
+			map[string][]string{
+				userID:  {teamID, teamID},
+				userID3: {teamID2},
+			},
+		)
+		So(err, ShouldBeNil)
+
+		actualUserExists, err := dataBase.IsTeamContainUser(teamID2, userID)
+		So(err, ShouldBeNil)
+		So(actualUserExists, ShouldBeTrue)
+
+		actualUserExists, err = dataBase.IsTeamContainUser(teamID2, "NonexistentUser")
+		So(err, ShouldBeNil)
+		So(actualUserExists, ShouldBeFalse)
+
+		actualUserExists, err = dataBase.IsTeamContainUser("NonexistentTeam", "NonexistentUser")
+		So(err, ShouldBeNil)
+		So(actualUserExists, ShouldBeFalse)
+
+		actualTeams, err = dataBase.GetUserTeams(userID)
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldResemble, []string{teamID})
+
+		actualTeams, err = dataBase.GetUserTeams("nonexistentUser")
+		So(err, ShouldBeNil)
+		So(actualTeams, ShouldResemble, []string{})
+	})
+}

--- a/datatypes.go
+++ b/datatypes.go
@@ -154,6 +154,12 @@ func (trigger TriggerData) GetTriggerURI(frontURI string) string {
 	return ""
 }
 
+// Team is a structure that represents a group of users that share a subscriptions and contacts
+type Team struct {
+	Name        string
+	Description string
+}
+
 // ContactData represents contact object
 type ContactData struct {
 	Type  string `json:"type"`

--- a/datatypes.go
+++ b/datatypes.go
@@ -156,6 +156,7 @@ func (trigger TriggerData) GetTriggerURI(frontURI string) string {
 
 // Team is a structure that represents a group of users that share a subscriptions and contacts
 type Team struct {
+	ID          string
 	Name        string
 	Description string
 }

--- a/datatypes.go
+++ b/datatypes.go
@@ -167,6 +167,7 @@ type ContactData struct {
 	Value string `json:"value"`
 	ID    string `json:"id"`
 	User  string `json:"user"`
+	Team  string `json:"team"`
 }
 
 // SubscriptionData represents user subscription
@@ -182,6 +183,7 @@ type SubscriptionData struct {
 	IgnoreRecoverings bool         `json:"ignore_recoverings,omitempty"`
 	ThrottlingEnabled bool         `json:"throttling"`
 	User              string       `json:"user"`
+	TeamID            string       `json:"team_id"`
 }
 
 // PlottingData represents plotting settings

--- a/interfaces.go
+++ b/interfaces.go
@@ -129,6 +129,14 @@ type Database interface {
 
 	// Creates Lock
 	NewLock(name string, ttl time.Duration) Lock
+
+	// Teams management
+	SaveTeam(teamID string, team Team) error
+	GetTeam(teamID string) (Team, error)
+	SaveTeamsAndUsers(teamID string, users []string, usersTeams map[string][]string) error
+	GetUserTeams(userID string) ([]string, error)
+	GetTeamUsers(teamID string) ([]string, error)
+	IsTeamContainUser(teamID, userID string) (bool, error)
 }
 
 // Lock implements lock abstraction

--- a/interfaces.go
+++ b/interfaces.go
@@ -66,6 +66,7 @@ type Database interface {
 	RemoveContact(contactID string) error
 	SaveContact(contact *ContactData) error
 	GetUserContactIDs(userLogin string) ([]string, error)
+	GetTeamContactIDs(teamID string) ([]string, error)
 
 	// SubscriptionData storing
 	GetSubscription(id string) (SubscriptionData, error)
@@ -74,6 +75,7 @@ type Database interface {
 	SaveSubscriptions(subscriptions []*SubscriptionData) error
 	RemoveSubscription(subscriptionID string) error
 	GetUserSubscriptionIDs(userLogin string) ([]string, error)
+	GetTeamSubscriptionIDs(teamID string) ([]string, error)
 	GetTagsSubscriptions(tags []string) ([]*SubscriptionData, error)
 
 	// ScheduledNotification storing
@@ -137,6 +139,7 @@ type Database interface {
 	GetUserTeams(userID string) ([]string, error)
 	GetTeamUsers(teamID string) ([]string, error)
 	IsTeamContainUser(teamID, userID string) (bool, error)
+	DeleteTeam(teamID, userID string) error
 }
 
 // Lock implements lock abstraction

--- a/mock/heartbeat/heartbeat.go
+++ b/mock/heartbeat/heartbeat.go
@@ -5,34 +5,35 @@
 package mock_heartbeat
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockHeartbeater is a mock of Heartbeater interface
+// MockHeartbeater is a mock of Heartbeater interface.
 type MockHeartbeater struct {
 	ctrl     *gomock.Controller
 	recorder *MockHeartbeaterMockRecorder
 }
 
-// MockHeartbeaterMockRecorder is the mock recorder for MockHeartbeater
+// MockHeartbeaterMockRecorder is the mock recorder for MockHeartbeater.
 type MockHeartbeaterMockRecorder struct {
 	mock *MockHeartbeater
 }
 
-// NewMockHeartbeater creates a new mock instance
+// NewMockHeartbeater creates a new mock instance.
 func NewMockHeartbeater(ctrl *gomock.Controller) *MockHeartbeater {
 	mock := &MockHeartbeater{ctrl: ctrl}
 	mock.recorder = &MockHeartbeaterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHeartbeater) EXPECT() *MockHeartbeaterMockRecorder {
 	return m.recorder
 }
 
-// Check mocks base method
+// Check mocks base method.
 func (m *MockHeartbeater) Check(arg0 int64) (int64, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Check", arg0)
@@ -42,13 +43,13 @@ func (m *MockHeartbeater) Check(arg0 int64) (int64, bool, error) {
 	return ret0, ret1, ret2
 }
 
-// Check indicates an expected call of Check
+// Check indicates an expected call of Check.
 func (mr *MockHeartbeaterMockRecorder) Check(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockHeartbeater)(nil).Check), arg0)
 }
 
-// GetErrorMessage mocks base method
+// GetErrorMessage mocks base method.
 func (m *MockHeartbeater) GetErrorMessage() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetErrorMessage")
@@ -56,13 +57,13 @@ func (m *MockHeartbeater) GetErrorMessage() string {
 	return ret0
 }
 
-// GetErrorMessage indicates an expected call of GetErrorMessage
+// GetErrorMessage indicates an expected call of GetErrorMessage.
 func (mr *MockHeartbeaterMockRecorder) GetErrorMessage() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetErrorMessage", reflect.TypeOf((*MockHeartbeater)(nil).GetErrorMessage))
 }
 
-// NeedToCheckOthers mocks base method
+// NeedToCheckOthers mocks base method.
 func (m *MockHeartbeater) NeedToCheckOthers() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NeedToCheckOthers")
@@ -70,13 +71,13 @@ func (m *MockHeartbeater) NeedToCheckOthers() bool {
 	return ret0
 }
 
-// NeedToCheckOthers indicates an expected call of NeedToCheckOthers
+// NeedToCheckOthers indicates an expected call of NeedToCheckOthers.
 func (mr *MockHeartbeaterMockRecorder) NeedToCheckOthers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedToCheckOthers", reflect.TypeOf((*MockHeartbeater)(nil).NeedToCheckOthers))
 }
 
-// NeedTurnOffNotifier mocks base method
+// NeedTurnOffNotifier mocks base method.
 func (m *MockHeartbeater) NeedTurnOffNotifier() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NeedTurnOffNotifier")
@@ -84,7 +85,7 @@ func (m *MockHeartbeater) NeedTurnOffNotifier() bool {
 	return ret0
 }
 
-// NeedTurnOffNotifier indicates an expected call of NeedTurnOffNotifier
+// NeedTurnOffNotifier indicates an expected call of NeedTurnOffNotifier.
 func (mr *MockHeartbeaterMockRecorder) NeedTurnOffNotifier() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedTurnOffNotifier", reflect.TypeOf((*MockHeartbeater)(nil).NeedTurnOffNotifier))

--- a/mock/metric_source/fetch_result.go
+++ b/mock/metric_source/fetch_result.go
@@ -5,35 +5,36 @@
 package mock_metric_source
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	metricsource "github.com/moira-alert/moira/metric_source"
-	reflect "reflect"
 )
 
-// MockFetchResult is a mock of FetchResult interface
+// MockFetchResult is a mock of FetchResult interface.
 type MockFetchResult struct {
 	ctrl     *gomock.Controller
 	recorder *MockFetchResultMockRecorder
 }
 
-// MockFetchResultMockRecorder is the mock recorder for MockFetchResult
+// MockFetchResultMockRecorder is the mock recorder for MockFetchResult.
 type MockFetchResultMockRecorder struct {
 	mock *MockFetchResult
 }
 
-// NewMockFetchResult creates a new mock instance
+// NewMockFetchResult creates a new mock instance.
 func NewMockFetchResult(ctrl *gomock.Controller) *MockFetchResult {
 	mock := &MockFetchResult{ctrl: ctrl}
 	mock.recorder = &MockFetchResultMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFetchResult) EXPECT() *MockFetchResultMockRecorder {
 	return m.recorder
 }
 
-// GetMetricsData mocks base method
+// GetMetricsData mocks base method.
 func (m *MockFetchResult) GetMetricsData() []metricsource.MetricData {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsData")
@@ -41,13 +42,13 @@ func (m *MockFetchResult) GetMetricsData() []metricsource.MetricData {
 	return ret0
 }
 
-// GetMetricsData indicates an expected call of GetMetricsData
+// GetMetricsData indicates an expected call of GetMetricsData.
 func (mr *MockFetchResultMockRecorder) GetMetricsData() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsData", reflect.TypeOf((*MockFetchResult)(nil).GetMetricsData))
 }
 
-// GetPatternMetrics mocks base method
+// GetPatternMetrics mocks base method.
 func (m *MockFetchResult) GetPatternMetrics() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatternMetrics")
@@ -56,13 +57,13 @@ func (m *MockFetchResult) GetPatternMetrics() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetPatternMetrics indicates an expected call of GetPatternMetrics
+// GetPatternMetrics indicates an expected call of GetPatternMetrics.
 func (mr *MockFetchResultMockRecorder) GetPatternMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatternMetrics", reflect.TypeOf((*MockFetchResult)(nil).GetPatternMetrics))
 }
 
-// GetPatterns mocks base method
+// GetPatterns mocks base method.
 func (m *MockFetchResult) GetPatterns() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatterns")
@@ -71,7 +72,7 @@ func (m *MockFetchResult) GetPatterns() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetPatterns indicates an expected call of GetPatterns
+// GetPatterns indicates an expected call of GetPatterns.
 func (mr *MockFetchResultMockRecorder) GetPatterns() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatterns", reflect.TypeOf((*MockFetchResult)(nil).GetPatterns))

--- a/mock/metric_source/source.go
+++ b/mock/metric_source/source.go
@@ -5,35 +5,36 @@
 package mock_metric_source
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	metricsource "github.com/moira-alert/moira/metric_source"
-	reflect "reflect"
 )
 
-// MockMetricSource is a mock of MetricSource interface
+// MockMetricSource is a mock of MetricSource interface.
 type MockMetricSource struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetricSourceMockRecorder
 }
 
-// MockMetricSourceMockRecorder is the mock recorder for MockMetricSource
+// MockMetricSourceMockRecorder is the mock recorder for MockMetricSource.
 type MockMetricSourceMockRecorder struct {
 	mock *MockMetricSource
 }
 
-// NewMockMetricSource creates a new mock instance
+// NewMockMetricSource creates a new mock instance.
 func NewMockMetricSource(ctrl *gomock.Controller) *MockMetricSource {
 	mock := &MockMetricSource{ctrl: ctrl}
 	mock.recorder = &MockMetricSourceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMetricSource) EXPECT() *MockMetricSourceMockRecorder {
 	return m.recorder
 }
 
-// Fetch mocks base method
+// Fetch mocks base method.
 func (m *MockMetricSource) Fetch(arg0 string, arg1, arg2 int64, arg3 bool) (metricsource.FetchResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch", arg0, arg1, arg2, arg3)
@@ -42,13 +43,13 @@ func (m *MockMetricSource) Fetch(arg0 string, arg1, arg2 int64, arg3 bool) (metr
 	return ret0, ret1
 }
 
-// Fetch indicates an expected call of Fetch
+// Fetch indicates an expected call of Fetch.
 func (mr *MockMetricSourceMockRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockMetricSource)(nil).Fetch), arg0, arg1, arg2, arg3)
 }
 
-// GetMetricsTTLSeconds mocks base method
+// GetMetricsTTLSeconds mocks base method.
 func (m *MockMetricSource) GetMetricsTTLSeconds() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsTTLSeconds")
@@ -56,13 +57,13 @@ func (m *MockMetricSource) GetMetricsTTLSeconds() int64 {
 	return ret0
 }
 
-// GetMetricsTTLSeconds indicates an expected call of GetMetricsTTLSeconds
+// GetMetricsTTLSeconds indicates an expected call of GetMetricsTTLSeconds.
 func (mr *MockMetricSourceMockRecorder) GetMetricsTTLSeconds() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsTTLSeconds", reflect.TypeOf((*MockMetricSource)(nil).GetMetricsTTLSeconds))
 }
 
-// IsConfigured mocks base method
+// IsConfigured mocks base method.
 func (m *MockMetricSource) IsConfigured() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsConfigured")
@@ -71,7 +72,7 @@ func (m *MockMetricSource) IsConfigured() (bool, error) {
 	return ret0, ret1
 }
 
-// IsConfigured indicates an expected call of IsConfigured
+// IsConfigured indicates an expected call of IsConfigured.
 func (mr *MockMetricSourceMockRecorder) IsConfigured() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConfigured", reflect.TypeOf((*MockMetricSource)(nil).IsConfigured))

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -134,6 +134,20 @@ func (mr *MockDatabaseMockRecorder) AllowStale() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllowStale", reflect.TypeOf((*MockDatabase)(nil).AllowStale))
 }
 
+// DeleteTeam mocks base method.
+func (m *MockDatabase) DeleteTeam(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTeam", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTeam indicates an expected call of DeleteTeam.
+func (mr *MockDatabaseMockRecorder) DeleteTeam(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTeam", reflect.TypeOf((*MockDatabase)(nil).DeleteTeam), arg0, arg1)
+}
+
 // DeleteTriggerCheckLock mocks base method.
 func (m *MockDatabase) DeleteTriggerCheckLock(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -654,6 +668,36 @@ func (m *MockDatabase) GetTeam(arg0 string) (moira.Team, error) {
 func (mr *MockDatabaseMockRecorder) GetTeam(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeam", reflect.TypeOf((*MockDatabase)(nil).GetTeam), arg0)
+}
+
+// GetTeamContactIDs mocks base method.
+func (m *MockDatabase) GetTeamContactIDs(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamContactIDs", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamContactIDs indicates an expected call of GetTeamContactIDs.
+func (mr *MockDatabaseMockRecorder) GetTeamContactIDs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamContactIDs", reflect.TypeOf((*MockDatabase)(nil).GetTeamContactIDs), arg0)
+}
+
+// GetTeamSubscriptionIDs mocks base method.
+func (m *MockDatabase) GetTeamSubscriptionIDs(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamSubscriptionIDs", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamSubscriptionIDs indicates an expected call of GetTeamSubscriptionIDs.
+func (mr *MockDatabaseMockRecorder) GetTeamSubscriptionIDs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamSubscriptionIDs", reflect.TypeOf((*MockDatabase)(nil).GetTeamSubscriptionIDs), arg0)
 }
 
 // GetTeamUsers mocks base method.

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -5,37 +5,38 @@
 package mock_moira_alert
 
 import (
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	moira "github.com/moira-alert/moira"
 	tomb "gopkg.in/tomb.v2"
-	reflect "reflect"
-	time "time"
 )
 
-// MockDatabase is a mock of Database interface
+// MockDatabase is a mock of Database interface.
 type MockDatabase struct {
 	ctrl     *gomock.Controller
 	recorder *MockDatabaseMockRecorder
 }
 
-// MockDatabaseMockRecorder is the mock recorder for MockDatabase
+// MockDatabaseMockRecorder is the mock recorder for MockDatabase.
 type MockDatabaseMockRecorder struct {
 	mock *MockDatabase
 }
 
-// NewMockDatabase creates a new mock instance
+// NewMockDatabase creates a new mock instance.
 func NewMockDatabase(ctrl *gomock.Controller) *MockDatabase {
 	mock := &MockDatabase{ctrl: ctrl}
 	mock.recorder = &MockDatabaseMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDatabase) EXPECT() *MockDatabaseMockRecorder {
 	return m.recorder
 }
 
-// AcquireTriggerCheckLock mocks base method
+// AcquireTriggerCheckLock mocks base method.
 func (m *MockDatabase) AcquireTriggerCheckLock(arg0 string, arg1 int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcquireTriggerCheckLock", arg0, arg1)
@@ -43,13 +44,13 @@ func (m *MockDatabase) AcquireTriggerCheckLock(arg0 string, arg1 int) error {
 	return ret0
 }
 
-// AcquireTriggerCheckLock indicates an expected call of AcquireTriggerCheckLock
+// AcquireTriggerCheckLock indicates an expected call of AcquireTriggerCheckLock.
 func (mr *MockDatabaseMockRecorder) AcquireTriggerCheckLock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcquireTriggerCheckLock", reflect.TypeOf((*MockDatabase)(nil).AcquireTriggerCheckLock), arg0, arg1)
 }
 
-// AddLocalTriggersToCheck mocks base method
+// AddLocalTriggersToCheck mocks base method.
 func (m *MockDatabase) AddLocalTriggersToCheck(arg0 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddLocalTriggersToCheck", arg0)
@@ -57,13 +58,13 @@ func (m *MockDatabase) AddLocalTriggersToCheck(arg0 []string) error {
 	return ret0
 }
 
-// AddLocalTriggersToCheck indicates an expected call of AddLocalTriggersToCheck
+// AddLocalTriggersToCheck indicates an expected call of AddLocalTriggersToCheck.
 func (mr *MockDatabaseMockRecorder) AddLocalTriggersToCheck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLocalTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddLocalTriggersToCheck), arg0)
 }
 
-// AddNotification mocks base method
+// AddNotification mocks base method.
 func (m *MockDatabase) AddNotification(arg0 *moira.ScheduledNotification) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddNotification", arg0)
@@ -71,13 +72,13 @@ func (m *MockDatabase) AddNotification(arg0 *moira.ScheduledNotification) error 
 	return ret0
 }
 
-// AddNotification indicates an expected call of AddNotification
+// AddNotification indicates an expected call of AddNotification.
 func (mr *MockDatabaseMockRecorder) AddNotification(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNotification", reflect.TypeOf((*MockDatabase)(nil).AddNotification), arg0)
 }
 
-// AddNotifications mocks base method
+// AddNotifications mocks base method.
 func (m *MockDatabase) AddNotifications(arg0 []*moira.ScheduledNotification, arg1 int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddNotifications", arg0, arg1)
@@ -85,13 +86,13 @@ func (m *MockDatabase) AddNotifications(arg0 []*moira.ScheduledNotification, arg
 	return ret0
 }
 
-// AddNotifications indicates an expected call of AddNotifications
+// AddNotifications indicates an expected call of AddNotifications.
 func (mr *MockDatabaseMockRecorder) AddNotifications(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNotifications", reflect.TypeOf((*MockDatabase)(nil).AddNotifications), arg0, arg1)
 }
 
-// AddPatternMetric mocks base method
+// AddPatternMetric mocks base method.
 func (m *MockDatabase) AddPatternMetric(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPatternMetric", arg0, arg1)
@@ -99,13 +100,13 @@ func (m *MockDatabase) AddPatternMetric(arg0, arg1 string) error {
 	return ret0
 }
 
-// AddPatternMetric indicates an expected call of AddPatternMetric
+// AddPatternMetric indicates an expected call of AddPatternMetric.
 func (mr *MockDatabaseMockRecorder) AddPatternMetric(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPatternMetric", reflect.TypeOf((*MockDatabase)(nil).AddPatternMetric), arg0, arg1)
 }
 
-// AddRemoteTriggersToCheck mocks base method
+// AddRemoteTriggersToCheck mocks base method.
 func (m *MockDatabase) AddRemoteTriggersToCheck(arg0 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddRemoteTriggersToCheck", arg0)
@@ -113,13 +114,13 @@ func (m *MockDatabase) AddRemoteTriggersToCheck(arg0 []string) error {
 	return ret0
 }
 
-// AddRemoteTriggersToCheck indicates an expected call of AddRemoteTriggersToCheck
+// AddRemoteTriggersToCheck indicates an expected call of AddRemoteTriggersToCheck.
 func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
-// AllowStale mocks base method
+// AllowStale mocks base method.
 func (m *MockDatabase) AllowStale() moira.Database {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllowStale")
@@ -127,13 +128,13 @@ func (m *MockDatabase) AllowStale() moira.Database {
 	return ret0
 }
 
-// AllowStale indicates an expected call of AllowStale
+// AllowStale indicates an expected call of AllowStale.
 func (mr *MockDatabaseMockRecorder) AllowStale() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllowStale", reflect.TypeOf((*MockDatabase)(nil).AllowStale))
 }
 
-// DeleteTriggerCheckLock mocks base method
+// DeleteTriggerCheckLock mocks base method.
 func (m *MockDatabase) DeleteTriggerCheckLock(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTriggerCheckLock", arg0)
@@ -141,13 +142,13 @@ func (m *MockDatabase) DeleteTriggerCheckLock(arg0 string) error {
 	return ret0
 }
 
-// DeleteTriggerCheckLock indicates an expected call of DeleteTriggerCheckLock
+// DeleteTriggerCheckLock indicates an expected call of DeleteTriggerCheckLock.
 func (mr *MockDatabaseMockRecorder) DeleteTriggerCheckLock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTriggerCheckLock", reflect.TypeOf((*MockDatabase)(nil).DeleteTriggerCheckLock), arg0)
 }
 
-// DeleteTriggerThrottling mocks base method
+// DeleteTriggerThrottling mocks base method.
 func (m *MockDatabase) DeleteTriggerThrottling(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTriggerThrottling", arg0)
@@ -155,13 +156,13 @@ func (m *MockDatabase) DeleteTriggerThrottling(arg0 string) error {
 	return ret0
 }
 
-// DeleteTriggerThrottling indicates an expected call of DeleteTriggerThrottling
+// DeleteTriggerThrottling indicates an expected call of DeleteTriggerThrottling.
 func (mr *MockDatabaseMockRecorder) DeleteTriggerThrottling(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTriggerThrottling", reflect.TypeOf((*MockDatabase)(nil).DeleteTriggerThrottling), arg0)
 }
 
-// FetchNotificationEvent mocks base method
+// FetchNotificationEvent mocks base method.
 func (m *MockDatabase) FetchNotificationEvent() (moira.NotificationEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchNotificationEvent")
@@ -170,13 +171,13 @@ func (m *MockDatabase) FetchNotificationEvent() (moira.NotificationEvent, error)
 	return ret0, ret1
 }
 
-// FetchNotificationEvent indicates an expected call of FetchNotificationEvent
+// FetchNotificationEvent indicates an expected call of FetchNotificationEvent.
 func (mr *MockDatabaseMockRecorder) FetchNotificationEvent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNotificationEvent", reflect.TypeOf((*MockDatabase)(nil).FetchNotificationEvent))
 }
 
-// FetchNotifications mocks base method
+// FetchNotifications mocks base method.
 func (m *MockDatabase) FetchNotifications(arg0, arg1 int64) ([]*moira.ScheduledNotification, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchNotifications", arg0, arg1)
@@ -185,13 +186,13 @@ func (m *MockDatabase) FetchNotifications(arg0, arg1 int64) ([]*moira.ScheduledN
 	return ret0, ret1
 }
 
-// FetchNotifications indicates an expected call of FetchNotifications
+// FetchNotifications indicates an expected call of FetchNotifications.
 func (mr *MockDatabaseMockRecorder) FetchNotifications(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNotifications", reflect.TypeOf((*MockDatabase)(nil).FetchNotifications), arg0, arg1)
 }
 
-// FetchTriggersToReindex mocks base method
+// FetchTriggersToReindex mocks base method.
 func (m *MockDatabase) FetchTriggersToReindex(arg0 int64) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchTriggersToReindex", arg0)
@@ -200,13 +201,13 @@ func (m *MockDatabase) FetchTriggersToReindex(arg0 int64) ([]string, error) {
 	return ret0, ret1
 }
 
-// FetchTriggersToReindex indicates an expected call of FetchTriggersToReindex
+// FetchTriggersToReindex indicates an expected call of FetchTriggersToReindex.
 func (mr *MockDatabaseMockRecorder) FetchTriggersToReindex(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchTriggersToReindex", reflect.TypeOf((*MockDatabase)(nil).FetchTriggersToReindex), arg0)
 }
 
-// GetAllContacts mocks base method
+// GetAllContacts mocks base method.
 func (m *MockDatabase) GetAllContacts() ([]*moira.ContactData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllContacts")
@@ -215,13 +216,13 @@ func (m *MockDatabase) GetAllContacts() ([]*moira.ContactData, error) {
 	return ret0, ret1
 }
 
-// GetAllContacts indicates an expected call of GetAllContacts
+// GetAllContacts indicates an expected call of GetAllContacts.
 func (mr *MockDatabaseMockRecorder) GetAllContacts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllContacts", reflect.TypeOf((*MockDatabase)(nil).GetAllContacts))
 }
 
-// GetAllTriggerIDs mocks base method
+// GetAllTriggerIDs mocks base method.
 func (m *MockDatabase) GetAllTriggerIDs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllTriggerIDs")
@@ -230,13 +231,13 @@ func (m *MockDatabase) GetAllTriggerIDs() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetAllTriggerIDs indicates an expected call of GetAllTriggerIDs
+// GetAllTriggerIDs indicates an expected call of GetAllTriggerIDs.
 func (mr *MockDatabaseMockRecorder) GetAllTriggerIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetAllTriggerIDs))
 }
 
-// GetChecksUpdatesCount mocks base method
+// GetChecksUpdatesCount mocks base method.
 func (m *MockDatabase) GetChecksUpdatesCount() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChecksUpdatesCount")
@@ -245,13 +246,13 @@ func (m *MockDatabase) GetChecksUpdatesCount() (int64, error) {
 	return ret0, ret1
 }
 
-// GetChecksUpdatesCount indicates an expected call of GetChecksUpdatesCount
+// GetChecksUpdatesCount indicates an expected call of GetChecksUpdatesCount.
 func (mr *MockDatabaseMockRecorder) GetChecksUpdatesCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChecksUpdatesCount", reflect.TypeOf((*MockDatabase)(nil).GetChecksUpdatesCount))
 }
 
-// GetContact mocks base method
+// GetContact mocks base method.
 func (m *MockDatabase) GetContact(arg0 string) (moira.ContactData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContact", arg0)
@@ -260,13 +261,13 @@ func (m *MockDatabase) GetContact(arg0 string) (moira.ContactData, error) {
 	return ret0, ret1
 }
 
-// GetContact indicates an expected call of GetContact
+// GetContact indicates an expected call of GetContact.
 func (mr *MockDatabaseMockRecorder) GetContact(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContact", reflect.TypeOf((*MockDatabase)(nil).GetContact), arg0)
 }
 
-// GetContacts mocks base method
+// GetContacts mocks base method.
 func (m *MockDatabase) GetContacts(arg0 []string) ([]*moira.ContactData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContacts", arg0)
@@ -275,13 +276,13 @@ func (m *MockDatabase) GetContacts(arg0 []string) ([]*moira.ContactData, error) 
 	return ret0, ret1
 }
 
-// GetContacts indicates an expected call of GetContacts
+// GetContacts indicates an expected call of GetContacts.
 func (mr *MockDatabaseMockRecorder) GetContacts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContacts", reflect.TypeOf((*MockDatabase)(nil).GetContacts), arg0)
 }
 
-// GetIDByUsername mocks base method
+// GetIDByUsername mocks base method.
 func (m *MockDatabase) GetIDByUsername(arg0, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIDByUsername", arg0, arg1)
@@ -290,13 +291,13 @@ func (m *MockDatabase) GetIDByUsername(arg0, arg1 string) (string, error) {
 	return ret0, ret1
 }
 
-// GetIDByUsername indicates an expected call of GetIDByUsername
+// GetIDByUsername indicates an expected call of GetIDByUsername.
 func (mr *MockDatabaseMockRecorder) GetIDByUsername(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDByUsername", reflect.TypeOf((*MockDatabase)(nil).GetIDByUsername), arg0, arg1)
 }
 
-// GetLocalTriggerIDs mocks base method
+// GetLocalTriggerIDs mocks base method.
 func (m *MockDatabase) GetLocalTriggerIDs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLocalTriggerIDs")
@@ -305,13 +306,13 @@ func (m *MockDatabase) GetLocalTriggerIDs() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetLocalTriggerIDs indicates an expected call of GetLocalTriggerIDs
+// GetLocalTriggerIDs indicates an expected call of GetLocalTriggerIDs.
 func (mr *MockDatabaseMockRecorder) GetLocalTriggerIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetLocalTriggerIDs))
 }
 
-// GetLocalTriggersToCheck mocks base method
+// GetLocalTriggersToCheck mocks base method.
 func (m *MockDatabase) GetLocalTriggersToCheck(arg0 int) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLocalTriggersToCheck", arg0)
@@ -320,13 +321,13 @@ func (m *MockDatabase) GetLocalTriggersToCheck(arg0 int) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetLocalTriggersToCheck indicates an expected call of GetLocalTriggersToCheck
+// GetLocalTriggersToCheck indicates an expected call of GetLocalTriggersToCheck.
 func (mr *MockDatabaseMockRecorder) GetLocalTriggersToCheck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).GetLocalTriggersToCheck), arg0)
 }
 
-// GetLocalTriggersToCheckCount mocks base method
+// GetLocalTriggersToCheckCount mocks base method.
 func (m *MockDatabase) GetLocalTriggersToCheckCount() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLocalTriggersToCheckCount")
@@ -335,13 +336,13 @@ func (m *MockDatabase) GetLocalTriggersToCheckCount() (int64, error) {
 	return ret0, ret1
 }
 
-// GetLocalTriggersToCheckCount indicates an expected call of GetLocalTriggersToCheckCount
+// GetLocalTriggersToCheckCount indicates an expected call of GetLocalTriggersToCheckCount.
 func (mr *MockDatabaseMockRecorder) GetLocalTriggersToCheckCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalTriggersToCheckCount", reflect.TypeOf((*MockDatabase)(nil).GetLocalTriggersToCheckCount))
 }
 
-// GetMetricRetention mocks base method
+// GetMetricRetention mocks base method.
 func (m *MockDatabase) GetMetricRetention(arg0 string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricRetention", arg0)
@@ -350,13 +351,13 @@ func (m *MockDatabase) GetMetricRetention(arg0 string) (int64, error) {
 	return ret0, ret1
 }
 
-// GetMetricRetention indicates an expected call of GetMetricRetention
+// GetMetricRetention indicates an expected call of GetMetricRetention.
 func (mr *MockDatabaseMockRecorder) GetMetricRetention(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricRetention", reflect.TypeOf((*MockDatabase)(nil).GetMetricRetention), arg0)
 }
 
-// GetMetricsTTLSeconds mocks base method
+// GetMetricsTTLSeconds mocks base method.
 func (m *MockDatabase) GetMetricsTTLSeconds() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsTTLSeconds")
@@ -364,13 +365,13 @@ func (m *MockDatabase) GetMetricsTTLSeconds() int64 {
 	return ret0
 }
 
-// GetMetricsTTLSeconds indicates an expected call of GetMetricsTTLSeconds
+// GetMetricsTTLSeconds indicates an expected call of GetMetricsTTLSeconds.
 func (mr *MockDatabaseMockRecorder) GetMetricsTTLSeconds() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsTTLSeconds", reflect.TypeOf((*MockDatabase)(nil).GetMetricsTTLSeconds))
 }
 
-// GetMetricsUpdatesCount mocks base method
+// GetMetricsUpdatesCount mocks base method.
 func (m *MockDatabase) GetMetricsUpdatesCount() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsUpdatesCount")
@@ -379,13 +380,13 @@ func (m *MockDatabase) GetMetricsUpdatesCount() (int64, error) {
 	return ret0, ret1
 }
 
-// GetMetricsUpdatesCount indicates an expected call of GetMetricsUpdatesCount
+// GetMetricsUpdatesCount indicates an expected call of GetMetricsUpdatesCount.
 func (mr *MockDatabaseMockRecorder) GetMetricsUpdatesCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsUpdatesCount", reflect.TypeOf((*MockDatabase)(nil).GetMetricsUpdatesCount))
 }
 
-// GetMetricsValues mocks base method
+// GetMetricsValues mocks base method.
 func (m *MockDatabase) GetMetricsValues(arg0 []string, arg1, arg2 int64) (map[string][]*moira.MetricValue, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsValues", arg0, arg1, arg2)
@@ -394,13 +395,13 @@ func (m *MockDatabase) GetMetricsValues(arg0 []string, arg1, arg2 int64) (map[st
 	return ret0, ret1
 }
 
-// GetMetricsValues indicates an expected call of GetMetricsValues
+// GetMetricsValues indicates an expected call of GetMetricsValues.
 func (mr *MockDatabaseMockRecorder) GetMetricsValues(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsValues", reflect.TypeOf((*MockDatabase)(nil).GetMetricsValues), arg0, arg1, arg2)
 }
 
-// GetNotificationEventCount mocks base method
+// GetNotificationEventCount mocks base method.
 func (m *MockDatabase) GetNotificationEventCount(arg0 string, arg1 int64) int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotificationEventCount", arg0, arg1)
@@ -408,13 +409,13 @@ func (m *MockDatabase) GetNotificationEventCount(arg0 string, arg1 int64) int64 
 	return ret0
 }
 
-// GetNotificationEventCount indicates an expected call of GetNotificationEventCount
+// GetNotificationEventCount indicates an expected call of GetNotificationEventCount.
 func (mr *MockDatabaseMockRecorder) GetNotificationEventCount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEventCount", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEventCount), arg0, arg1)
 }
 
-// GetNotificationEvents mocks base method
+// GetNotificationEvents mocks base method.
 func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2 int64) ([]*moira.NotificationEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2)
@@ -423,13 +424,13 @@ func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2 int64) ([]*
 	return ret0, ret1
 }
 
-// GetNotificationEvents indicates an expected call of GetNotificationEvents
+// GetNotificationEvents indicates an expected call of GetNotificationEvents.
 func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1, arg2)
 }
 
-// GetNotifications mocks base method
+// GetNotifications mocks base method.
 func (m *MockDatabase) GetNotifications(arg0, arg1 int64) ([]*moira.ScheduledNotification, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotifications", arg0, arg1)
@@ -439,13 +440,13 @@ func (m *MockDatabase) GetNotifications(arg0, arg1 int64) ([]*moira.ScheduledNot
 	return ret0, ret1, ret2
 }
 
-// GetNotifications indicates an expected call of GetNotifications
+// GetNotifications indicates an expected call of GetNotifications.
 func (mr *MockDatabaseMockRecorder) GetNotifications(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifications", reflect.TypeOf((*MockDatabase)(nil).GetNotifications), arg0, arg1)
 }
 
-// GetNotifierState mocks base method
+// GetNotifierState mocks base method.
 func (m *MockDatabase) GetNotifierState() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotifierState")
@@ -454,13 +455,13 @@ func (m *MockDatabase) GetNotifierState() (string, error) {
 	return ret0, ret1
 }
 
-// GetNotifierState indicates an expected call of GetNotifierState
+// GetNotifierState indicates an expected call of GetNotifierState.
 func (mr *MockDatabaseMockRecorder) GetNotifierState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifierState", reflect.TypeOf((*MockDatabase)(nil).GetNotifierState))
 }
 
-// GetPatternMetrics mocks base method
+// GetPatternMetrics mocks base method.
 func (m *MockDatabase) GetPatternMetrics(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatternMetrics", arg0)
@@ -469,13 +470,13 @@ func (m *MockDatabase) GetPatternMetrics(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetPatternMetrics indicates an expected call of GetPatternMetrics
+// GetPatternMetrics indicates an expected call of GetPatternMetrics.
 func (mr *MockDatabaseMockRecorder) GetPatternMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatternMetrics", reflect.TypeOf((*MockDatabase)(nil).GetPatternMetrics), arg0)
 }
 
-// GetPatternTriggerIDs mocks base method
+// GetPatternTriggerIDs mocks base method.
 func (m *MockDatabase) GetPatternTriggerIDs(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatternTriggerIDs", arg0)
@@ -484,13 +485,13 @@ func (m *MockDatabase) GetPatternTriggerIDs(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetPatternTriggerIDs indicates an expected call of GetPatternTriggerIDs
+// GetPatternTriggerIDs indicates an expected call of GetPatternTriggerIDs.
 func (mr *MockDatabaseMockRecorder) GetPatternTriggerIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatternTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetPatternTriggerIDs), arg0)
 }
 
-// GetPatterns mocks base method
+// GetPatterns mocks base method.
 func (m *MockDatabase) GetPatterns() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatterns")
@@ -499,13 +500,13 @@ func (m *MockDatabase) GetPatterns() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetPatterns indicates an expected call of GetPatterns
+// GetPatterns indicates an expected call of GetPatterns.
 func (mr *MockDatabaseMockRecorder) GetPatterns() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatterns", reflect.TypeOf((*MockDatabase)(nil).GetPatterns))
 }
 
-// GetRemoteChecksUpdatesCount mocks base method
+// GetRemoteChecksUpdatesCount mocks base method.
 func (m *MockDatabase) GetRemoteChecksUpdatesCount() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteChecksUpdatesCount")
@@ -514,13 +515,13 @@ func (m *MockDatabase) GetRemoteChecksUpdatesCount() (int64, error) {
 	return ret0, ret1
 }
 
-// GetRemoteChecksUpdatesCount indicates an expected call of GetRemoteChecksUpdatesCount
+// GetRemoteChecksUpdatesCount indicates an expected call of GetRemoteChecksUpdatesCount.
 func (mr *MockDatabaseMockRecorder) GetRemoteChecksUpdatesCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteChecksUpdatesCount", reflect.TypeOf((*MockDatabase)(nil).GetRemoteChecksUpdatesCount))
 }
 
-// GetRemoteTriggerIDs mocks base method
+// GetRemoteTriggerIDs mocks base method.
 func (m *MockDatabase) GetRemoteTriggerIDs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteTriggerIDs")
@@ -529,13 +530,13 @@ func (m *MockDatabase) GetRemoteTriggerIDs() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetRemoteTriggerIDs indicates an expected call of GetRemoteTriggerIDs
+// GetRemoteTriggerIDs indicates an expected call of GetRemoteTriggerIDs.
 func (mr *MockDatabaseMockRecorder) GetRemoteTriggerIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetRemoteTriggerIDs))
 }
 
-// GetRemoteTriggersToCheck mocks base method
+// GetRemoteTriggersToCheck mocks base method.
 func (m *MockDatabase) GetRemoteTriggersToCheck(arg0 int) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteTriggersToCheck", arg0)
@@ -544,13 +545,13 @@ func (m *MockDatabase) GetRemoteTriggersToCheck(arg0 int) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetRemoteTriggersToCheck indicates an expected call of GetRemoteTriggersToCheck
+// GetRemoteTriggersToCheck indicates an expected call of GetRemoteTriggersToCheck.
 func (mr *MockDatabaseMockRecorder) GetRemoteTriggersToCheck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).GetRemoteTriggersToCheck), arg0)
 }
 
-// GetRemoteTriggersToCheckCount mocks base method
+// GetRemoteTriggersToCheckCount mocks base method.
 func (m *MockDatabase) GetRemoteTriggersToCheckCount() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteTriggersToCheckCount")
@@ -559,13 +560,13 @@ func (m *MockDatabase) GetRemoteTriggersToCheckCount() (int64, error) {
 	return ret0, ret1
 }
 
-// GetRemoteTriggersToCheckCount indicates an expected call of GetRemoteTriggersToCheckCount
+// GetRemoteTriggersToCheckCount indicates an expected call of GetRemoteTriggersToCheckCount.
 func (mr *MockDatabaseMockRecorder) GetRemoteTriggersToCheckCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteTriggersToCheckCount", reflect.TypeOf((*MockDatabase)(nil).GetRemoteTriggersToCheckCount))
 }
 
-// GetSubscription mocks base method
+// GetSubscription mocks base method.
 func (m *MockDatabase) GetSubscription(arg0 string) (moira.SubscriptionData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubscription", arg0)
@@ -574,13 +575,13 @@ func (m *MockDatabase) GetSubscription(arg0 string) (moira.SubscriptionData, err
 	return ret0, ret1
 }
 
-// GetSubscription indicates an expected call of GetSubscription
+// GetSubscription indicates an expected call of GetSubscription.
 func (mr *MockDatabaseMockRecorder) GetSubscription(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscription", reflect.TypeOf((*MockDatabase)(nil).GetSubscription), arg0)
 }
 
-// GetSubscriptions mocks base method
+// GetSubscriptions mocks base method.
 func (m *MockDatabase) GetSubscriptions(arg0 []string) ([]*moira.SubscriptionData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubscriptions", arg0)
@@ -589,13 +590,13 @@ func (m *MockDatabase) GetSubscriptions(arg0 []string) ([]*moira.SubscriptionDat
 	return ret0, ret1
 }
 
-// GetSubscriptions indicates an expected call of GetSubscriptions
+// GetSubscriptions indicates an expected call of GetSubscriptions.
 func (mr *MockDatabaseMockRecorder) GetSubscriptions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubscriptions", reflect.TypeOf((*MockDatabase)(nil).GetSubscriptions), arg0)
 }
 
-// GetTagNames mocks base method
+// GetTagNames mocks base method.
 func (m *MockDatabase) GetTagNames() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagNames")
@@ -604,13 +605,13 @@ func (m *MockDatabase) GetTagNames() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetTagNames indicates an expected call of GetTagNames
+// GetTagNames indicates an expected call of GetTagNames.
 func (mr *MockDatabaseMockRecorder) GetTagNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagNames", reflect.TypeOf((*MockDatabase)(nil).GetTagNames))
 }
 
-// GetTagTriggerIDs mocks base method
+// GetTagTriggerIDs mocks base method.
 func (m *MockDatabase) GetTagTriggerIDs(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagTriggerIDs", arg0)
@@ -619,13 +620,13 @@ func (m *MockDatabase) GetTagTriggerIDs(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetTagTriggerIDs indicates an expected call of GetTagTriggerIDs
+// GetTagTriggerIDs indicates an expected call of GetTagTriggerIDs.
 func (mr *MockDatabaseMockRecorder) GetTagTriggerIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetTagTriggerIDs), arg0)
 }
 
-// GetTagsSubscriptions mocks base method
+// GetTagsSubscriptions mocks base method.
 func (m *MockDatabase) GetTagsSubscriptions(arg0 []string) ([]*moira.SubscriptionData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagsSubscriptions", arg0)
@@ -634,13 +635,43 @@ func (m *MockDatabase) GetTagsSubscriptions(arg0 []string) ([]*moira.Subscriptio
 	return ret0, ret1
 }
 
-// GetTagsSubscriptions indicates an expected call of GetTagsSubscriptions
+// GetTagsSubscriptions indicates an expected call of GetTagsSubscriptions.
 func (mr *MockDatabaseMockRecorder) GetTagsSubscriptions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagsSubscriptions", reflect.TypeOf((*MockDatabase)(nil).GetTagsSubscriptions), arg0)
 }
 
-// GetTrigger mocks base method
+// GetTeam mocks base method.
+func (m *MockDatabase) GetTeam(arg0 string) (moira.Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeam", arg0)
+	ret0, _ := ret[0].(moira.Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeam indicates an expected call of GetTeam.
+func (mr *MockDatabaseMockRecorder) GetTeam(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeam", reflect.TypeOf((*MockDatabase)(nil).GetTeam), arg0)
+}
+
+// GetTeamUsers mocks base method.
+func (m *MockDatabase) GetTeamUsers(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamUsers", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamUsers indicates an expected call of GetTeamUsers.
+func (mr *MockDatabaseMockRecorder) GetTeamUsers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamUsers", reflect.TypeOf((*MockDatabase)(nil).GetTeamUsers), arg0)
+}
+
+// GetTrigger mocks base method.
 func (m *MockDatabase) GetTrigger(arg0 string) (moira.Trigger, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTrigger", arg0)
@@ -649,13 +680,13 @@ func (m *MockDatabase) GetTrigger(arg0 string) (moira.Trigger, error) {
 	return ret0, ret1
 }
 
-// GetTrigger indicates an expected call of GetTrigger
+// GetTrigger indicates an expected call of GetTrigger.
 func (mr *MockDatabaseMockRecorder) GetTrigger(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrigger", reflect.TypeOf((*MockDatabase)(nil).GetTrigger), arg0)
 }
 
-// GetTriggerChecks mocks base method
+// GetTriggerChecks mocks base method.
 func (m *MockDatabase) GetTriggerChecks(arg0 []string) ([]*moira.TriggerCheck, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTriggerChecks", arg0)
@@ -664,13 +695,13 @@ func (m *MockDatabase) GetTriggerChecks(arg0 []string) ([]*moira.TriggerCheck, e
 	return ret0, ret1
 }
 
-// GetTriggerChecks indicates an expected call of GetTriggerChecks
+// GetTriggerChecks indicates an expected call of GetTriggerChecks.
 func (mr *MockDatabaseMockRecorder) GetTriggerChecks(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggerChecks", reflect.TypeOf((*MockDatabase)(nil).GetTriggerChecks), arg0)
 }
 
-// GetTriggerLastCheck mocks base method
+// GetTriggerLastCheck mocks base method.
 func (m *MockDatabase) GetTriggerLastCheck(arg0 string) (moira.CheckData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTriggerLastCheck", arg0)
@@ -679,13 +710,13 @@ func (m *MockDatabase) GetTriggerLastCheck(arg0 string) (moira.CheckData, error)
 	return ret0, ret1
 }
 
-// GetTriggerLastCheck indicates an expected call of GetTriggerLastCheck
+// GetTriggerLastCheck indicates an expected call of GetTriggerLastCheck.
 func (mr *MockDatabaseMockRecorder) GetTriggerLastCheck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggerLastCheck", reflect.TypeOf((*MockDatabase)(nil).GetTriggerLastCheck), arg0)
 }
 
-// GetTriggerThrottling mocks base method
+// GetTriggerThrottling mocks base method.
 func (m *MockDatabase) GetTriggerThrottling(arg0 string) (time.Time, time.Time) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTriggerThrottling", arg0)
@@ -694,13 +725,13 @@ func (m *MockDatabase) GetTriggerThrottling(arg0 string) (time.Time, time.Time) 
 	return ret0, ret1
 }
 
-// GetTriggerThrottling indicates an expected call of GetTriggerThrottling
+// GetTriggerThrottling indicates an expected call of GetTriggerThrottling.
 func (mr *MockDatabaseMockRecorder) GetTriggerThrottling(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggerThrottling", reflect.TypeOf((*MockDatabase)(nil).GetTriggerThrottling), arg0)
 }
 
-// GetTriggers mocks base method
+// GetTriggers mocks base method.
 func (m *MockDatabase) GetTriggers(arg0 []string) ([]*moira.Trigger, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTriggers", arg0)
@@ -709,13 +740,13 @@ func (m *MockDatabase) GetTriggers(arg0 []string) ([]*moira.Trigger, error) {
 	return ret0, ret1
 }
 
-// GetTriggers indicates an expected call of GetTriggers
+// GetTriggers indicates an expected call of GetTriggers.
 func (mr *MockDatabaseMockRecorder) GetTriggers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggers", reflect.TypeOf((*MockDatabase)(nil).GetTriggers), arg0)
 }
 
-// GetTriggersSearchResults mocks base method
+// GetTriggersSearchResults mocks base method.
 func (m *MockDatabase) GetTriggersSearchResults(arg0 string, arg1, arg2 int64) ([]*moira.SearchResult, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTriggersSearchResults", arg0, arg1, arg2)
@@ -725,13 +756,13 @@ func (m *MockDatabase) GetTriggersSearchResults(arg0 string, arg1, arg2 int64) (
 	return ret0, ret1, ret2
 }
 
-// GetTriggersSearchResults indicates an expected call of GetTriggersSearchResults
+// GetTriggersSearchResults indicates an expected call of GetTriggersSearchResults.
 func (mr *MockDatabaseMockRecorder) GetTriggersSearchResults(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTriggersSearchResults", reflect.TypeOf((*MockDatabase)(nil).GetTriggersSearchResults), arg0, arg1, arg2)
 }
 
-// GetUnusedTriggerIDs mocks base method
+// GetUnusedTriggerIDs mocks base method.
 func (m *MockDatabase) GetUnusedTriggerIDs() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnusedTriggerIDs")
@@ -740,13 +771,13 @@ func (m *MockDatabase) GetUnusedTriggerIDs() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetUnusedTriggerIDs indicates an expected call of GetUnusedTriggerIDs
+// GetUnusedTriggerIDs indicates an expected call of GetUnusedTriggerIDs.
 func (mr *MockDatabaseMockRecorder) GetUnusedTriggerIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnusedTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).GetUnusedTriggerIDs))
 }
 
-// GetUserContactIDs mocks base method
+// GetUserContactIDs mocks base method.
 func (m *MockDatabase) GetUserContactIDs(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserContactIDs", arg0)
@@ -755,13 +786,13 @@ func (m *MockDatabase) GetUserContactIDs(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetUserContactIDs indicates an expected call of GetUserContactIDs
+// GetUserContactIDs indicates an expected call of GetUserContactIDs.
 func (mr *MockDatabaseMockRecorder) GetUserContactIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserContactIDs", reflect.TypeOf((*MockDatabase)(nil).GetUserContactIDs), arg0)
 }
 
-// GetUserSubscriptionIDs mocks base method
+// GetUserSubscriptionIDs mocks base method.
 func (m *MockDatabase) GetUserSubscriptionIDs(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserSubscriptionIDs", arg0)
@@ -770,13 +801,43 @@ func (m *MockDatabase) GetUserSubscriptionIDs(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetUserSubscriptionIDs indicates an expected call of GetUserSubscriptionIDs
+// GetUserSubscriptionIDs indicates an expected call of GetUserSubscriptionIDs.
 func (mr *MockDatabaseMockRecorder) GetUserSubscriptionIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSubscriptionIDs", reflect.TypeOf((*MockDatabase)(nil).GetUserSubscriptionIDs), arg0)
 }
 
-// MarkTriggersAsUnused mocks base method
+// GetUserTeams mocks base method.
+func (m *MockDatabase) GetUserTeams(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserTeams", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserTeams indicates an expected call of GetUserTeams.
+func (mr *MockDatabaseMockRecorder) GetUserTeams(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTeams", reflect.TypeOf((*MockDatabase)(nil).GetUserTeams), arg0)
+}
+
+// IsTeamContainUser mocks base method.
+func (m *MockDatabase) IsTeamContainUser(arg0, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsTeamContainUser", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsTeamContainUser indicates an expected call of IsTeamContainUser.
+func (mr *MockDatabaseMockRecorder) IsTeamContainUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamContainUser", reflect.TypeOf((*MockDatabase)(nil).IsTeamContainUser), arg0, arg1)
+}
+
+// MarkTriggersAsUnused mocks base method.
 func (m *MockDatabase) MarkTriggersAsUnused(arg0 ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -788,13 +849,13 @@ func (m *MockDatabase) MarkTriggersAsUnused(arg0 ...string) error {
 	return ret0
 }
 
-// MarkTriggersAsUnused indicates an expected call of MarkTriggersAsUnused
+// MarkTriggersAsUnused indicates an expected call of MarkTriggersAsUnused.
 func (mr *MockDatabaseMockRecorder) MarkTriggersAsUnused(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkTriggersAsUnused", reflect.TypeOf((*MockDatabase)(nil).MarkTriggersAsUnused), arg0...)
 }
 
-// MarkTriggersAsUsed mocks base method
+// MarkTriggersAsUsed mocks base method.
 func (m *MockDatabase) MarkTriggersAsUsed(arg0 ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -806,13 +867,13 @@ func (m *MockDatabase) MarkTriggersAsUsed(arg0 ...string) error {
 	return ret0
 }
 
-// MarkTriggersAsUsed indicates an expected call of MarkTriggersAsUsed
+// MarkTriggersAsUsed indicates an expected call of MarkTriggersAsUsed.
 func (mr *MockDatabaseMockRecorder) MarkTriggersAsUsed(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkTriggersAsUsed", reflect.TypeOf((*MockDatabase)(nil).MarkTriggersAsUsed), arg0...)
 }
 
-// NewLock mocks base method
+// NewLock mocks base method.
 func (m *MockDatabase) NewLock(arg0 string, arg1 time.Duration) moira.Lock {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewLock", arg0, arg1)
@@ -820,13 +881,13 @@ func (m *MockDatabase) NewLock(arg0 string, arg1 time.Duration) moira.Lock {
 	return ret0
 }
 
-// NewLock indicates an expected call of NewLock
+// NewLock indicates an expected call of NewLock.
 func (mr *MockDatabaseMockRecorder) NewLock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewLock", reflect.TypeOf((*MockDatabase)(nil).NewLock), arg0, arg1)
 }
 
-// PushNotificationEvent mocks base method
+// PushNotificationEvent mocks base method.
 func (m *MockDatabase) PushNotificationEvent(arg0 *moira.NotificationEvent, arg1 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PushNotificationEvent", arg0, arg1)
@@ -834,13 +895,13 @@ func (m *MockDatabase) PushNotificationEvent(arg0 *moira.NotificationEvent, arg1
 	return ret0
 }
 
-// PushNotificationEvent indicates an expected call of PushNotificationEvent
+// PushNotificationEvent indicates an expected call of PushNotificationEvent.
 func (mr *MockDatabaseMockRecorder) PushNotificationEvent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushNotificationEvent", reflect.TypeOf((*MockDatabase)(nil).PushNotificationEvent), arg0, arg1)
 }
 
-// RemoveAllNotificationEvents mocks base method
+// RemoveAllNotificationEvents mocks base method.
 func (m *MockDatabase) RemoveAllNotificationEvents() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllNotificationEvents")
@@ -848,13 +909,13 @@ func (m *MockDatabase) RemoveAllNotificationEvents() error {
 	return ret0
 }
 
-// RemoveAllNotificationEvents indicates an expected call of RemoveAllNotificationEvents
+// RemoveAllNotificationEvents indicates an expected call of RemoveAllNotificationEvents.
 func (mr *MockDatabaseMockRecorder) RemoveAllNotificationEvents() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).RemoveAllNotificationEvents))
 }
 
-// RemoveAllNotifications mocks base method
+// RemoveAllNotifications mocks base method.
 func (m *MockDatabase) RemoveAllNotifications() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAllNotifications")
@@ -862,13 +923,13 @@ func (m *MockDatabase) RemoveAllNotifications() error {
 	return ret0
 }
 
-// RemoveAllNotifications indicates an expected call of RemoveAllNotifications
+// RemoveAllNotifications indicates an expected call of RemoveAllNotifications.
 func (mr *MockDatabaseMockRecorder) RemoveAllNotifications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllNotifications", reflect.TypeOf((*MockDatabase)(nil).RemoveAllNotifications))
 }
 
-// RemoveContact mocks base method
+// RemoveContact mocks base method.
 func (m *MockDatabase) RemoveContact(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveContact", arg0)
@@ -876,13 +937,13 @@ func (m *MockDatabase) RemoveContact(arg0 string) error {
 	return ret0
 }
 
-// RemoveContact indicates an expected call of RemoveContact
+// RemoveContact indicates an expected call of RemoveContact.
 func (mr *MockDatabaseMockRecorder) RemoveContact(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContact", reflect.TypeOf((*MockDatabase)(nil).RemoveContact), arg0)
 }
 
-// RemoveMetricValues mocks base method
+// RemoveMetricValues mocks base method.
 func (m *MockDatabase) RemoveMetricValues(arg0 string, arg1 int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveMetricValues", arg0, arg1)
@@ -890,13 +951,13 @@ func (m *MockDatabase) RemoveMetricValues(arg0 string, arg1 int64) error {
 	return ret0
 }
 
-// RemoveMetricValues indicates an expected call of RemoveMetricValues
+// RemoveMetricValues indicates an expected call of RemoveMetricValues.
 func (mr *MockDatabaseMockRecorder) RemoveMetricValues(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMetricValues", reflect.TypeOf((*MockDatabase)(nil).RemoveMetricValues), arg0, arg1)
 }
 
-// RemoveMetricsValues mocks base method
+// RemoveMetricsValues mocks base method.
 func (m *MockDatabase) RemoveMetricsValues(arg0 []string, arg1 int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveMetricsValues", arg0, arg1)
@@ -904,13 +965,13 @@ func (m *MockDatabase) RemoveMetricsValues(arg0 []string, arg1 int64) error {
 	return ret0
 }
 
-// RemoveMetricsValues indicates an expected call of RemoveMetricsValues
+// RemoveMetricsValues indicates an expected call of RemoveMetricsValues.
 func (mr *MockDatabaseMockRecorder) RemoveMetricsValues(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMetricsValues", reflect.TypeOf((*MockDatabase)(nil).RemoveMetricsValues), arg0, arg1)
 }
 
-// RemoveNotification mocks base method
+// RemoveNotification mocks base method.
 func (m *MockDatabase) RemoveNotification(arg0 string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveNotification", arg0)
@@ -919,13 +980,13 @@ func (m *MockDatabase) RemoveNotification(arg0 string) (int64, error) {
 	return ret0, ret1
 }
 
-// RemoveNotification indicates an expected call of RemoveNotification
+// RemoveNotification indicates an expected call of RemoveNotification.
 func (mr *MockDatabaseMockRecorder) RemoveNotification(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveNotification", reflect.TypeOf((*MockDatabase)(nil).RemoveNotification), arg0)
 }
 
-// RemovePattern mocks base method
+// RemovePattern mocks base method.
 func (m *MockDatabase) RemovePattern(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemovePattern", arg0)
@@ -933,13 +994,13 @@ func (m *MockDatabase) RemovePattern(arg0 string) error {
 	return ret0
 }
 
-// RemovePattern indicates an expected call of RemovePattern
+// RemovePattern indicates an expected call of RemovePattern.
 func (mr *MockDatabaseMockRecorder) RemovePattern(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePattern", reflect.TypeOf((*MockDatabase)(nil).RemovePattern), arg0)
 }
 
-// RemovePatternTriggerIDs mocks base method
+// RemovePatternTriggerIDs mocks base method.
 func (m *MockDatabase) RemovePatternTriggerIDs(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemovePatternTriggerIDs", arg0)
@@ -947,13 +1008,13 @@ func (m *MockDatabase) RemovePatternTriggerIDs(arg0 string) error {
 	return ret0
 }
 
-// RemovePatternTriggerIDs indicates an expected call of RemovePatternTriggerIDs
+// RemovePatternTriggerIDs indicates an expected call of RemovePatternTriggerIDs.
 func (mr *MockDatabaseMockRecorder) RemovePatternTriggerIDs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePatternTriggerIDs", reflect.TypeOf((*MockDatabase)(nil).RemovePatternTriggerIDs), arg0)
 }
 
-// RemovePatternWithMetrics mocks base method
+// RemovePatternWithMetrics mocks base method.
 func (m *MockDatabase) RemovePatternWithMetrics(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemovePatternWithMetrics", arg0)
@@ -961,13 +1022,13 @@ func (m *MockDatabase) RemovePatternWithMetrics(arg0 string) error {
 	return ret0
 }
 
-// RemovePatternWithMetrics indicates an expected call of RemovePatternWithMetrics
+// RemovePatternWithMetrics indicates an expected call of RemovePatternWithMetrics.
 func (mr *MockDatabaseMockRecorder) RemovePatternWithMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePatternWithMetrics", reflect.TypeOf((*MockDatabase)(nil).RemovePatternWithMetrics), arg0)
 }
 
-// RemovePatternsMetrics mocks base method
+// RemovePatternsMetrics mocks base method.
 func (m *MockDatabase) RemovePatternsMetrics(arg0 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemovePatternsMetrics", arg0)
@@ -975,13 +1036,13 @@ func (m *MockDatabase) RemovePatternsMetrics(arg0 []string) error {
 	return ret0
 }
 
-// RemovePatternsMetrics indicates an expected call of RemovePatternsMetrics
+// RemovePatternsMetrics indicates an expected call of RemovePatternsMetrics.
 func (mr *MockDatabaseMockRecorder) RemovePatternsMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePatternsMetrics", reflect.TypeOf((*MockDatabase)(nil).RemovePatternsMetrics), arg0)
 }
 
-// RemoveSubscription mocks base method
+// RemoveSubscription mocks base method.
 func (m *MockDatabase) RemoveSubscription(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSubscription", arg0)
@@ -989,13 +1050,13 @@ func (m *MockDatabase) RemoveSubscription(arg0 string) error {
 	return ret0
 }
 
-// RemoveSubscription indicates an expected call of RemoveSubscription
+// RemoveSubscription indicates an expected call of RemoveSubscription.
 func (mr *MockDatabaseMockRecorder) RemoveSubscription(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubscription", reflect.TypeOf((*MockDatabase)(nil).RemoveSubscription), arg0)
 }
 
-// RemoveTag mocks base method
+// RemoveTag mocks base method.
 func (m *MockDatabase) RemoveTag(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTag", arg0)
@@ -1003,13 +1064,13 @@ func (m *MockDatabase) RemoveTag(arg0 string) error {
 	return ret0
 }
 
-// RemoveTag indicates an expected call of RemoveTag
+// RemoveTag indicates an expected call of RemoveTag.
 func (mr *MockDatabaseMockRecorder) RemoveTag(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTag", reflect.TypeOf((*MockDatabase)(nil).RemoveTag), arg0)
 }
 
-// RemoveTrigger mocks base method
+// RemoveTrigger mocks base method.
 func (m *MockDatabase) RemoveTrigger(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTrigger", arg0)
@@ -1017,13 +1078,13 @@ func (m *MockDatabase) RemoveTrigger(arg0 string) error {
 	return ret0
 }
 
-// RemoveTrigger indicates an expected call of RemoveTrigger
+// RemoveTrigger indicates an expected call of RemoveTrigger.
 func (mr *MockDatabaseMockRecorder) RemoveTrigger(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTrigger", reflect.TypeOf((*MockDatabase)(nil).RemoveTrigger), arg0)
 }
 
-// RemoveTriggerLastCheck mocks base method
+// RemoveTriggerLastCheck mocks base method.
 func (m *MockDatabase) RemoveTriggerLastCheck(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTriggerLastCheck", arg0)
@@ -1031,13 +1092,13 @@ func (m *MockDatabase) RemoveTriggerLastCheck(arg0 string) error {
 	return ret0
 }
 
-// RemoveTriggerLastCheck indicates an expected call of RemoveTriggerLastCheck
+// RemoveTriggerLastCheck indicates an expected call of RemoveTriggerLastCheck.
 func (mr *MockDatabaseMockRecorder) RemoveTriggerLastCheck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTriggerLastCheck", reflect.TypeOf((*MockDatabase)(nil).RemoveTriggerLastCheck), arg0)
 }
 
-// RemoveTriggersToReindex mocks base method
+// RemoveTriggersToReindex mocks base method.
 func (m *MockDatabase) RemoveTriggersToReindex(arg0 int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTriggersToReindex", arg0)
@@ -1045,13 +1106,13 @@ func (m *MockDatabase) RemoveTriggersToReindex(arg0 int64) error {
 	return ret0
 }
 
-// RemoveTriggersToReindex indicates an expected call of RemoveTriggersToReindex
+// RemoveTriggersToReindex indicates an expected call of RemoveTriggersToReindex.
 func (mr *MockDatabaseMockRecorder) RemoveTriggersToReindex(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTriggersToReindex", reflect.TypeOf((*MockDatabase)(nil).RemoveTriggersToReindex), arg0)
 }
 
-// RemoveUser mocks base method
+// RemoveUser mocks base method.
 func (m *MockDatabase) RemoveUser(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveUser", arg0, arg1)
@@ -1059,13 +1120,13 @@ func (m *MockDatabase) RemoveUser(arg0, arg1 string) error {
 	return ret0
 }
 
-// RemoveUser indicates an expected call of RemoveUser
+// RemoveUser indicates an expected call of RemoveUser.
 func (mr *MockDatabaseMockRecorder) RemoveUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUser", reflect.TypeOf((*MockDatabase)(nil).RemoveUser), arg0, arg1)
 }
 
-// SaveContact mocks base method
+// SaveContact mocks base method.
 func (m *MockDatabase) SaveContact(arg0 *moira.ContactData) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveContact", arg0)
@@ -1073,13 +1134,13 @@ func (m *MockDatabase) SaveContact(arg0 *moira.ContactData) error {
 	return ret0
 }
 
-// SaveContact indicates an expected call of SaveContact
+// SaveContact indicates an expected call of SaveContact.
 func (mr *MockDatabaseMockRecorder) SaveContact(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveContact", reflect.TypeOf((*MockDatabase)(nil).SaveContact), arg0)
 }
 
-// SaveMetrics mocks base method
+// SaveMetrics mocks base method.
 func (m *MockDatabase) SaveMetrics(arg0 map[string]*moira.MatchedMetric) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveMetrics", arg0)
@@ -1087,13 +1148,13 @@ func (m *MockDatabase) SaveMetrics(arg0 map[string]*moira.MatchedMetric) error {
 	return ret0
 }
 
-// SaveMetrics indicates an expected call of SaveMetrics
+// SaveMetrics indicates an expected call of SaveMetrics.
 func (mr *MockDatabaseMockRecorder) SaveMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveMetrics", reflect.TypeOf((*MockDatabase)(nil).SaveMetrics), arg0)
 }
 
-// SaveSubscription mocks base method
+// SaveSubscription mocks base method.
 func (m *MockDatabase) SaveSubscription(arg0 *moira.SubscriptionData) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSubscription", arg0)
@@ -1101,13 +1162,13 @@ func (m *MockDatabase) SaveSubscription(arg0 *moira.SubscriptionData) error {
 	return ret0
 }
 
-// SaveSubscription indicates an expected call of SaveSubscription
+// SaveSubscription indicates an expected call of SaveSubscription.
 func (mr *MockDatabaseMockRecorder) SaveSubscription(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSubscription", reflect.TypeOf((*MockDatabase)(nil).SaveSubscription), arg0)
 }
 
-// SaveSubscriptions mocks base method
+// SaveSubscriptions mocks base method.
 func (m *MockDatabase) SaveSubscriptions(arg0 []*moira.SubscriptionData) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSubscriptions", arg0)
@@ -1115,13 +1176,41 @@ func (m *MockDatabase) SaveSubscriptions(arg0 []*moira.SubscriptionData) error {
 	return ret0
 }
 
-// SaveSubscriptions indicates an expected call of SaveSubscriptions
+// SaveSubscriptions indicates an expected call of SaveSubscriptions.
 func (mr *MockDatabaseMockRecorder) SaveSubscriptions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSubscriptions", reflect.TypeOf((*MockDatabase)(nil).SaveSubscriptions), arg0)
 }
 
-// SaveTrigger mocks base method
+// SaveTeam mocks base method.
+func (m *MockDatabase) SaveTeam(arg0 string, arg1 moira.Team) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveTeam", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveTeam indicates an expected call of SaveTeam.
+func (mr *MockDatabaseMockRecorder) SaveTeam(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTeam", reflect.TypeOf((*MockDatabase)(nil).SaveTeam), arg0, arg1)
+}
+
+// SaveTeamsAndUsers mocks base method.
+func (m *MockDatabase) SaveTeamsAndUsers(arg0 string, arg1 []string, arg2 map[string][]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveTeamsAndUsers", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveTeamsAndUsers indicates an expected call of SaveTeamsAndUsers.
+func (mr *MockDatabaseMockRecorder) SaveTeamsAndUsers(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTeamsAndUsers", reflect.TypeOf((*MockDatabase)(nil).SaveTeamsAndUsers), arg0, arg1, arg2)
+}
+
+// SaveTrigger mocks base method.
 func (m *MockDatabase) SaveTrigger(arg0 string, arg1 *moira.Trigger) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveTrigger", arg0, arg1)
@@ -1129,13 +1218,13 @@ func (m *MockDatabase) SaveTrigger(arg0 string, arg1 *moira.Trigger) error {
 	return ret0
 }
 
-// SaveTrigger indicates an expected call of SaveTrigger
+// SaveTrigger indicates an expected call of SaveTrigger.
 func (mr *MockDatabaseMockRecorder) SaveTrigger(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTrigger", reflect.TypeOf((*MockDatabase)(nil).SaveTrigger), arg0, arg1)
 }
 
-// SaveTriggersSearchResults mocks base method
+// SaveTriggersSearchResults mocks base method.
 func (m *MockDatabase) SaveTriggersSearchResults(arg0 string, arg1 []*moira.SearchResult) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveTriggersSearchResults", arg0, arg1)
@@ -1143,13 +1232,13 @@ func (m *MockDatabase) SaveTriggersSearchResults(arg0 string, arg1 []*moira.Sear
 	return ret0
 }
 
-// SaveTriggersSearchResults indicates an expected call of SaveTriggersSearchResults
+// SaveTriggersSearchResults indicates an expected call of SaveTriggersSearchResults.
 func (mr *MockDatabaseMockRecorder) SaveTriggersSearchResults(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveTriggersSearchResults", reflect.TypeOf((*MockDatabase)(nil).SaveTriggersSearchResults), arg0, arg1)
 }
 
-// SetNotifierState mocks base method
+// SetNotifierState mocks base method.
 func (m *MockDatabase) SetNotifierState(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNotifierState", arg0)
@@ -1157,13 +1246,13 @@ func (m *MockDatabase) SetNotifierState(arg0 string) error {
 	return ret0
 }
 
-// SetNotifierState indicates an expected call of SetNotifierState
+// SetNotifierState indicates an expected call of SetNotifierState.
 func (mr *MockDatabaseMockRecorder) SetNotifierState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNotifierState", reflect.TypeOf((*MockDatabase)(nil).SetNotifierState), arg0)
 }
 
-// SetTriggerCheckLock mocks base method
+// SetTriggerCheckLock mocks base method.
 func (m *MockDatabase) SetTriggerCheckLock(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetTriggerCheckLock", arg0)
@@ -1172,13 +1261,13 @@ func (m *MockDatabase) SetTriggerCheckLock(arg0 string) (bool, error) {
 	return ret0, ret1
 }
 
-// SetTriggerCheckLock indicates an expected call of SetTriggerCheckLock
+// SetTriggerCheckLock indicates an expected call of SetTriggerCheckLock.
 func (mr *MockDatabaseMockRecorder) SetTriggerCheckLock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTriggerCheckLock", reflect.TypeOf((*MockDatabase)(nil).SetTriggerCheckLock), arg0)
 }
 
-// SetTriggerCheckMaintenance mocks base method
+// SetTriggerCheckMaintenance mocks base method.
 func (m *MockDatabase) SetTriggerCheckMaintenance(arg0 string, arg1 map[string]int64, arg2 *int64, arg3 string, arg4 int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetTriggerCheckMaintenance", arg0, arg1, arg2, arg3, arg4)
@@ -1186,13 +1275,13 @@ func (m *MockDatabase) SetTriggerCheckMaintenance(arg0 string, arg1 map[string]i
 	return ret0
 }
 
-// SetTriggerCheckMaintenance indicates an expected call of SetTriggerCheckMaintenance
+// SetTriggerCheckMaintenance indicates an expected call of SetTriggerCheckMaintenance.
 func (mr *MockDatabaseMockRecorder) SetTriggerCheckMaintenance(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTriggerCheckMaintenance", reflect.TypeOf((*MockDatabase)(nil).SetTriggerCheckMaintenance), arg0, arg1, arg2, arg3, arg4)
 }
 
-// SetTriggerLastCheck mocks base method
+// SetTriggerLastCheck mocks base method.
 func (m *MockDatabase) SetTriggerLastCheck(arg0 string, arg1 *moira.CheckData, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetTriggerLastCheck", arg0, arg1, arg2)
@@ -1200,13 +1289,13 @@ func (m *MockDatabase) SetTriggerLastCheck(arg0 string, arg1 *moira.CheckData, a
 	return ret0
 }
 
-// SetTriggerLastCheck indicates an expected call of SetTriggerLastCheck
+// SetTriggerLastCheck indicates an expected call of SetTriggerLastCheck.
 func (mr *MockDatabaseMockRecorder) SetTriggerLastCheck(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTriggerLastCheck", reflect.TypeOf((*MockDatabase)(nil).SetTriggerLastCheck), arg0, arg1, arg2)
 }
 
-// SetTriggerThrottling mocks base method
+// SetTriggerThrottling mocks base method.
 func (m *MockDatabase) SetTriggerThrottling(arg0 string, arg1 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetTriggerThrottling", arg0, arg1)
@@ -1214,13 +1303,13 @@ func (m *MockDatabase) SetTriggerThrottling(arg0 string, arg1 time.Time) error {
 	return ret0
 }
 
-// SetTriggerThrottling indicates an expected call of SetTriggerThrottling
+// SetTriggerThrottling indicates an expected call of SetTriggerThrottling.
 func (mr *MockDatabaseMockRecorder) SetTriggerThrottling(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTriggerThrottling", reflect.TypeOf((*MockDatabase)(nil).SetTriggerThrottling), arg0, arg1)
 }
 
-// SetUsernameID mocks base method
+// SetUsernameID mocks base method.
 func (m *MockDatabase) SetUsernameID(arg0, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUsernameID", arg0, arg1, arg2)
@@ -1228,13 +1317,13 @@ func (m *MockDatabase) SetUsernameID(arg0, arg1, arg2 string) error {
 	return ret0
 }
 
-// SetUsernameID indicates an expected call of SetUsernameID
+// SetUsernameID indicates an expected call of SetUsernameID.
 func (mr *MockDatabaseMockRecorder) SetUsernameID(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUsernameID", reflect.TypeOf((*MockDatabase)(nil).SetUsernameID), arg0, arg1, arg2)
 }
 
-// SubscribeMetricEvents mocks base method
+// SubscribeMetricEvents mocks base method.
 func (m *MockDatabase) SubscribeMetricEvents(arg0 *tomb.Tomb) (<-chan *moira.MetricEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeMetricEvents", arg0)
@@ -1243,13 +1332,13 @@ func (m *MockDatabase) SubscribeMetricEvents(arg0 *tomb.Tomb) (<-chan *moira.Met
 	return ret0, ret1
 }
 
-// SubscribeMetricEvents indicates an expected call of SubscribeMetricEvents
+// SubscribeMetricEvents indicates an expected call of SubscribeMetricEvents.
 func (mr *MockDatabaseMockRecorder) SubscribeMetricEvents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeMetricEvents", reflect.TypeOf((*MockDatabase)(nil).SubscribeMetricEvents), arg0)
 }
 
-// UpdateMetricsHeartbeat mocks base method
+// UpdateMetricsHeartbeat mocks base method.
 func (m *MockDatabase) UpdateMetricsHeartbeat() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMetricsHeartbeat")
@@ -1257,7 +1346,7 @@ func (m *MockDatabase) UpdateMetricsHeartbeat() error {
 	return ret0
 }
 
-// UpdateMetricsHeartbeat indicates an expected call of UpdateMetricsHeartbeat
+// UpdateMetricsHeartbeat indicates an expected call of UpdateMetricsHeartbeat.
 func (mr *MockDatabaseMockRecorder) UpdateMetricsHeartbeat() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricsHeartbeat", reflect.TypeOf((*MockDatabase)(nil).UpdateMetricsHeartbeat))

--- a/mock/moira-alert/image_store.go
+++ b/mock/moira-alert/image_store.go
@@ -5,34 +5,35 @@
 package mock_moira_alert
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockImageStore is a mock of ImageStore interface
+// MockImageStore is a mock of ImageStore interface.
 type MockImageStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockImageStoreMockRecorder
 }
 
-// MockImageStoreMockRecorder is the mock recorder for MockImageStore
+// MockImageStoreMockRecorder is the mock recorder for MockImageStore.
 type MockImageStoreMockRecorder struct {
 	mock *MockImageStore
 }
 
-// NewMockImageStore creates a new mock instance
+// NewMockImageStore creates a new mock instance.
 func NewMockImageStore(ctrl *gomock.Controller) *MockImageStore {
 	mock := &MockImageStore{ctrl: ctrl}
 	mock.recorder = &MockImageStoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockImageStore) EXPECT() *MockImageStoreMockRecorder {
 	return m.recorder
 }
 
-// IsEnabled mocks base method
+// IsEnabled mocks base method.
 func (m *MockImageStore) IsEnabled() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsEnabled")
@@ -40,13 +41,13 @@ func (m *MockImageStore) IsEnabled() bool {
 	return ret0
 }
 
-// IsEnabled indicates an expected call of IsEnabled
+// IsEnabled indicates an expected call of IsEnabled.
 func (mr *MockImageStoreMockRecorder) IsEnabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEnabled", reflect.TypeOf((*MockImageStore)(nil).IsEnabled))
 }
 
-// StoreImage mocks base method
+// StoreImage mocks base method.
 func (m *MockImageStore) StoreImage(arg0 []byte) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreImage", arg0)
@@ -55,7 +56,7 @@ func (m *MockImageStore) StoreImage(arg0 []byte) (string, error) {
 	return ret0, ret1
 }
 
-// StoreImage indicates an expected call of StoreImage
+// StoreImage indicates an expected call of StoreImage.
 func (mr *MockImageStoreMockRecorder) StoreImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreImage", reflect.TypeOf((*MockImageStore)(nil).StoreImage), arg0)

--- a/mock/moira-alert/locks.go
+++ b/mock/moira-alert/locks.go
@@ -5,34 +5,35 @@
 package mock_moira_alert
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockLock is a mock of Lock interface
+// MockLock is a mock of Lock interface.
 type MockLock struct {
 	ctrl     *gomock.Controller
 	recorder *MockLockMockRecorder
 }
 
-// MockLockMockRecorder is the mock recorder for MockLock
+// MockLockMockRecorder is the mock recorder for MockLock.
 type MockLockMockRecorder struct {
 	mock *MockLock
 }
 
-// NewMockLock creates a new mock instance
+// NewMockLock creates a new mock instance.
 func NewMockLock(ctrl *gomock.Controller) *MockLock {
 	mock := &MockLock{ctrl: ctrl}
 	mock.recorder = &MockLockMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLock) EXPECT() *MockLockMockRecorder {
 	return m.recorder
 }
 
-// Acquire mocks base method
+// Acquire mocks base method.
 func (m *MockLock) Acquire(arg0 <-chan struct{}) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Acquire", arg0)
@@ -41,19 +42,19 @@ func (m *MockLock) Acquire(arg0 <-chan struct{}) (<-chan struct{}, error) {
 	return ret0, ret1
 }
 
-// Acquire indicates an expected call of Acquire
+// Acquire indicates an expected call of Acquire.
 func (mr *MockLockMockRecorder) Acquire(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockLock)(nil).Acquire), arg0)
 }
 
-// Release mocks base method
+// Release mocks base method.
 func (m *MockLock) Release() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Release")
 }
 
-// Release indicates an expected call of Release
+// Release indicates an expected call of Release.
 func (mr *MockLockMockRecorder) Release() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Release", reflect.TypeOf((*MockLock)(nil).Release))

--- a/mock/moira-alert/logger.go
+++ b/mock/moira-alert/logger.go
@@ -5,35 +5,36 @@
 package mock_moira_alert
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	moira "github.com/moira-alert/moira"
-	reflect "reflect"
 )
 
-// MockLogger is a mock of Logger interface
+// MockLogger is a mock of Logger interface.
 type MockLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerMockRecorder
 }
 
-// MockLoggerMockRecorder is the mock recorder for MockLogger
+// MockLoggerMockRecorder is the mock recorder for MockLogger.
 type MockLoggerMockRecorder struct {
 	mock *MockLogger
 }
 
-// NewMockLogger creates a new mock instance
+// NewMockLogger creates a new mock instance.
 func NewMockLogger(ctrl *gomock.Controller) *MockLogger {
 	mock := &MockLogger{ctrl: ctrl}
 	mock.recorder = &MockLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
-// Clone mocks base method
+// Clone mocks base method.
 func (m *MockLogger) Clone() moira.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone")
@@ -41,13 +42,13 @@ func (m *MockLogger) Clone() moira.Logger {
 	return ret0
 }
 
-// Clone indicates an expected call of Clone
+// Clone indicates an expected call of Clone.
 func (mr *MockLoggerMockRecorder) Clone() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockLogger)(nil).Clone))
 }
 
-// Debug mocks base method
+// Debug mocks base method.
 func (m *MockLogger) Debug(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -57,13 +58,13 @@ func (m *MockLogger) Debug(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Debug", varargs...)
 }
 
-// Debug indicates an expected call of Debug
+// Debug indicates an expected call of Debug.
 func (mr *MockLoggerMockRecorder) Debug(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockLogger)(nil).Debug), arg0...)
 }
 
-// Debugf mocks base method
+// Debugf mocks base method.
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -73,14 +74,14 @@ func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Debugf", varargs...)
 }
 
-// Debugf indicates an expected call of Debugf
+// Debugf indicates an expected call of Debugf.
 func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
-// Error mocks base method
+// Error mocks base method.
 func (m *MockLogger) Error(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -90,13 +91,13 @@ func (m *MockLogger) Error(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Error", varargs...)
 }
 
-// Error indicates an expected call of Error
+// Error indicates an expected call of Error.
 func (mr *MockLoggerMockRecorder) Error(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockLogger)(nil).Error), arg0...)
 }
 
-// Errorf mocks base method
+// Errorf mocks base method.
 func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -106,14 +107,14 @@ func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Errorf", varargs...)
 }
 
-// Errorf indicates an expected call of Errorf
+// Errorf indicates an expected call of Errorf.
 func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
 }
 
-// Fatal mocks base method
+// Fatal mocks base method.
 func (m *MockLogger) Fatal(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -123,13 +124,13 @@ func (m *MockLogger) Fatal(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Fatal", varargs...)
 }
 
-// Fatal indicates an expected call of Fatal
+// Fatal indicates an expected call of Fatal.
 func (mr *MockLoggerMockRecorder) Fatal(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fatal", reflect.TypeOf((*MockLogger)(nil).Fatal), arg0...)
 }
 
-// Fatalf mocks base method
+// Fatalf mocks base method.
 func (m *MockLogger) Fatalf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -139,14 +140,14 @@ func (m *MockLogger) Fatalf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Fatalf", varargs...)
 }
 
-// Fatalf indicates an expected call of Fatalf
+// Fatalf indicates an expected call of Fatalf.
 func (mr *MockLoggerMockRecorder) Fatalf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fatalf", reflect.TypeOf((*MockLogger)(nil).Fatalf), varargs...)
 }
 
-// Fields mocks base method
+// Fields mocks base method.
 func (m *MockLogger) Fields(arg0 map[string]interface{}) moira.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fields", arg0)
@@ -154,13 +155,13 @@ func (m *MockLogger) Fields(arg0 map[string]interface{}) moira.Logger {
 	return ret0
 }
 
-// Fields indicates an expected call of Fields
+// Fields indicates an expected call of Fields.
 func (mr *MockLoggerMockRecorder) Fields(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fields", reflect.TypeOf((*MockLogger)(nil).Fields), arg0)
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockLogger) Info(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -170,13 +171,13 @@ func (m *MockLogger) Info(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Info", varargs...)
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockLoggerMockRecorder) Info(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLogger)(nil).Info), arg0...)
 }
 
-// Infof mocks base method
+// Infof mocks base method.
 func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -186,14 +187,14 @@ func (m *MockLogger) Infof(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Infof", varargs...)
 }
 
-// Infof indicates an expected call of Infof
+// Infof indicates an expected call of Infof.
 func (mr *MockLoggerMockRecorder) Infof(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Infof", reflect.TypeOf((*MockLogger)(nil).Infof), varargs...)
 }
 
-// Int mocks base method
+// Int mocks base method.
 func (m *MockLogger) Int(arg0 string, arg1 int) moira.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Int", arg0, arg1)
@@ -201,13 +202,13 @@ func (m *MockLogger) Int(arg0 string, arg1 int) moira.Logger {
 	return ret0
 }
 
-// Int indicates an expected call of Int
+// Int indicates an expected call of Int.
 func (mr *MockLoggerMockRecorder) Int(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Int", reflect.TypeOf((*MockLogger)(nil).Int), arg0, arg1)
 }
 
-// Int64 mocks base method
+// Int64 mocks base method.
 func (m *MockLogger) Int64(arg0 string, arg1 int64) moira.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Int64", arg0, arg1)
@@ -215,13 +216,13 @@ func (m *MockLogger) Int64(arg0 string, arg1 int64) moira.Logger {
 	return ret0
 }
 
-// Int64 indicates an expected call of Int64
+// Int64 indicates an expected call of Int64.
 func (mr *MockLoggerMockRecorder) Int64(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Int64", reflect.TypeOf((*MockLogger)(nil).Int64), arg0, arg1)
 }
 
-// Level mocks base method
+// Level mocks base method.
 func (m *MockLogger) Level(arg0 string) (moira.Logger, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Level", arg0)
@@ -230,13 +231,13 @@ func (m *MockLogger) Level(arg0 string) (moira.Logger, error) {
 	return ret0, ret1
 }
 
-// Level indicates an expected call of Level
+// Level indicates an expected call of Level.
 func (mr *MockLoggerMockRecorder) Level(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Level", reflect.TypeOf((*MockLogger)(nil).Level), arg0)
 }
 
-// String mocks base method
+// String mocks base method.
 func (m *MockLogger) String(arg0, arg1 string) moira.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String", arg0, arg1)
@@ -244,13 +245,13 @@ func (m *MockLogger) String(arg0, arg1 string) moira.Logger {
 	return ret0
 }
 
-// String indicates an expected call of String
+// String indicates an expected call of String.
 func (mr *MockLoggerMockRecorder) String(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockLogger)(nil).String), arg0, arg1)
 }
 
-// Warning mocks base method
+// Warning mocks base method.
 func (m *MockLogger) Warning(arg0 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -260,13 +261,13 @@ func (m *MockLogger) Warning(arg0 ...interface{}) {
 	m.ctrl.Call(m, "Warning", varargs...)
 }
 
-// Warning indicates an expected call of Warning
+// Warning indicates an expected call of Warning.
 func (mr *MockLoggerMockRecorder) Warning(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warning", reflect.TypeOf((*MockLogger)(nil).Warning), arg0...)
 }
 
-// Warningf mocks base method
+// Warningf mocks base method.
 func (m *MockLogger) Warningf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -276,7 +277,7 @@ func (m *MockLogger) Warningf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Warningf", varargs...)
 }
 
-// Warningf indicates an expected call of Warningf
+// Warningf indicates an expected call of Warningf.
 func (mr *MockLoggerMockRecorder) Warningf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)

--- a/mock/moira-alert/searcher.go
+++ b/mock/moira-alert/searcher.go
@@ -5,35 +5,36 @@
 package mock_moira_alert
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	moira "github.com/moira-alert/moira"
-	reflect "reflect"
 )
 
-// MockSearcher is a mock of Searcher interface
+// MockSearcher is a mock of Searcher interface.
 type MockSearcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockSearcherMockRecorder
 }
 
-// MockSearcherMockRecorder is the mock recorder for MockSearcher
+// MockSearcherMockRecorder is the mock recorder for MockSearcher.
 type MockSearcherMockRecorder struct {
 	mock *MockSearcher
 }
 
-// NewMockSearcher creates a new mock instance
+// NewMockSearcher creates a new mock instance.
 func NewMockSearcher(ctrl *gomock.Controller) *MockSearcher {
 	mock := &MockSearcher{ctrl: ctrl}
 	mock.recorder = &MockSearcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSearcher) EXPECT() *MockSearcherMockRecorder {
 	return m.recorder
 }
 
-// IsReady mocks base method
+// IsReady mocks base method.
 func (m *MockSearcher) IsReady() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsReady")
@@ -41,13 +42,13 @@ func (m *MockSearcher) IsReady() bool {
 	return ret0
 }
 
-// IsReady indicates an expected call of IsReady
+// IsReady indicates an expected call of IsReady.
 func (mr *MockSearcherMockRecorder) IsReady() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockSearcher)(nil).IsReady))
 }
 
-// SearchTriggers mocks base method
+// SearchTriggers mocks base method.
 func (m *MockSearcher) SearchTriggers(arg0 []string, arg1 string, arg2 bool, arg3, arg4 int64) ([]*moira.SearchResult, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchTriggers", arg0, arg1, arg2, arg3, arg4)
@@ -57,13 +58,13 @@ func (m *MockSearcher) SearchTriggers(arg0 []string, arg1 string, arg2 bool, arg
 	return ret0, ret1, ret2
 }
 
-// SearchTriggers indicates an expected call of SearchTriggers
+// SearchTriggers indicates an expected call of SearchTriggers.
 func (mr *MockSearcherMockRecorder) SearchTriggers(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTriggers", reflect.TypeOf((*MockSearcher)(nil).SearchTriggers), arg0, arg1, arg2, arg3, arg4)
 }
 
-// Start mocks base method
+// Start mocks base method.
 func (m *MockSearcher) Start() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start")
@@ -71,13 +72,13 @@ func (m *MockSearcher) Start() error {
 	return ret0
 }
 
-// Start indicates an expected call of Start
+// Start indicates an expected call of Start.
 func (mr *MockSearcherMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSearcher)(nil).Start))
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockSearcher) Stop() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
@@ -85,7 +86,7 @@ func (m *MockSearcher) Stop() error {
 	return ret0
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockSearcherMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockSearcher)(nil).Stop))

--- a/mock/moira-alert/sender.go
+++ b/mock/moira-alert/sender.go
@@ -5,36 +5,37 @@
 package mock_moira_alert
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	moira "github.com/moira-alert/moira"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	moira "github.com/moira-alert/moira"
 )
 
-// MockSender is a mock of Sender interface
+// MockSender is a mock of Sender interface.
 type MockSender struct {
 	ctrl     *gomock.Controller
 	recorder *MockSenderMockRecorder
 }
 
-// MockSenderMockRecorder is the mock recorder for MockSender
+// MockSenderMockRecorder is the mock recorder for MockSender.
 type MockSenderMockRecorder struct {
 	mock *MockSender
 }
 
-// NewMockSender creates a new mock instance
+// NewMockSender creates a new mock instance.
 func NewMockSender(ctrl *gomock.Controller) *MockSender {
 	mock := &MockSender{ctrl: ctrl}
 	mock.recorder = &MockSenderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSender) EXPECT() *MockSenderMockRecorder {
 	return m.recorder
 }
 
-// Init mocks base method
+// Init mocks base method.
 func (m *MockSender) Init(arg0 map[string]string, arg1 moira.Logger, arg2 *time.Location, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Init", arg0, arg1, arg2, arg3)
@@ -42,13 +43,13 @@ func (m *MockSender) Init(arg0 map[string]string, arg1 moira.Logger, arg2 *time.
 	return ret0
 }
 
-// Init indicates an expected call of Init
+// Init indicates an expected call of Init.
 func (mr *MockSenderMockRecorder) Init(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockSender)(nil).Init), arg0, arg1, arg2, arg3)
 }
 
-// SendEvents mocks base method
+// SendEvents mocks base method.
 func (m *MockSender) SendEvents(arg0 moira.NotificationEvents, arg1 moira.ContactData, arg2 moira.TriggerData, arg3 [][]byte, arg4 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendEvents", arg0, arg1, arg2, arg3, arg4)
@@ -56,7 +57,7 @@ func (m *MockSender) SendEvents(arg0 moira.NotificationEvents, arg1 moira.Contac
 	return ret0
 }
 
-// SendEvents indicates an expected call of SendEvents
+// SendEvents indicates an expected call of SendEvents.
 func (mr *MockSenderMockRecorder) SendEvents(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendEvents", reflect.TypeOf((*MockSender)(nil).SendEvents), arg0, arg1, arg2, arg3, arg4)

--- a/mock/notifier/notifier.go
+++ b/mock/notifier/notifier.go
@@ -5,37 +5,38 @@
 package mock_notifier
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	gomock "github.com/golang/mock/gomock"
 	moira "github.com/moira-alert/moira"
 	notifier "github.com/moira-alert/moira/notifier"
-	reflect "reflect"
-	sync "sync"
 )
 
-// MockNotifier is a mock of Notifier interface
+// MockNotifier is a mock of Notifier interface.
 type MockNotifier struct {
 	ctrl     *gomock.Controller
 	recorder *MockNotifierMockRecorder
 }
 
-// MockNotifierMockRecorder is the mock recorder for MockNotifier
+// MockNotifierMockRecorder is the mock recorder for MockNotifier.
 type MockNotifierMockRecorder struct {
 	mock *MockNotifier
 }
 
-// NewMockNotifier creates a new mock instance
+// NewMockNotifier creates a new mock instance.
 func NewMockNotifier(ctrl *gomock.Controller) *MockNotifier {
 	mock := &MockNotifier{ctrl: ctrl}
 	mock.recorder = &MockNotifierMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNotifier) EXPECT() *MockNotifierMockRecorder {
 	return m.recorder
 }
 
-// GetReadBatchSize mocks base method
+// GetReadBatchSize mocks base method.
 func (m *MockNotifier) GetReadBatchSize() int64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReadBatchSize")
@@ -43,13 +44,13 @@ func (m *MockNotifier) GetReadBatchSize() int64 {
 	return ret0
 }
 
-// GetReadBatchSize indicates an expected call of GetReadBatchSize
+// GetReadBatchSize indicates an expected call of GetReadBatchSize.
 func (mr *MockNotifierMockRecorder) GetReadBatchSize() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReadBatchSize", reflect.TypeOf((*MockNotifier)(nil).GetReadBatchSize))
 }
 
-// GetSenders mocks base method
+// GetSenders mocks base method.
 func (m *MockNotifier) GetSenders() map[string]bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSenders")
@@ -57,13 +58,13 @@ func (m *MockNotifier) GetSenders() map[string]bool {
 	return ret0
 }
 
-// GetSenders indicates an expected call of GetSenders
+// GetSenders indicates an expected call of GetSenders.
 func (mr *MockNotifierMockRecorder) GetSenders() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSenders", reflect.TypeOf((*MockNotifier)(nil).GetSenders))
 }
 
-// RegisterSender mocks base method
+// RegisterSender mocks base method.
 func (m *MockNotifier) RegisterSender(arg0 map[string]string, arg1 moira.Sender) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterSender", arg0, arg1)
@@ -71,31 +72,31 @@ func (m *MockNotifier) RegisterSender(arg0 map[string]string, arg1 moira.Sender)
 	return ret0
 }
 
-// RegisterSender indicates an expected call of RegisterSender
+// RegisterSender indicates an expected call of RegisterSender.
 func (mr *MockNotifierMockRecorder) RegisterSender(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSender", reflect.TypeOf((*MockNotifier)(nil).RegisterSender), arg0, arg1)
 }
 
-// Send mocks base method
+// Send mocks base method.
 func (m *MockNotifier) Send(arg0 *notifier.NotificationPackage, arg1 *sync.WaitGroup) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Send", arg0, arg1)
 }
 
-// Send indicates an expected call of Send
+// Send indicates an expected call of Send.
 func (mr *MockNotifierMockRecorder) Send(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockNotifier)(nil).Send), arg0, arg1)
 }
 
-// StopSenders mocks base method
+// StopSenders mocks base method.
 func (m *MockNotifier) StopSenders() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StopSenders")
 }
 
-// StopSenders indicates an expected call of StopSenders
+// StopSenders indicates an expected call of StopSenders.
 func (mr *MockNotifierMockRecorder) StopSenders() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopSenders", reflect.TypeOf((*MockNotifier)(nil).StopSenders))

--- a/mock/scheduler/scheduler.go
+++ b/mock/scheduler/scheduler.go
@@ -5,36 +5,37 @@
 package mock_scheduler
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	moira "github.com/moira-alert/moira"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	moira "github.com/moira-alert/moira"
 )
 
-// MockScheduler is a mock of Scheduler interface
+// MockScheduler is a mock of Scheduler interface.
 type MockScheduler struct {
 	ctrl     *gomock.Controller
 	recorder *MockSchedulerMockRecorder
 }
 
-// MockSchedulerMockRecorder is the mock recorder for MockScheduler
+// MockSchedulerMockRecorder is the mock recorder for MockScheduler.
 type MockSchedulerMockRecorder struct {
 	mock *MockScheduler
 }
 
-// NewMockScheduler creates a new mock instance
+// NewMockScheduler creates a new mock instance.
 func NewMockScheduler(ctrl *gomock.Controller) *MockScheduler {
 	mock := &MockScheduler{ctrl: ctrl}
 	mock.recorder = &MockSchedulerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockScheduler) EXPECT() *MockSchedulerMockRecorder {
 	return m.recorder
 }
 
-// ScheduleNotification mocks base method
+// ScheduleNotification mocks base method.
 func (m *MockScheduler) ScheduleNotification(arg0 time.Time, arg1 moira.NotificationEvent, arg2 moira.TriggerData, arg3 moira.ContactData, arg4 moira.PlottingData, arg5 bool, arg6 int, arg7 moira.Logger) *moira.ScheduledNotification {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleNotification", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
@@ -42,7 +43,7 @@ func (m *MockScheduler) ScheduleNotification(arg0 time.Time, arg1 moira.Notifica
 	return ret0
 }
 
-// ScheduleNotification indicates an expected call of ScheduleNotification
+// ScheduleNotification indicates an expected call of ScheduleNotification.
 func (mr *MockSchedulerMockRecorder) ScheduleNotification(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleNotification", reflect.TypeOf((*MockScheduler)(nil).ScheduleNotification), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)

--- a/notifier/events/event.go
+++ b/notifier/events/event.go
@@ -176,6 +176,7 @@ func (worker *FetchEventsWorker) getNotificationSubscriptions(event moira.Notifi
 		sub := &moira.SubscriptionData{
 			ID:                "testSubscription",
 			User:              contact.User,
+			TeamID:            contact.Team,
 			ThrottlingEnabled: false,
 			Enabled:           true,
 			Tags:              make([]string, 0),

--- a/senders/script/script_test.go
+++ b/senders/script/script_test.go
@@ -86,7 +86,7 @@ func TestBuildCommandData(t *testing.T) {
 		So(scriptFile, ShouldResemble, "script.go")
 		So(args, ShouldResemble, []string{"first", "second"})
 		So(err, ShouldBeNil)
-		So(string(scriptBody), ShouldResemble, "{\n\t\"events\": [\n\t\t{\n\t\t\t\"timestamp\": 0,\n\t\t\t\"metric\": \"New metric\",\n\t\t\t\"state\": \"\",\n\t\t\t\"trigger_id\": \"\",\n\t\t\t\"old_state\": \"\",\n\t\t\t\"event_message\": null\n\t\t}\n\t],\n\t\"trigger\": {\n\t\t\"id\": \"TriggerID\",\n\t\t\"name\": \"\",\n\t\t\"desc\": \"\",\n\t\t\"targets\": null,\n\t\t\"warn_value\": 0,\n\t\t\"error_value\": 0,\n\t\t\"is_remote\": false,\n\t\t\"__notifier_trigger_tags\": null\n\t},\n\t\"contact\": {\n\t\t\"type\": \"\",\n\t\t\"value\": \"\",\n\t\t\"id\": \"ContactID\",\n\t\t\"user\": \"\"\n\t},\n\t\"throttled\": true,\n\t\"timestamp\": 0\n}")
+		So(string(scriptBody), ShouldResemble, "{\n\t\"events\": [\n\t\t{\n\t\t\t\"timestamp\": 0,\n\t\t\t\"metric\": \"New metric\",\n\t\t\t\"state\": \"\",\n\t\t\t\"trigger_id\": \"\",\n\t\t\t\"old_state\": \"\",\n\t\t\t\"event_message\": null\n\t\t}\n\t],\n\t\"trigger\": {\n\t\t\"id\": \"TriggerID\",\n\t\t\"name\": \"\",\n\t\t\"desc\": \"\",\n\t\t\"targets\": null,\n\t\t\"warn_value\": 0,\n\t\t\"error_value\": 0,\n\t\t\"is_remote\": false,\n\t\t\"__notifier_trigger_tags\": null\n\t},\n\t\"contact\": {\n\t\t\"type\": \"\",\n\t\t\"value\": \"\",\n\t\t\"id\": \"ContactID\",\n\t\t\"user\": \"\",\n\t\t\"team\": \"\"\n\t},\n\t\"throttled\": true,\n\t\"timestamp\": 0\n}")
 	})
 
 	Convey("Test file not found", t, func() {

--- a/senders/webhook/payload.go
+++ b/senders/webhook/payload.go
@@ -36,6 +36,7 @@ type contactData struct {
 	Value string `json:"value"`
 	ID    string `json:"id"`
 	User  string `json:"user"`
+	Team  string `json:"team"`
 }
 
 // toTriggerData returns correct triggerData structure to marshall JSON

--- a/senders/webhook/request.go
+++ b/senders/webhook/request.go
@@ -51,6 +51,7 @@ func buildRequestBody(events moira.NotificationEvents, contact moira.ContactData
 			Value: contact.Value,
 			ID:    contact.ID,
 			User:  contact.User,
+			Team:  contact.Team,
 		},
 		Plot:      encodedFirstPlot,
 		Plots:     encodedPlots,

--- a/senders/webhook/request_test.go
+++ b/senders/webhook/request_test.go
@@ -20,6 +20,7 @@ var (
 		Type:  "contactType",
 		Value: "contactValue",
 		User:  "contactUser",
+		Team:  "contactTeam",
 	}
 	testTrigger = moira.TriggerData{
 		ID:   "triggerID",
@@ -96,7 +97,8 @@ const expectedStateChangePayload = `
     "type": "contactType",
     "value": "contactValue",
     "id": "contactID",
-    "user": "contactUser"
+    "user": "contactUser",
+    "team": "contactTeam"
 	},
 	"plot": "",
   "plots": [],
@@ -117,7 +119,8 @@ const expectedEmptyPayload = `
         "type": "",
         "value": "",
         "id": "",
-        "user": ""
+        "user": "",
+        "team": ""
 		},
 		"plot": "",
     "plots": [],


### PR DESCRIPTION
# PR Summary

In this PR I would like to introduce a team subscriptions and contacts. The core concept of teams is that users of Moira can unite to groups and manage subscriptions and contacts in this groups.

Relates #230 
