### PR TITLE
fix(checker): Rewrite validation for empty targets

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -81,7 +81,7 @@ func (triggerChecker *TriggerChecker) handlePrepareError(checkData moira.CheckDa
 // handleFetchError is a function that checks error returned from fetchTriggerMetrics function.
 func (triggerChecker *TriggerChecker) handleFetchError(checkData moira.CheckData, err error) error {
 	switch err.(type) {
-	case ErrTargetHasNoMetrics, ErrTriggerHasOnlyWildcards:
+	case ErrTriggerHasEmptyTargets, ErrTriggerHasOnlyWildcards:
 		triggerChecker.logger.Debugf("Trigger %s: %s", triggerChecker.triggerID, err.Error())
 		triggerState := triggerChecker.ttlState.ToTriggerState()
 		checkData.State = triggerState

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -41,14 +41,14 @@ func (err ErrTriggerHasSameMetricNames) Error() string {
 	return builder.String()
 }
 
-// ErrTargetHasNoMetrics used if additional trigger target has not metrics data after fetch from source
-type ErrTargetHasNoMetrics struct {
-	targetIndex int
+// ErrTriggerHasEmptyTargets used if additional trigger target has not metrics data after fetch from source
+type ErrTriggerHasEmptyTargets struct {
+	targets []string
 }
 
-// ErrTargetHasNoMetrics implementation with constant error message
-func (err ErrTargetHasNoMetrics) Error() string {
-	return fmt.Sprintf("target t%v has no metrics", err.targetIndex+1)
+// ErrTriggerHasEmptyTargets implementation with error message
+func (err ErrTriggerHasEmptyTargets) Error() string {
+	return fmt.Sprintf("target t%v has no metrics", strings.Join(err.targets, ", "))
 }
 
 // ErrUnexpectedAloneMetric is an error that fired by checker if alone metrics do not

--- a/checker/fetch.go
+++ b/checker/fetch.go
@@ -15,6 +15,9 @@ func (triggerChecker *TriggerChecker) fetchTriggerMetrics() (map[string][]metric
 	triggerChecker.cleanupMetricsValues(metrics, triggerChecker.until)
 
 	if len(triggerChecker.lastCheck.Metrics) == 0 {
+		if hasEmptyTargets, emptyTargets := conversion.HasEmptyTargets(triggerMetricsData); hasEmptyTargets {
+			return nil, ErrTriggerHasEmptyTargets{targets: emptyTargets}
+		}
 		if conversion.HasOnlyWildcards(triggerMetricsData) {
 			return triggerMetricsData, ErrTriggerHasOnlyWildcards{}
 		}
@@ -38,9 +41,6 @@ func (triggerChecker *TriggerChecker) fetch() (map[string][]metricSource.MetricD
 
 		metricsFetchResult, metricsErr := fetchResult.GetPatternMetrics()
 
-		if len(metricsFetchResult) == 0 {
-			return nil, nil, ErrTargetHasNoMetrics{targetIndex: targetIndex}
-		}
 		if metricsErr == nil {
 			metricsArr = append(metricsArr, metricsFetchResult...)
 		}

--- a/checker/fetch_test.go
+++ b/checker/fetch_test.go
@@ -61,7 +61,7 @@ func TestFetchTriggerMetrics(t *testing.T) {
 				fetchResult.EXPECT().GetPatternMetrics().Return([]string{}, nil)
 
 				actual, err := triggerChecker.fetchTriggerMetrics()
-				So(err, ShouldResemble, ErrTargetHasNoMetrics{targetIndex: 1})
+				So(err, ShouldResemble, ErrTriggerHasEmptyTargets{targets: []string{"t1"}})
 				So(actual, ShouldBeNil)
 			})
 		})
@@ -79,7 +79,7 @@ func TestFetchTriggerMetrics(t *testing.T) {
 
 				actual, err := triggerChecker.fetchTriggerMetrics()
 				So(err, ShouldBeEmpty)
-				So(actual, ShouldResemble, map[string][]metricSource.MetricData{"t1": []metricSource.MetricData{{Name: pattern, Wildcard: true}}})
+				So(actual, ShouldResemble, map[string][]metricSource.MetricData{"t1": {{Name: pattern, Wildcard: true}}})
 			})
 
 			Convey("fetch returns no metrics", func() {
@@ -88,8 +88,8 @@ func TestFetchTriggerMetrics(t *testing.T) {
 				fetchResult.EXPECT().GetPatternMetrics().Return([]string{}, nil)
 
 				actual, err := triggerChecker.fetchTriggerMetrics()
-				So(err, ShouldResemble, ErrTargetHasNoMetrics{targetIndex: 1})
-				So(actual, ShouldBeNil)
+				So(err, ShouldBeNil)
+				So(actual, ShouldResemble, map[string][]metricSource.MetricData{"t1": {}})
 			})
 		})
 	})
@@ -148,9 +148,9 @@ func TestFetch(t *testing.T) {
 		fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{metricData})
 		fetchResult.EXPECT().GetPatternMetrics().Return([]string{}, nil)
 		actual, metrics, err := triggerChecker.fetch()
-		So(actual, ShouldBeNil)
+		So(actual, ShouldResemble, map[string][]metricSource.MetricData{"t1": {metricData}})
 		So(metrics, ShouldBeEmpty)
-		So(err, ShouldResemble, ErrTargetHasNoMetrics{targetIndex: 1})
+		So(err, ShouldBeNil)
 	})
 
 	Convey("Test has metrics", t, func() {
@@ -166,7 +166,7 @@ func TestFetch(t *testing.T) {
 				StepTime:  retention,
 				Values:    []float64{0, 1, 2, 3, 4},
 			}
-			expected := map[string][]metricSource.MetricData{"t1": []metricSource.MetricData{metricData}}
+			expected := map[string][]metricSource.MetricData{"t1": {metricData}}
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, expected)
 			So(metrics, ShouldResemble, []string{metric})

--- a/checker/metrics/conversion/conversion.go
+++ b/checker/metrics/conversion/conversion.go
@@ -64,3 +64,14 @@ func HasOnlyWildcards(metrics map[string][]metricSource.MetricData) bool {
 	}
 	return true
 }
