### PR TITLE
fix(api): return 'not found' when rendering non-existing trigger chart

### DIFF
--- a/api/handler/trigger_render.go
+++ b/api/handler/trigger_render.go
@@ -26,7 +26,7 @@ func renderTrigger(writer http.ResponseWriter, request *http.Request) {
 	metricsData, trigger, err := evaluateTargetMetrics(sourceProvider, from, to, triggerID, fetchRealtimeData)
 	if err != nil {
 		if trigger == nil {
-			render.Render(writer, request, api.ErrorInvalidRequest(err))
+			render.Render(writer, request, api.ErrorNotFound(fmt.Sprintf("trigger with ID = '%s' does not exists", triggerID)))
 		} else {
 			render.Render(writer, request, api.ErrorInternalServer(err))
 		}

--- a/api/handler/trigger_render.go
+++ b/api/handler/trigger_render.go
@@ -25,7 +25,11 @@ func renderTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 	metricsData, trigger, err := evaluateTargetMetrics(sourceProvider, from, to, triggerID, fetchRealtimeData)
 	if err != nil {
-		render.Render(writer, request, api.ErrorInternalServer(err))
+		if trigger == nil {
+			render.Render(writer, request, api.ErrorInvalidRequest(err))
+		} else {
+			render.Render(writer, request, api.ErrorInternalServer(err))
+		}
 		return
 	}
 


### PR DESCRIPTION
### PR Summary
The `/trigger/{triggerID}/render` route is used to render the graph for a trigger. If no trigger with the matching triggerID is found, the API returns a 500 internal server error.

This commit changes it to return a 400 error instead with the corresponding message.

### Additional information
I think a 404 error is better for when a resource is not found, but I've used 400 so that it is consistent with other places where the trigger is nil (e.g deleting a trigger metric).
