### PR TITLE
fix http schema escaping when build url in webhook sender

### DIFF
--- a/senders/webhook/request.go
+++ b/senders/webhook/request.go
@@ -70,7 +70,7 @@ func buildRequestURL(template string, trigger moira.TriggerData, contact moira.C
 	for k, v := range templateVariables {
 		value := url.PathEscape(v)
 		if k == moira.VariableContactValue &&
-			(strings.HasPrefix(v, "http:/") || strings.HasPrefix(v, "https://")) {
+			(strings.HasPrefix(v, "http://") || strings.HasPrefix(v, "https://")) {
 			value = v
 		}
 		template = strings.Replace(template, k, value, -1)

--- a/senders/webhook/request.go
+++ b/senders/webhook/request.go
@@ -68,7 +68,12 @@ func buildRequestURL(template string, trigger moira.TriggerData, contact moira.C
 		moira.VariableTriggerID:    trigger.ID,
 	}
 	for k, v := range templateVariables {
-		template = strings.Replace(template, k, url.PathEscape(v), -1)
+		value := url.PathEscape(v)
+		if k == moira.VariableContactValue &&
+			(strings.HasPrefix(v, "http:/") || strings.HasPrefix(v, "https://")) {
+			value = v
+		}
+		template = strings.Replace(template, k, value, -1)
 	}
 	return template
 }

--- a/senders/webhook/request_test.go
+++ b/senders/webhook/request_test.go
@@ -213,7 +213,7 @@ func TestBuildRequestURL(t *testing.T) {
 	})
 }
 
-var testContactWithUrl = moira.ContactData{
+var testContactWithURL = moira.ContactData{
 	ID:    "contactID",
 	Type:  "contactType",
 	Value: "https://test/moirahook",
@@ -223,7 +223,7 @@ var testContactWithUrl = moira.ContactData{
 
 func TestBuildRequestURL_FromContactValueWithURL(t *testing.T) {
 	Convey("URL should contain variables values", t, func() {
-		actual := buildRequestURL("${contact_value}", testTrigger, testContactWithUrl)
+		actual := buildRequestURL("${contact_value}", testTrigger, testContactWithURL)
 		So(actual, ShouldEqual, "https://test/moirahook")
 	})
 }

--- a/senders/webhook/request_test.go
+++ b/senders/webhook/request_test.go
@@ -213,6 +213,21 @@ func TestBuildRequestURL(t *testing.T) {
 	})
 }
 
+var testContactWithUrl = moira.ContactData{
+	ID:    "contactID",
+	Type:  "contactType",
+	Value: "https://test/moirahook",
+	User:  "contactUser",
+	Team:  "contactTeam",
+}
+
+func TestBuildRequestURL_FromContactValueWithURL(t *testing.T) {
+	Convey("URL should contain variables values", t, func() {
+		actual := buildRequestURL("${contact_value}", testTrigger, testContactWithUrl)
+		So(actual, ShouldEqual, "https://test/moirahook")
+	})
+}
+
 func prepareStrings(actual, expected string) (string, string) {
 	return strings.Join(strings.Fields(actual), ""), strings.Join(strings.Fields(expected), "")
 }

--- a/senders/webhook/request_test.go
+++ b/senders/webhook/request_test.go
@@ -216,7 +216,7 @@ func TestBuildRequestURL(t *testing.T) {
 var testContactWithURL = moira.ContactData{
 	ID:    "contactID",
 	Type:  "contactType",
-	Value: "https://test/moirahook",
+	Value: "https://test.org/moirahook",
 	User:  "contactUser",
 	Team:  "contactTeam",
 }
@@ -224,7 +224,7 @@ var testContactWithURL = moira.ContactData{
 func TestBuildRequestURL_FromContactValueWithURL(t *testing.T) {
 	Convey("URL should contain variables values", t, func() {
 		actual := buildRequestURL("${contact_value}", testTrigger, testContactWithURL)
-		So(actual, ShouldEqual, "https://test/moirahook")
+		So(actual, ShouldEqual, "https://test.org/moirahook")
 	})
 }
 


### PR DESCRIPTION
# PR Summary

Bug with webhook: url has encoded slashes if contact value looks like `http://ya.ru/`.

Closes/Relates #issue