+
+// HasEmptyTargets is a function that checks if there is exist targets withhout metrics.
+func HasEmptyTargets(metrics map[string][]metricSource.MetricData) (bool, []string) {
+	result := []string{}
+	for targetName, targetMetrics := range metrics {
+		if len(targetMetrics) == 0 {
+			result = append(result, targetName)
+		}
+	}
+	return len(result) > 0, result
+}

--- a/checker/metrics/conversion/conversion_test.go
+++ b/checker/metrics/conversion/conversion_test.go
@@ -255,3 +255,56 @@ func TestHasOnlyWildcards(t *testing.T) {
 		}
 	})
 }
+
+func TestHasEmptyTargets(t *testing.T) {
+	type args struct {
+		metrics map[string][]metricSource.MetricData
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  bool
+		want1 []string
+	}{
+		{
+			name: "all targets not empty",
+			args: args{
+				metrics: map[string][]metricSource.MetricData{
+					"t1": {
+						{Name: "metric.test.1"},
+						{Name: "metric.test.2"},
+					},
+					"t2": {
+						{Name: "metric.test.1"},
+						{Name: "metric.test.2"},
+					},
+				},
+			},
+			want:  false,
+			want1: []string{},
+		},
+		{
+			name: "one target is empty",
+			args: args{
+				metrics: map[string][]metricSource.MetricData{
+					"t1": {
+						{Name: "metric.test.1"},
+						{Name: "metric.test.2"},
+					},
+					"t2": {},
+				},
+			},
+			want:  true,
+			want1: []string{"t2"},
+		},
+	}
+	Convey("HasEmptyTargets", t, func() {
+		for _, tt := range tests {
+			Convey(tt.name, func() {
+				got, got1 := HasEmptyTargets(tt.args.metrics)
+				So(got, ShouldResemble, tt.want)
+				So(got1, ShouldResemble, tt.want1)
+			})
+		}
+	})
+}


### PR DESCRIPTION
When checker pulls metrics after each fetch for target result of fetch
is checked for emptiness. This validation did not use last check result
that caused false errors when fetch result for target does not have
metrics

Relates #428
