### PR TITLE
feat(checker): Simplify ConvertForCheck function

### DIFF
--- a/checker/metrics/conversion/trigger_metrics.go
+++ b/checker/metrics/conversion/trigger_metrics.go
@@ -196,40 +196,16 @@ func (m TriggerMetrics) Diff(declaredAloneMetrics map[string]bool) map[string]ma
 	return result
 }
 
-// getTargetMetrics is a function that returns metrics of any target.
-func (m TriggerMetrics) getTargetMetrics() (string, setHelper) {
-	commonMetrics := make(setHelper)
-	for targetName, metrics := range m {
-		for metricName := range metrics {
-			commonMetrics[metricName] = true
-		}
-		return targetName, commonMetrics
-	}
-	return "", nil
-}
-
 // ConvertForCheck is a function that converts TriggerMetrics with structure
 // map[TargetName]map[MetricName]MetricData to ConvertedTriggerMetrics
-// with structure map[MetricName]map[TargetName]MetricData and fill with
-// duplicated metrics targets that have only one metric. Second return value is
-// a map with names of targets that had only one metric as key and original metric name as value.
+// with structure map[MetricName]map[TargetName]MetricData.
 func (m TriggerMetrics) ConvertForCheck() map[string]map[string]metricSource.MetricData {
 	result := make(map[string]map[string]metricSource.MetricData)
-	_, commonMetrics := m.getTargetMetrics()
-
 	for targetName, targetMetrics := range m {
-		oneMetricTarget, oneMetricName := isOneMetricMap(targetMetrics)
-
-		for metricName := range commonMetrics {
+		for metricName := range targetMetrics {
 			if _, ok := result[metricName]; !ok {
 				result[metricName] = make(map[string]metricSource.MetricData, len(m))
 			}
-
-			if oneMetricTarget {
-				result[metricName][targetName] = m[targetName][oneMetricName]
-				continue
-			}
-
 			result[metricName][targetName] = m[targetName][metricName]
 		}
 	}

--- a/checker/metrics/conversion/trigger_metrics_test.go
+++ b/checker/metrics/conversion/trigger_metrics_test.go
@@ -2,7 +2,6 @@ package conversion
 
 import (
 	"math"
-	"reflect"
 	"testing"
 
 	"github.com/moira-alert/moira"
@@ -446,28 +445,6 @@ func TestTriggerMetrics_Diff(t *testing.T) {
 	})
 }
 
-func TestTriggerMetrics_multiMetricsTarget(t *testing.T) {
-	tests := []struct {
-		name  string
-		m     TriggerMetrics
-		want  string
-		want1 setHelper
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := tt.m.getTargetMetrics()
-			if got != tt.want {
-				t.Errorf("TriggerMetrics.multiMetricsTarget() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("TriggerMetrics.multiMetricsTarget() got1 = %v, want %v", got1, tt.want1)
-			}
-		})
-	}
-}
-
 func TestTriggerMetrics_ConvertForCheck(t *testing.T) {
 	tests := []struct {
 		name string
@@ -493,28 +470,6 @@ func TestTriggerMetrics_ConvertForCheck(t *testing.T) {
 				},
 				"metric.test.2": {
 					"t1": {Name: "metric.test.2"},
-				},
-			},
-		},
-		{
-			name: "origin have metrics and target with empty metrics",
-			m: TriggerMetrics{
-				"t1": TriggerTargetMetrics{
-					"metric.test.1": {Name: "metric.test.1"},
-					"metric.test.2": {Name: "metric.test.2"},
-				},
-				"t2": TriggerTargetMetrics{
-					"metric.test.3": {Name: "metric.test.3"},
-				},
-			},
-			want: map[string]map[string]metricSource.MetricData{
-				"metric.test.1": {
-					"t1": {Name: "metric.test.1"},
-					"t2": {Name: "metric.test.3"},
-				},
-				"metric.test.2": {
-					"t1": {Name: "metric.test.2"},
-					"t2": {Name: "metric.test.3"},
 				},
 			},
 		},


### PR DESCRIPTION
# PR Summary

In first versions of a new advanced mode after preparation metrics were
mixed. In one metrics set there was single and multi metrics targets.
Due to this on the step of conversion between
map[TargetName]map[MetricName]metrics to
map[MetricName]map[TargetName]metrics we had to check if some target is
alone metrics target and handle alone metrics targets separately. On the
other hand now on the step of preparation all targets are multi metric
targets and alone metric targets were filtered on the steps before so
we do not need to check alone metrics target on the step of conversion.

Relates #428
