### PR TITLE
feat(telegram): Added private channels support

### DIFF
--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"gopkg.in/tucnak/telebot.v2"
 
@@ -86,10 +87,24 @@ func (sender *Sender) buildMessage(events moira.NotificationEvents, trigger moir
 	return buffer.String()
 }
 
+func (sender *Sender) getChatUID(username string) (string, error) {
+	var uid string
+	if strings.HasPrefix(username, "%") {
+		uid = "-100" + username[1:]
+	} else {
+		var err error
+		uid, err = sender.DataBase.GetIDByUsername(messenger, username)
+		if err != nil {
+			return "", fmt.Errorf("failed to get username uuid: %s", err.Error())
+		}
+	}
+	return uid, nil
+}
+
 func (sender *Sender) getChat(username string) (*telebot.Chat, error) {
-	uid, err := sender.DataBase.GetIDByUsername(messenger, username)
+	uid, err := sender.getChatUID(username)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get username uuid: %s", err.Error())
+		return nil, err
 	}
 	chat, err := sender.bot.ChatByID(uid)
 	if err != nil {

--- a/senders/telegram/send_test.go
+++ b/senders/telegram/send_test.go
@@ -110,3 +110,17 @@ http://moira.url/trigger/TriggerID
 		})
 	})
 }
+
+func TestGetChatUID(t *testing.T) {
+	location, _ := time.LoadLocation("UTC")
+	sender := Sender{location: location, frontURI: "http://moira.url"}
+
+	Convey("Get Telegram chat's UID", t, func() {
+		Convey("For private channel with % prefix should return with -100 prefix", func() {
+			actual, err := sender.getChatUID("%1494975744")
+			expected := "-1001494975744"
+			So(actual, ShouldResemble, expected)
+			So(err, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
Added the ability to set the identifier of private channels for notifications. It starts with `%`.

Closes #563 
