### PR TITLE
Clean last check on trigger update

### DIFF
--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -39,6 +39,7 @@ func saveTrigger(dataBase moira.Database, trigger *moira.Trigger, triggerID stri
 				lastCheck.RemoveMetricState(metric)
 			}
 		}
+		lastCheck.RemoveMetricsToTargetRelation()
 	} else {
 		triggerState := moira.StateNODATA
 		if trigger.TTLState != nil {

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -63,9 +63,13 @@ func TestSaveTrigger(t *testing.T) {
 			"super.metric1": {},
 			"super.metric2": {},
 		},
+		MetricsToTargetRelation: map[string]string{
+			"t2": "super.metric3",
+		},
 	}
 	emptyLastCheck := moira.CheckData{
-		Metrics: make(map[string]moira.MetricState),
+		Metrics:                 make(map[string]moira.MetricState),
+		MetricsToTargetRelation: map[string]string{},
 	}
 
 	Convey("No timeSeries", t, func() {
@@ -84,12 +88,11 @@ func TestSaveTrigger(t *testing.T) {
 			dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
 			dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
 			dataBase.EXPECT().GetTriggerLastCheck(triggerID).Return(actualLastCheck, nil)
-			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &actualLastCheck, trigger.IsRemote).Return(nil)
+			dataBase.EXPECT().SetTriggerLastCheck(triggerID, &emptyLastCheck, trigger.IsRemote).Return(nil)
 			dataBase.EXPECT().SaveTrigger(triggerID, &trigger).Return(nil)
 			resp, err := saveTrigger(dataBase, &trigger, triggerID, make(map[string]bool))
 			So(err, ShouldBeNil)
 			So(resp, ShouldResemble, &dto.SaveTriggerResponse{ID: triggerID, Message: "trigger updated"})
-			So(actualLastCheck, ShouldResemble, emptyLastCheck)
 		})
 	})
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -292,6 +292,11 @@ func (checkData CheckData) RemoveMetricState(metricName string) {
 	delete(checkData.Metrics, metricName)
 }
 
+// RemoveMetricsToTargetRelation is a function that sets an empty map to MetricsToTargetRelation.
+func (checkData *CheckData) RemoveMetricsToTargetRelation() {
+	checkData.MetricsToTargetRelation = make(map[string]string)
+}
+
 // MetricState represents metric state data for given timestamp
 type MetricState struct {
 	EventTimestamp  int64              `json:"event_timestamp"`


### PR DESCRIPTION
# PR Summary

In last check some targets have a records in MetricsToTargetRelation
dictionary. This records did not cleaned during trigger update that led
checker to use metric names from this dictionary to populate the set of
metrics to check.

Closes #593