### PR TITLE
Return false as default pass value in handlePrepareError

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -75,7 +75,7 @@ func (triggerChecker *TriggerChecker) handlePrepareError(checkData moira.CheckDa
 		return false, checkData, err
 	}
 	checkData.UpdateScore()
-	return true, checkData, triggerChecker.database.SetTriggerLastCheck(triggerChecker.triggerID, &checkData, triggerChecker.trigger.IsRemote)
+	return false, checkData, triggerChecker.database.SetTriggerLastCheck(triggerChecker.triggerID, &checkData, triggerChecker.trigger.IsRemote)
 }
 
 // handleFetchError is a function that checks error returned from fetchTriggerMetrics function.


### PR DESCRIPTION
In checker handlePrepareError returns a boolean called pass which notify
caller should it continue or should it return with error immediately.
By default true was returned. Default changed to false.

Relates #428