### PR TITLE
perf(checker): Improve performance of check

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -321,7 +321,7 @@ func (triggerChecker *TriggerChecker) getMetricStepsStates(metricName string, me
 
 	previousState := last
 	for valueTimestamp := startTime; valueTimestamp < triggerChecker.until+stepTime; valueTimestamp += stepTime {
-		metricNewState, err := triggerChecker.getMetricDataState(metricName, metrics, previousState, valueTimestamp, checkPoint)
+		metricNewState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &previousState, &valueTimestamp, &checkPoint)
 		if err != nil {
 			return last, current, err
 		}
@@ -334,8 +334,8 @@ func (triggerChecker *TriggerChecker) getMetricStepsStates(metricName string, me
 	return last, current, nil
 }
 
-func (triggerChecker *TriggerChecker) getMetricDataState(metricName string, metrics map[string]metricSource.MetricData, lastState moira.MetricState, valueTimestamp, checkPoint int64) (*moira.MetricState, error) {
-	if valueTimestamp <= checkPoint {
+func (triggerChecker *TriggerChecker) getMetricDataState(metricName *string, metrics *map[string]metricSource.MetricData, lastState *moira.MetricState, valueTimestamp, checkPoint *int64) (*moira.MetricState, error) {
+	if *valueTimestamp <= *checkPoint {
 		return nil, nil
 	}
 	triggerExpression, values, noEmptyValues := getExpressionValues(metrics, valueTimestamp)
@@ -356,23 +356,23 @@ func (triggerChecker *TriggerChecker) getMetricDataState(metricName string, metr
 	}
 
 	return newMetricState(
-		lastState,
+		*lastState,
 		expressionState,
-		valueTimestamp,
+		*valueTimestamp,
 		values,
 	), nil
 }
 
-func getExpressionValues(metrics map[string]metricSource.MetricData, valueTimestamp int64) (*expression.TriggerExpression, map[string]float64, bool) {
+func getExpressionValues(metrics *map[string]metricSource.MetricData, valueTimestamp *int64) (*expression.TriggerExpression, map[string]float64, bool) {
 	expression := &expression.TriggerExpression{
-		AdditionalTargetsValues: make(map[string]float64, len(metrics)-1),
+		AdditionalTargetsValues: make(map[string]float64, len(*metrics)-1),
 	}
-	values := make(map[string]float64, len(metrics))
+	values := make(map[string]float64, len(*metrics))
 
-	for i := 0; i < len(metrics); i++ {
+	for i := 0; i < len(*metrics); i++ {
 		targetName := fmt.Sprintf("t%d", i+1)
-		metric := metrics[targetName]
-		value := metric.GetTimestampValue(valueTimestamp)
+		metric := (*metrics)[targetName]
+		value := metric.GetTimestampValue(*valueTimestamp)
 		values[targetName] = value
 		if !moira.IsValidFloat64(value) {
 			return expression, values, false

--- a/checker/check.go
+++ b/checker/check.go
@@ -319,8 +319,17 @@ func (triggerChecker *TriggerChecker) getMetricStepsStates(metricName string, me
 
 	current = make([]moira.MetricState, 0)
 
+	// DO NOT CHANGE
+	// Specific optimization magic
 	previousState := last
-	for valueTimestamp := startTime; valueTimestamp < triggerChecker.until+stepTime; valueTimestamp += stepTime {
+	difference := moira.MaxInt64(checkPoint-startTime, 0)
+	stepsDifference := difference / stepTime
+	if (difference % stepTime) > 0 {
+		stepsDifference++
+	}
+	valueTimestamp := startTime + stepTime*stepsDifference
+	endTimestamp := triggerChecker.until + stepTime
+	for ; valueTimestamp < endTimestamp; valueTimestamp += stepTime {
 		metricNewState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &previousState, &valueTimestamp, &checkPoint)
 		if err != nil {
 			return last, current, err

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -59,15 +59,19 @@ func TestGetMetricDataState(t *testing.T) {
 		Suppressed:  true,
 	}
 
+	var valueTimestamp int64 = 37
+	var checkPoint int64 = 47
 	Convey("Checkpoint more than valueTimestamp", t, func() {
-		metricState, err := triggerChecker.getMetricDataState(metricName, metrics, metricLastState, 37, 47)
+		metricState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &metricLastState, &valueTimestamp, &checkPoint)
 		So(err, ShouldBeNil)
 		So(metricState, ShouldBeNil)
 	})
 
 	Convey("Checkpoint lover than valueTimestamp", t, func() {
 		Convey("Has all value by eventTimestamp step", func() {
-			metricState, err := triggerChecker.getMetricDataState(metricName, metrics, metricLastState, 42, 27)
+			var valueTimestamp int64 = 42
+			var checkPoint int64 = 27
+			metricState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &metricLastState, &valueTimestamp, &checkPoint)
 			So(err, ShouldBeNil)
 			So(metricState, ShouldResemble, &moira.MetricState{
 				State:          moira.StateOK,
@@ -80,19 +84,25 @@ func TestGetMetricDataState(t *testing.T) {
 		})
 
 		Convey("No value in main metric data by eventTimestamp step", func() {
-			metricState, err := triggerChecker.getMetricDataState(metricName, metrics, metricLastState, 66, 11)
+			var valueTimestamp int64 = 66
+			var checkPoint int64 = 11
+			metricState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &metricLastState, &valueTimestamp, &checkPoint)
 			So(err, ShouldBeNil)
 			So(metricState, ShouldBeNil)
 		})
 
 		Convey("IsAbsent in main metric data by eventTimestamp step", func() {
-			metricState, err := triggerChecker.getMetricDataState(metricName, metrics, metricLastState, 29, 11)
+			var valueTimestamp int64 = 29
+			var checkPoint int64 = 11
+			metricState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &metricLastState, &valueTimestamp, &checkPoint)
 			So(err, ShouldBeNil)
 			So(metricState, ShouldBeNil)
 		})
 
 		Convey("No value in additional metric data by eventTimestamp step", func() {
-			metricState, err := triggerChecker.getMetricDataState(metricName, metrics, metricLastState, 26, 11)
+			var valueTimestamp int64 = 26
+			var checkPoint int64 = 11
+			metricState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &metricLastState, &valueTimestamp, &checkPoint)
 			So(err, ShouldBeNil)
 			So(metricState, ShouldBeNil)
 		})
@@ -101,7 +111,9 @@ func TestGetMetricDataState(t *testing.T) {
 	Convey("No warn and error value with default expression", t, func() {
 		triggerChecker.trigger.WarnValue = nil
 		triggerChecker.trigger.ErrorValue = nil
-		metricState, err := triggerChecker.getMetricDataState(metricName, metrics, metricLastState, 42, 27)
+		var valueTimestamp int64 = 42
+		var checkPoint int64 = 27
+		metricState, err := triggerChecker.getMetricDataState(&metricName, &metrics, &metricLastState, &valueTimestamp, &checkPoint)
 		So(err.Error(), ShouldResemble, "error value and warning value can not be empty")
 		So(metricState, ShouldBeNil)
 	})
@@ -1235,22 +1247,26 @@ func TestGetExpressionValues(t *testing.T) {
 			}
 			expectedValues := map[string]float64{"t1": 0}
 
-			expression, values, noEmptyValues := getExpressionValues(metrics, 17)
+			var valueTimestamp int64 = 17
+			expression, values, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeTrue)
 			So(expression, ShouldResemble, expectedExpression)
 			So(values, ShouldResemble, expectedValues)
 		})
 		Convey("last value is empty", func() {
-			_, _, noEmptyValues := getExpressionValues(metrics, 67)
+			var valueTimestamp int64 = 67
+			_, _, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeFalse)
 		})
 		Convey("value before first value", func() {
-			_, _, noEmptyValues := getExpressionValues(metrics, 11)
+			var valueTimestamp int64 = 11
+			_, _, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeFalse)
 		})
 
 		Convey("value in the middle is empty ", func() {
-			_, _, noEmptyValues := getExpressionValues(metrics, 44)
+			var valueTimestamp int64 = 44
+			_, _, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeFalse)
 		})
 
@@ -1261,7 +1277,8 @@ func TestGetExpressionValues(t *testing.T) {
 			}
 			expectedValues := map[string]float64{"t1": 3}
 
-			expression, values, noEmptyValues := getExpressionValues(metrics, 53)
+			var valueTimestamp int64 = 53
+			expression, values, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeTrue)
 			So(expression, ShouldResemble, expectedExpression)
 			So(values, ShouldResemble, expectedValues)
@@ -1289,19 +1306,22 @@ func TestGetExpressionValues(t *testing.T) {
 		}
 
 		Convey("t1 value in the middle is empty ", func() {
-			_, _, noEmptyValues := getExpressionValues(metrics, 29)
+			var valueTimestamp int64 = 29
+			_, _, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeFalse)
 		})
 
 		Convey("t1 and t2 values in the middle is empty ", func() {
-			_, _, noEmptyValues := getExpressionValues(metrics, 42)
+			var valueTimestamp int64 = 42
+			_, _, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeFalse)
 		})
 
 		Convey("both first values is valid ", func() {
 			expectedValues := map[string]float64{"t1": 0, "t2": 4}
 
-			expression, values, noEmptyValues := getExpressionValues(metrics, 17)
+			var valueTimestamp int64 = 17
+			expression, values, noEmptyValues := getExpressionValues(&metrics, &valueTimestamp)
 			So(noEmptyValues, ShouldBeTrue)
 			So(expression.MainTargetValue, ShouldBeIn, []float64{0, 4})
 			So(values, ShouldResemble, expectedValues)


### PR DESCRIPTION
In checker the most hot place is a calls for getMetricDataState function. This PR tries to improve performance of this calls.

Relates #428