### PR TITLE
Fix goroutines leak in filter

### DIFF
--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -50,6 +50,7 @@ func startTelemetryServer(logger moira.Logger, listen string, pprofConfig Profil
 		serverMux.HandleFunc("/pprof/symbol", pprof.Symbol)
 		serverMux.HandleFunc("/pprof/trace", pprof.Trace)
 		serverMux.HandleFunc("/pprof/heap", pprof.Handler("heap").ServeHTTP)
+		serverMux.HandleFunc("/pprof/goroutine", pprof.Handler("goroutine").ServeHTTP)
 	}
 	serverMux.Handle("/metrics", promhttp.InstrumentMetricHandler(prometheusRegistry, promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{})))
 	server := &http.Server{Handler: serverMux}

--- a/filter/connection/handler.go
+++ b/filter/connection/handler.go
@@ -48,7 +48,8 @@ func (handler *Handler) handle(connection net.Conn, lineChan chan<- []byte) {
 			if err != io.EOF {
 				handler.logger.Errorf("Fail to read from metric connection: %s", err)
 			}
-			break
+			handler.terminate <- struct{}{}
+			return
 		}
 		bytesWithoutCRLF := dropCRLF(bytes)
 		if len(bytesWithoutCRLF) > 0 {


### PR DESCRIPTION
# PR Summary

Add sending value to channel which is needed to close coroutines after TCP connection is closed.

Closes/Relates #560
