### PR TITLE
fix(api): Remove populate check in trigger update

### DIFF
--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -37,11 +37,6 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	if err = checkingTemplateFilling(request, *trigger); err != nil {
-		render.Render(writer, request, err) //nolint
-		return
-	}
-
 	timeSeriesNames := middleware.GetTimeSeriesNames(request)
 	response, err := controller.UpdateTrigger(database, &trigger.TriggerModel, triggerID, timeSeriesNames)
 	if err != nil {


### PR DESCRIPTION
# PR Summary

In trigger update handler were used check for populate description. This
check is not necessary in trigger update and causes panic because it
tries to check "populated" query param that is not allowed for this
route.

Relates #182