### PR TITLE
Fix full-text search if the text is in uppercase

### DIFF
--- a/api/handler/tiggers_test.go
+++ b/api/handler/tiggers_test.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetSearchRequestString(t *testing.T) {
+	Convey("Given a search request string", t, func() {
+		Convey("The value should be converted into lower case", func() {
+			testCases := []struct {
+				text                  string
+				expectedSearchRequest string
+			}{
+				{"query", "query"},
+				{"QUERY", "query"},
+				{"Query", "query"},
+				{"QueRy", "query"},
+			}
+			for _, testCase := range testCases {
+				req, _ := http.NewRequest("GET", fmt.Sprintf("/api/trigger/search?onlyProblems=false&p=0&size=20&text=%s", testCase.text), nil)
+				searchRequest := getSearchRequestString(req)
+				So(searchRequest, ShouldEqual, testCase.expectedSearchRequest)
+			}
+		})
+	})
+}

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
@@ -125,6 +126,7 @@ func getOnlyProblemsFlag(request *http.Request) bool {
 
 func getSearchRequestString(request *http.Request) string {
 	searchText := request.FormValue("text")
+	searchText = strings.ToLower(searchText)
 	searchText, _ = url.PathUnescape(searchText)
 	return searchText
 }


### PR DESCRIPTION
# Fix full-text search if the text is in uppercase

Added search text converting to lowercase.

Closes/Relates #512
