### PR TITLE
feat(checker): Allow targets be single if it not declared

### DIFF
--- a/checker/metrics/conversion/conversion.go
+++ b/checker/metrics/conversion/conversion.go
@@ -27,10 +27,10 @@ func MetricName(metrics map[string]metricSource.MetricData) string {
 
 // GetRelations is a function that returns a map with relation between target name and metric
 // name for this target.
-func GetRelations(metrics map[string]metricSource.MetricData) map[string]string {
+func GetRelations(metrics map[string]metricSource.MetricData, declaredAloneMetrics map[string]bool) map[string]string {
 	result := make(map[string]string, len(metrics))
-	for targetName, metric := range metrics {
-		result[targetName] = metric.Name
+	for targetName := range declaredAloneMetrics {
+		result[targetName] = metrics[targetName].Name
 	}
 	return result
 }

--- a/checker/metrics/conversion/conversion_test.go
+++ b/checker/metrics/conversion/conversion_test.go
@@ -109,7 +109,8 @@ func TestMetricName(t *testing.T) {
 
 func TestGetRelations(t *testing.T) {
 	type args struct {
-		metrics map[string]metricSource.MetricData
+		metrics              map[string]metricSource.MetricData
+		declaredAloneMetrics map[string]bool
 	}
 	tests := []struct {
 		name string
@@ -119,8 +120,8 @@ func TestGetRelations(t *testing.T) {
 		{
 			name: "origin is empty",
 			args: args{
-
-				metrics: map[string]metricSource.MetricData{},
+				metrics:              map[string]metricSource.MetricData{},
+				declaredAloneMetrics: map[string]bool{},
 			},
 			want: map[string]string{},
 		},
@@ -128,8 +129,12 @@ func TestGetRelations(t *testing.T) {
 			name: "origin is not empty",
 			args: args{
 				metrics: map[string]metricSource.MetricData{
-					"t1": metricSource.MetricData{Name: "metric.test.1"}, //nolint
-					"t2": metricSource.MetricData{Name: "metric.test.2"},
+					"t1": {Name: "metric.test.1"},
+					"t2": {Name: "metric.test.2"},
+				},
+				declaredAloneMetrics: map[string]bool{
+					"t1": true,
+					"t2": true,
 				},
 			},
 			want: map[string]string{
@@ -137,11 +142,26 @@ func TestGetRelations(t *testing.T) {
 				"t2": "metric.test.2",
 			},
 		},
+		{
+			name: "origin is not empty and declared different targets",
+			args: args{
+				metrics: map[string]metricSource.MetricData{
+					"t1": {Name: "metric.test.1"},
+					"t2": {Name: "metric.test.2"},
+				},
+				declaredAloneMetrics: map[string]bool{
+					"t1": true,
+				},
+			},
+			want: map[string]string{
+				"t1": "metric.test.1",
+			},
+		},
 	}
 	Convey("GetRelations", t, func() {
 		for _, tt := range tests {
 			Convey(tt.name, func() {
-				actual := GetRelations(tt.args.metrics)
+				actual := GetRelations(tt.args.metrics, tt.args.declaredAloneMetrics)
 				So(actual, ShouldResemble, tt.want)
 			})
 		}

--- a/checker/metrics/conversion/trigger_metrics.go
+++ b/checker/metrics/conversion/trigger_metrics.go
@@ -62,19 +62,18 @@ func NewTriggerMetricsWithCapacity(capacity int) TriggerMetrics {
 // Populate is a function that takes TriggerMetrics and populate targets
 // that is missing metrics that appear in another targets except the targets that have
 // only alone metrics.
-func (m TriggerMetrics) Populate(lastCheck moira.CheckData, from int64, to int64) TriggerMetrics {
+func (m TriggerMetrics) Populate(lastCheck moira.CheckData, declaredAloneMetrics map[string]bool, from int64, to int64) TriggerMetrics {
+	// This one have all metrics that should be in final TriggerMetrics.
+	// This structure filled with metrics from last check,
+	// current received metrics alone metrics from last check.
 	allMetrics := make(map[string]map[string]bool, len(m))
-	lastAloneMetrics := make(map[string]bool, len(lastCheck.MetricsToTargetRelation))
 
+	// Gathering alone metrics that were at last check
 	for targetName, metricName := range lastCheck.MetricsToTargetRelation {
 		allMetrics[targetName] = map[string]bool{metricName: true}
-		lastAloneMetrics[metricName] = true
 	}
 
 	for metricName, metricState := range lastCheck.Metrics {
-		if lastAloneMetrics[metricName] {
-			continue
-		}
 		for targetName := range metricState.Values {
 			if _, ok := lastCheck.MetricsToTargetRelation[targetName]; ok {
 				continue
@@ -85,6 +84,7 @@ func (m TriggerMetrics) Populate(lastCheck moira.CheckData, from int64, to int64
 			allMetrics[targetName][metricName] = true
 		}
 	}
+
 	for targetName, metrics := range m {
 		for metricName := range metrics {
 			if _, ok := allMetrics[targetName]; !ok {
@@ -94,7 +94,7 @@ func (m TriggerMetrics) Populate(lastCheck moira.CheckData, from int64, to int64
 		}
 	}
 
-	diff := m.Diff()
+	diff := m.Diff(declaredAloneMetrics)
 
 	for targetName, metrics := range diff {
 		for metricName := range metrics {
@@ -116,12 +116,13 @@ func (m TriggerMetrics) Populate(lastCheck moira.CheckData, from int64, to int64
 
 // FilterAloneMetrics is a function that remove alone metrics targets from TriggerMetrics
 // and return this metrics in format map[targetName]MetricData.
-func (m TriggerMetrics) FilterAloneMetrics() (TriggerMetrics, map[string]metricSource.MetricData) {
+func (m TriggerMetrics) FilterAloneMetrics(declaredAloneMetrics map[string]bool) (TriggerMetrics, map[string]metricSource.MetricData) {
 	result := NewTriggerMetricsWithCapacity(len(m))
 	aloneMetrics := make(map[string]metricSource.MetricData)
 
 	for targetName, targetMetrics := range m {
-		if oneMetricMap, metricName := isOneMetricMap(targetMetrics); oneMetricMap {
+		oneMetricMap, metricName := isOneMetricMap(targetMetrics)
+		if declaredAloneMetrics[targetName] && oneMetricMap {
 			aloneMetrics[targetName] = targetMetrics[metricName]
 			continue
 		}
@@ -132,7 +133,7 @@ func (m TriggerMetrics) FilterAloneMetrics() (TriggerMetrics, map[string]metricS
 
 // Diff is a function that returns a map of target names with metric names that are absent in
 // current target but appear in another targets.
-func (m TriggerMetrics) Diff() map[string]map[string]bool {
+func (m TriggerMetrics) Diff(declaredAloneMetrics map[string]bool) map[string]map[string]bool {
 	result := make(map[string]map[string]bool)
 
 	if len(m) == 0 {
@@ -141,8 +142,8 @@ func (m TriggerMetrics) Diff() map[string]map[string]bool {
 
 	fullMetrics := make(setHelper)
 
-	for _, targetMetrics := range m {
-		if oneMetricTarget, _ := isOneMetricMap(targetMetrics); oneMetricTarget {
+	for targetName, targetMetrics := range m {
+		if declaredAloneMetrics[targetName] {
 			continue
 		}
 		currentMetrics := newSetHelperFromTriggerTargetMetrics(targetMetrics)
@@ -151,7 +152,7 @@ func (m TriggerMetrics) Diff() map[string]map[string]bool {
 
 	for targetName, targetMetrics := range m {
 		metricsSet := newSetHelperFromTriggerTargetMetrics(targetMetrics)
-		if oneMetricTarget, _ := isOneMetricMap(targetMetrics); oneMetricTarget {
+		if declaredAloneMetrics[targetName] {
 			continue
 		}
 		diff := metricsSet.diff(fullMetrics)
@@ -162,17 +163,14 @@ func (m TriggerMetrics) Diff() map[string]map[string]bool {
 	return result
 }
 
-// multiMetricsTarget is a function that finds any first target with
-// amount of metrics greater than one and returns set with names of this metrics.
-func (m TriggerMetrics) multiMetricsTarget() (string, setHelper) {
+// getTargetMetrics is a function that returns metrics of any target.
+func (m TriggerMetrics) getTargetMetrics() (string, setHelper) {
 	commonMetrics := make(setHelper)
 	for targetName, metrics := range m {
-		if len(metrics) > 1 {
-			for metricName := range metrics {
-				commonMetrics[metricName] = true
-			}
-			return targetName, commonMetrics
+		for metricName := range metrics {
+			commonMetrics[metricName] = true
 		}
+		return targetName, commonMetrics
 	}
 	return "", nil
 }
@@ -184,12 +182,10 @@ func (m TriggerMetrics) multiMetricsTarget() (string, setHelper) {
 // a map with names of targets that had only one metric as key and original metric name as value.
 func (m TriggerMetrics) ConvertForCheck() map[string]map[string]metricSource.MetricData {
 	result := make(map[string]map[string]metricSource.MetricData)
-	_, commonMetrics := m.multiMetricsTarget()
+	_, commonMetrics := m.getTargetMetrics()
 
-	hasAtLeastOneMultiMetricsTarget := commonMetrics != nil
-
-	if !hasAtLeastOneMultiMetricsTarget && len(m) <= 1 {
-		return result
+	if commonMetrics != nil && len(commonMetrics) <= 1 {
+		return nil
 	}
 
 	for targetName, targetMetrics := range m {


### PR DESCRIPTION
Targets in trigger can be marked as a "Single" what is mean that in
this target will be only one metric. If target have one metric and it is
not marked as "Single" check of this trigger will set trigger to
exception state as it was expected to have more than one metric in this
target.

This commit changes behavior of checker to allow targets not marked as
alone to have only one metric.

Relates #428
