### PR TITLE
build: Bump golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VERSION_RELEASE := ${GIT_TAG}.${GIT_COMMIT}
 GO_VERSION := $(shell go version | cut -d' ' -f3)
 GO_PATH := $(shell go env GOPATH)
 GO111MODULE := on
-GOLANGCI_LINT_VERSION := "v1.23.8"
+GOLANGCI_LINT_VERSION := "v1.32.0"
 REVIEWDOG_VERSION := "v0.9.17"
 REVIEWDOG_RUNNERS ?= golangci
 

--- a/senders/slack/slack.go
+++ b/senders/slack/slack.go
@@ -180,7 +180,7 @@ func (sender *Sender) sendMessage(message string, contact string, triggerID stri
 		AsUser:    useDirectMessaging,
 		IconEmoji: emoji,
 		Markdown:  true,
-		Parse: "full",
+		Parse:     "full",
 		LinkNames: 1,
 	}
 	sender.logger.Debugf("Calling slack with message body %s", message)


### PR DESCRIPTION
Older version stopped working on Travis CI for some reason.