### PR TITLE
Add support of Slack user-group mentioning in the alert message

### DIFF
--- a/senders/slack/slack.go
+++ b/senders/slack/slack.go
@@ -180,6 +180,8 @@ func (sender *Sender) sendMessage(message string, contact string, triggerID stri
 		AsUser:    useDirectMessaging,
 		IconEmoji: emoji,
 		Markdown:  true,
+		Parse: "full",
+		LinkNames: 1,
 	}
 	sender.logger.Debugf("Calling slack with message body %s", message)
 	channelID, threadTimestamp, err := sender.client.PostMessage(contact, slack.MsgOptionText(message, false), slack.MsgOptionPostMessageParameters(params))


### PR DESCRIPTION
Hello, 
My team has a single channel for alerts across all our applications. For each application we added a separate Slack user-group (`@gitlab_duty`/`@teamcity_duty` for example) that contains one or several engineers on duty and we would like to mention these groups in the alert message. 

Moira uses Slack API `chat.postMessage` for sending alert messages and that requires us to specify that user group by using the rather complicated syntax `<!Subteam^SAZ94GDB8>` (see https://api.slack.com/reference/surfaces/formatting#mentioning-groups). We can't get user-group ID from the Slack Desktop App and we have to use Slack API in order to do that.

There is another way: we can specify additional property `Parse` with value `full` in PostMessageParameters which change how Slack treats the message (see https://api.slack.com/methods/chat.postMessage#formatting). In my opinion this way is more user-friendly and the required changes are minor.