### PR TITLE
feat(checker): Change default metric name to T1

### DIFF
--- a/checker/metrics/conversion/conversion.go
+++ b/checker/metrics/conversion/conversion.go
@@ -1,10 +1,10 @@
 package conversion
 
 import (
-	"sort"
-
 	metricSource "github.com/moira-alert/moira/metric_source"
 )
+
+const firstTarget = "t1"
 
 // isOneMetricMap is a function that checks that map have only one metric and if so returns that metric key.
 func isOneMetricMap(metrics map[string]metricSource.MetricData) (bool, string) {
@@ -16,18 +16,13 @@ func isOneMetricMap(metrics map[string]metricSource.MetricData) (bool, string) {
 	return false, ""
 }
 
-// MetricName is a function that returns a metric name from random metric in MetricsToCheck.
+// MetricName is a function that returns a metric name from first target metric in MetricsToCheck.
 // Should be used with care if MetricsToCheck have metrics with different names.
 func MetricName(metrics map[string]metricSource.MetricData) string {
-	if len(metrics) == 0 {
-		return ""
+	if metric, ok := metrics[firstTarget]; ok {
+		return metric.Name
 	}
-	var metricNames []string
-	for _, metric := range metrics {
-		metricNames = append(metricNames, metric.Name)
-	}
-	sort.Strings(metricNames)
-	return metricNames[0]
+	return ""
 }
 
 // GetRelations is a function that returns a map with relation between target name and metric

--- a/checker/metrics/conversion/conversion_test.go
+++ b/checker/metrics/conversion/conversion_test.go
@@ -84,7 +84,17 @@ func TestMetricName(t *testing.T) {
 					"t2": metricSource.MetricData{Name: "metric.test.1"},
 				},
 			},
-			want: "metric.test.1",
+			want: "metric.test.2",
+		},
+		{
+			name: "origin is not empty, metrics have different names and there is no t1",
+			args: args{
+				metrics: map[string]metricSource.MetricData{
+					"t2": metricSource.MetricData{Name: "metric.test.2"},
+					"t3": metricSource.MetricData{Name: "metric.test.1"},
+				},
+			},
+			want: "",
 		},
 	}
 	Convey("MetricName", t, func() {


### PR DESCRIPTION
If all targets are marked as targets with alone metrics there is a
inconvenient which metric name should be used in check result. This
commit change default metric name from first alphabetical metric name to
metric name from T1.

Relates #428
