### PR TITLE
feat: Switch off exceptions on database freezes

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -109,6 +109,8 @@ func (triggerChecker *TriggerChecker) handleFetchError(checkData moira.CheckData
 		checkData.State = moira.StateEXCEPTION
 		checkData.Message = err.Error()
 		triggerChecker.logger.Warning(formatTriggerCheckException(triggerChecker.triggerID, err))
+	case ErrNetwork:
+		triggerChecker.logger.Error(err.Error())
 	default:
 		return triggerChecker.handleUndefinedError(checkData, err)
 	}

--- a/checker/errors.go
+++ b/checker/errors.go
@@ -50,3 +50,13 @@ type ErrTriggerHasEmptyTargets struct {
 func (err ErrTriggerHasEmptyTargets) Error() string {
 	return fmt.Sprintf("target t%v has no metrics", strings.Join(err.targets, ", "))
 }
+
+// ErrNetwork used if network error occurred during fetch
+type ErrNetwork struct {
+	networkError error
+}
+
+// ErrNetwork implementation with error message
+func (err ErrNetwork) Error() string {
+	return fmt.Sprintf("network error during fetch: %s", err.networkError.Error())
+}

--- a/checker/fetch.go
+++ b/checker/fetch.go
@@ -1,7 +1,9 @@
 package checker
 
 import (
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/moira-alert/moira/checker/metrics/conversion"
 	metricSource "github.com/moira-alert/moira/metric_source"
@@ -35,6 +37,10 @@ func (triggerChecker *TriggerChecker) fetch() (map[string][]metricSource.MetricD
 		targetIndex++ // increasing target index to have target names started from 1 instead of 0
 		fetchResult, err := triggerChecker.source.Fetch(target, triggerChecker.from, triggerChecker.until, isSimpleTrigger)
 		if err != nil {
+			var e *net.OpError
+			if errors.As(err, &e) {
+				return nil, nil, err
+			}
 			return nil, nil, err
 		}
 		metricsData := fetchResult.GetMetricsData()

--- a/database/redis/bot.go
+++ b/database/redis/bot.go
@@ -37,7 +37,7 @@ func (connector *DbConnector) RemoveUser(messenger, username string) error {
 	defer c.Close()
 	_, err := c.Do("DEL", usernameKey(messenger, username))
 	if err != nil {
-		return fmt.Errorf("failed to delete username '%s' from messenger '%s', error: %s", username, messenger, err.Error())
+		return fmt.Errorf("failed to delete username '%s' from messenger '%s', error: %w", username, messenger, err)
 	}
 	return nil
 }

--- a/database/redis/contact.go
+++ b/database/redis/contact.go
@@ -95,7 +95,7 @@ func (connector *DbConnector) SaveContact(contact *moira.ContactData) error {
 	}
 	_, err = c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to EXEC: %s", err.Error())
+		return fmt.Errorf("failed to EXEC: %w", err)
 	}
 	return nil
 }
@@ -115,7 +115,7 @@ func (connector *DbConnector) RemoveContact(contactID string) error {
 	c.Send("SREM", teamContactsKey(existing.Team), contactID) //nolint
 	_, err = c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to EXEC: %s", err.Error())
+		return fmt.Errorf("failed to EXEC: %w", err)
 	}
 	return nil
 }
@@ -127,7 +127,7 @@ func (connector *DbConnector) GetUserContactIDs(login string) ([]string, error) 
 
 	contacts, err := redis.Strings(c.Do("SMEMBERS", userContactsKey(login)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get contacts for user login %s: %s", login, err.Error())
+		return nil, fmt.Errorf("failed to get contacts for user login %s: %w", login, err)
 	}
 	return contacts, nil
 }
@@ -139,7 +139,7 @@ func (connector *DbConnector) GetTeamContactIDs(login string) ([]string, error) 
 
 	contacts, err := redis.Strings(c.Do("SMEMBERS", teamContactsKey(login)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get contacts for team login %s: %s", login, err.Error())
+		return nil, fmt.Errorf("failed to get contacts for team login %s: %w", login, err)
 	}
 	return contacts, nil
 }

--- a/database/redis/database.go
+++ b/database/redis/database.go
@@ -67,7 +67,7 @@ func NewDatabase(logger moira.Logger, config Config, source DBSource) *DbConnect
 		TestOnBorrow: poolDialer.Test,
 	}
 	syncPool := &redis.Pool{
-		MaxIdle:      3, //nolint
+		MaxIdle:      3,  //nolint
 		MaxActive:    10, //nolint
 		Wait:         true,
 		IdleTimeout:  240 * time.Second, //nolint
@@ -162,7 +162,7 @@ func (connector *DbConnector) makePubSubConnection(channel string) (*redis.PubSu
 	psc := redis.PubSubConn{Conn: c}
 	if err := psc.Subscribe(channel); err != nil {
 		c.Close()
-		return nil, fmt.Errorf("failed to subscribe to '%s', error: %v", channel, err)
+		return nil, fmt.Errorf("failed to subscribe to '%s', error: %w", channel, err)
 	}
 	return &psc, nil
 }
@@ -205,7 +205,7 @@ func (connector *DbConnector) manageSubscriptions(tomb *tomb.Tomb, channel strin
 				connector.logger.Infof("psc.Receive() returned *net.OpError: %s. Reconnecting...", n.Err.Error())
 				newPsc, err := connector.makePubSubConnection(metricEventKey)
 				if err != nil {
-					connector.logger.Errorf("Failed to reconnect to subscription: %v", err)
+					connector.logger.Errorf("Failed to reconnect to subscription: %w", err)
 					<-time.After(receiveErrorSleepDuration)
 					continue
 				}

--- a/database/redis/last_check.go
+++ b/database/redis/last_check.go
@@ -34,8 +34,8 @@ func (connector *DbConnector) SetTriggerLastCheck(triggerID string, checkData *m
 
 	c := connector.pool.Get()
 	defer c.Close()
-	c.Send("MULTI") //nolint
-	c.Send("SET", metricLastCheckKey(triggerID), bytes) //nolint
+	c.Send("MULTI")                                               //nolint
+	c.Send("SET", metricLastCheckKey(triggerID), bytes)           //nolint
 	c.Send("ZADD", triggersChecksKey, checkData.Score, triggerID) //nolint
 	if selfStateCheckCountKey != "" {
 		c.Send("INCR", selfStateCheckCountKey) //nolint
@@ -50,7 +50,7 @@ func (connector *DbConnector) SetTriggerLastCheck(triggerID string, checkData *m
 	}
 	_, err = c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to EXEC: %s", err.Error())
+		return fmt.Errorf("failed to EXEC: %w", err)
 	}
 	return nil
 }
@@ -69,14 +69,14 @@ func (connector *DbConnector) getSelfStateCheckCountKey(isRemote bool) string {
 func (connector *DbConnector) RemoveTriggerLastCheck(triggerID string) error {
 	c := connector.pool.Get()
 	defer c.Close()
-	c.Send("MULTI") //nolint
-	c.Send("DEL", metricLastCheckKey(triggerID)) //nolint
-	c.Send("ZREM", triggersChecksKey, triggerID) //nolint
-	c.Send("SREM", badStateTriggersKey, triggerID) //nolint
+	c.Send("MULTI")                                                    //nolint
+	c.Send("DEL", metricLastCheckKey(triggerID))                       //nolint
+	c.Send("ZREM", triggersChecksKey, triggerID)                       //nolint
+	c.Send("SREM", badStateTriggersKey, triggerID)                     //nolint
 	c.Send("ZADD", triggersToReindexKey, time.Now().Unix(), triggerID) //nolint
 	_, err := c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to EXEC: %s", err.Error())
+		return fmt.Errorf("failed to EXEC: %w", err)
 	}
 
 	return nil
@@ -98,7 +98,7 @@ func (connector *DbConnector) SetTriggerCheckMaintenance(triggerID string, metri
 		var lastCheck = moira.CheckData{}
 		err := json.Unmarshal([]byte(lastCheckString), &lastCheck)
 		if err != nil {
-			return fmt.Errorf("failed to parse lastCheck json %s: %s", lastCheckString, err.Error())
+			return fmt.Errorf("failed to parse lastCheck json %s: %w", lastCheckString, err)
 		}
 		metricsCheck := lastCheck.Metrics
 		if len(metricsCheck) > 0 {

--- a/database/redis/reply/check.go
+++ b/database/redis/reply/check.go
@@ -95,12 +95,12 @@ func Check(rep interface{}, err error) (moira.CheckData, error) {
 		if err == redis.ErrNil {
 			return moira.CheckData{}, database.ErrNil
 		}
-		return moira.CheckData{}, fmt.Errorf("failed to read lastCheck: %s", err.Error())
+		return moira.CheckData{}, fmt.Errorf("failed to read lastCheck: %w", err)
 	}
 	checkSE := checkDataStorageElement{}
 	err = json.Unmarshal(bytes, &checkSE)
 	if err != nil {
-		return moira.CheckData{}, fmt.Errorf("failed to parse lastCheck json %s: %s", string(bytes), err.Error())
+		return moira.CheckData{}, fmt.Errorf("failed to parse lastCheck json %s: %w", string(bytes), err)
 	}
 	return checkSE.toCheckData(), nil
 }
@@ -110,7 +110,7 @@ func GetCheckBytes(check moira.CheckData) ([]byte, error) {
 	checkSE := toCheckDataStorageElement(check)
 	bytes, err := json.Marshal(checkSE)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal check data: %s", err.Error())
+		return nil, fmt.Errorf("failed to marshal check data: %w", err)
 	}
 	return bytes, nil
 }

--- a/database/redis/reply/contact.go
+++ b/database/redis/reply/contact.go
@@ -17,11 +17,11 @@ func Contact(rep interface{}, err error) (moira.ContactData, error) {
 		if err == redis.ErrNil {
 			return contact, database.ErrNil
 		}
-		return contact, fmt.Errorf("failed to read contact: %s", err.Error())
+		return contact, fmt.Errorf("failed to read contact: %w", err)
 	}
 	err = json.Unmarshal(bytes, &contact)
 	if err != nil {
-		return contact, fmt.Errorf("failed to parse contact json %s: %s", string(bytes), err.Error())
+		return contact, fmt.Errorf("failed to parse contact json %s: %w", string(bytes), err)
 	}
 	return contact, nil
 }
@@ -33,7 +33,7 @@ func Contacts(rep interface{}, err error) ([]*moira.ContactData, error) {
 		if err == redis.ErrNil {
 			return make([]*moira.ContactData, 0), nil
 		}
-		return nil, fmt.Errorf("failed to read contacts: %s", err.Error())
+		return nil, fmt.Errorf("failed to read contacts: %w", err)
 	}
 	contacts := make([]*moira.ContactData, len(values))
 	for i, value := range values {

--- a/database/redis/reply/event.go
+++ b/database/redis/reply/event.go
@@ -79,7 +79,7 @@ func GetEventBytes(event moira.NotificationEvent) ([]byte, error) {
 	eventSE := toNotificationEventStorageElement(event)
 	bytes, err := json.Marshal(eventSE)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal notification event: %s", err.Error())
+		return nil, fmt.Errorf("failed to marshal notification event: %w", err)
 	}
 	return bytes, nil
 }
@@ -91,12 +91,12 @@ func Event(rep interface{}, err error) (moira.NotificationEvent, error) {
 		if err == redis.ErrNil {
 			return moira.NotificationEvent{}, database.ErrNil
 		}
-		return moira.NotificationEvent{}, fmt.Errorf("failed to read event: %s", err.Error())
+		return moira.NotificationEvent{}, fmt.Errorf("failed to read event: %w", err)
 	}
 	eventSE := notificationEventStorageElement{}
 	err = json.Unmarshal(bytes, &eventSE)
 	if err != nil {
-		return moira.NotificationEvent{}, fmt.Errorf("failed to parse event json %s: %s", string(bytes), err.Error())
+		return moira.NotificationEvent{}, fmt.Errorf("failed to parse event json %s: %w", string(bytes), err)
 	}
 	return eventSE.toNotificationEvent(), nil
 }
@@ -108,7 +108,7 @@ func Events(rep interface{}, err error) ([]*moira.NotificationEvent, error) {
 		if err == redis.ErrNil {
 			return make([]*moira.NotificationEvent, 0), nil
 		}
-		return nil, fmt.Errorf("failed to read events: %s", err.Error())
+		return nil, fmt.Errorf("failed to read events: %w", err)
 	}
 	events := make([]*moira.NotificationEvent, len(values))
 	for i, value := range values {

--- a/database/redis/reply/metric.go
+++ b/database/redis/reply/metric.go
@@ -16,7 +16,7 @@ func MetricValues(values interface{}) ([]*moira.MetricValue, error) {
 		if err == redis.ErrNil {
 			return make([]*moira.MetricValue, 0), nil
 		}
-		return nil, fmt.Errorf("failed to read metricValues: %s", err.Error())
+		return nil, fmt.Errorf("failed to read metricValues: %w", err)
 	}
 	metricsValues := make([]*moira.MetricValue, 0, len(resultByMetricArr)/2) //nolint
 	for i := 0; i < len(resultByMetricArr); i += 2 {
@@ -28,17 +28,17 @@ func MetricValues(values interface{}) ([]*moira.MetricValue, error) {
 		if len(valuesArr) != 2 { //nolint
 			return nil, fmt.Errorf("value format is not valid: %s", val)
 		}
-		timestamp, err := strconv.ParseInt(valuesArr[0], 10, 64)
+		timestamp, err := strconv.ParseInt(valuesArr[0], 10, 64) // nolint
 		if err != nil {
-			return nil, fmt.Errorf("metric timestamp format is not valid: %s", err.Error())
+			return nil, fmt.Errorf("metric timestamp format is not valid: %w", err)
 		}
-		value, err := strconv.ParseFloat(valuesArr[1], 64)
+		value, err := strconv.ParseFloat(valuesArr[1], 64) // nolint
 		if err != nil {
-			return nil, fmt.Errorf("metric value format is not valid: %s", err.Error())
+			return nil, fmt.Errorf("metric value format is not valid: %w", err)
 		}
 		retentionTimestamp, err := redis.Int64(resultByMetricArr[i+1], nil)
 		if err != nil {
-			return nil, fmt.Errorf("retention timestamp format is not valid: %s", err.Error())
+			return nil, fmt.Errorf("retention timestamp format is not valid: %w", err)
 		}
 		metricValue := moira.MetricValue{
 			RetentionTimestamp: retentionTimestamp,

--- a/database/redis/reply/notification.go
+++ b/database/redis/reply/notification.go
@@ -49,7 +49,7 @@ func GetNotificationBytes(notification moira.ScheduledNotification) ([]byte, err
 	notificationSE := toScheduledNotificationStorageElement(notification)
 	bytes, err := json.Marshal(notificationSE)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal notification: %s", err.Error())
+		return nil, fmt.Errorf("failed to marshal notification: %w", err)
 	}
 	return bytes, nil
 }
@@ -61,12 +61,12 @@ func Notification(rep interface{}, err error) (moira.ScheduledNotification, erro
 		if err == redis.ErrNil {
 			return moira.ScheduledNotification{}, database.ErrNil
 		}
-		return moira.ScheduledNotification{}, fmt.Errorf("failed to read scheduledNotification: %s", err.Error())
+		return moira.ScheduledNotification{}, fmt.Errorf("failed to read scheduledNotification: %w", err)
 	}
 	notificationSE := scheduledNotificationStorageElement{}
 	err = json.Unmarshal(bytes, &notificationSE)
 	if err != nil {
-		return moira.ScheduledNotification{}, fmt.Errorf("failed to parse notification json %s: %s", string(bytes), err.Error())
+		return moira.ScheduledNotification{}, fmt.Errorf("failed to parse notification json %s: %w", string(bytes), err)
 	}
 	return notificationSE.toScheduledNotification(), nil
 }
@@ -78,7 +78,7 @@ func Notifications(rep interface{}, err error) ([]*moira.ScheduledNotification, 
 		if err == redis.ErrNil {
 			return make([]*moira.ScheduledNotification, 0), nil
 		}
-		return nil, fmt.Errorf("failed to read ScheduledNotifications: %s", err.Error())
+		return nil, fmt.Errorf("failed to read ScheduledNotifications: %w", err)
 	}
 	notifications := make([]*moira.ScheduledNotification, len(values))
 	for i, value := range values {

--- a/database/redis/reply/subscription.go
+++ b/database/redis/reply/subscription.go
@@ -20,11 +20,11 @@ func Subscription(rep interface{}, err error) (moira.SubscriptionData, error) {
 		if err == redis.ErrNil {
 			return subscription, database.ErrNil
 		}
-		return subscription, fmt.Errorf("failed to read subscription: %s", err.Error())
+		return subscription, fmt.Errorf("failed to read subscription: %w", err)
 	}
 	err = json.Unmarshal(bytes, &subscription)
 	if err != nil {
-		return subscription, fmt.Errorf("failed to parse subscription json %s: %s", string(bytes), err.Error())
+		return subscription, fmt.Errorf("failed to parse subscription json %s: %w", string(bytes), err)
 	}
 	return subscription, nil
 }
@@ -36,7 +36,7 @@ func Subscriptions(rep interface{}, err error) ([]*moira.SubscriptionData, error
 		if err == redis.ErrNil {
 			return make([]*moira.SubscriptionData, 0), nil
 		}
-		return nil, fmt.Errorf("failed to read subscriptions: %s", err.Error())
+		return nil, fmt.Errorf("failed to read subscriptions: %w", err)
 	}
 	subscriptions := make([]*moira.SubscriptionData, len(values))
 	for i, value := range values {

--- a/database/redis/reply/trigger.go
+++ b/database/redis/reply/trigger.go
@@ -104,12 +104,12 @@ func Trigger(rep interface{}, err error) (moira.Trigger, error) {
 		if err == redis.ErrNil {
 			return moira.Trigger{}, database.ErrNil
 		}
-		return moira.Trigger{}, fmt.Errorf("failed to read trigger: %s", err.Error())
+		return moira.Trigger{}, fmt.Errorf("failed to read trigger: %w", err)
 	}
 	triggerSE := &triggerStorageElement{}
 	err = json.Unmarshal(bytes, triggerSE)
 	if err != nil {
-		return moira.Trigger{}, fmt.Errorf("failed to parse trigger json %s: %s", string(bytes), err.Error())
+		return moira.Trigger{}, fmt.Errorf("failed to parse trigger json %s: %w", string(bytes), err)
 	}
 
 	trigger := triggerSE.toTrigger()
@@ -121,7 +121,7 @@ func GetTriggerBytes(triggerID string, trigger *moira.Trigger) ([]byte, error) {
 	triggerSE := toTriggerStorageElement(trigger, triggerID)
 	bytes, err := json.Marshal(triggerSE)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal trigger: %s", err.Error())
+		return nil, fmt.Errorf("failed to marshal trigger: %w", err)
 	}
 	return bytes, nil
 }

--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -13,7 +13,7 @@ func (connector *DbConnector) GetTagNames() ([]string, error) {
 
 	tagNames, err := redis.Strings(c.Do("SMEMBERS", tagsKey))
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve tags: %s", err.Error())
+		return nil, fmt.Errorf("failed to retrieve tags: %w", err)
 	}
 	return tagNames, nil
 }
@@ -23,13 +23,13 @@ func (connector *DbConnector) RemoveTag(tagName string) error {
 	c := connector.pool.Get()
 	defer c.Close()
 
-	c.Send("MULTI") //nolint
+	c.Send("MULTI")                  //nolint
 	c.Send("SREM", tagsKey, tagName) //nolint
 	c.Send("DEL", tagSubscriptionKey(tagName))
 	c.Send("DEL", tagTriggersKey(tagName)) //nolint
 	_, err := c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to EXEC: %s", err.Error())
+		return fmt.Errorf("failed to EXEC: %w", err)
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func (connector *DbConnector) GetTagTriggerIDs(tagName string) ([]string, error)
 		if err == redis.ErrNil {
 			return make([]string, 0), nil
 		}
-		return nil, fmt.Errorf("failed to retrieve tag triggers:%s, err: %s", tagName, err.Error())
+		return nil, fmt.Errorf("failed to retrieve tag triggers:%s, err: %w", tagName, err)
 	}
 	return triggerIDs, nil
 }

--- a/database/redis/throttling.go
+++ b/database/redis/throttling.go
@@ -31,12 +31,12 @@ func (connector *DbConnector) DeleteTriggerThrottling(triggerID string) error {
 	c := connector.pool.Get()
 	defer c.Close()
 
-	c.Send("MULTI") //nolint
+	c.Send("MULTI")                                                             //nolint
 	c.Send("SET", notifierThrottlingBeginningKey(triggerID), time.Now().Unix()) //nolint
-	c.Send("DEL", notifierNextKey(triggerID)) //nolint
+	c.Send("DEL", notifierNextKey(triggerID))                                   //nolint
 	_, err := c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to EXEC: %s", err.Error())
+		return fmt.Errorf("failed to EXEC: %w", err)
 	}
 	return nil
 }

--- a/database/redis/triggers_lock.go
+++ b/database/redis/triggers_lock.go
@@ -37,7 +37,7 @@ func (connector *DbConnector) SetTriggerCheckLock(triggerID string) (bool, error
 		if err == redis.ErrNil {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to set check lock: %s error: %s", triggerID, err.Error())
+		return false, fmt.Errorf("failed to set check lock: %s error: %w", triggerID, err)
 	}
 	return true, nil
 }
@@ -48,7 +48,7 @@ func (connector *DbConnector) DeleteTriggerCheckLock(triggerID string) error {
 	defer c.Close()
 	_, err := c.Do("DEL", metricCheckLockKey(triggerID))
 	if err != nil {
-		return fmt.Errorf("failed to delete trigger check lock: %s error: %s", triggerID, err.Error())
+		return fmt.Errorf("failed to delete trigger check lock: %s error: %w", triggerID, err)
 	}
 	return nil
 }

--- a/database/redis/triggers_to_check.go
+++ b/database/redis/triggers_to_check.go
@@ -47,7 +47,7 @@ func (connector *DbConnector) addTriggersToCheck(key string, triggerIDs []string
 	}
 	_, err := redis.Values(c.Do("EXEC"))
 	if err != nil {
-		return fmt.Errorf("failed to add triggers to check: %s", err.Error())
+		return fmt.Errorf("failed to add triggers to check: %w", err)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func (connector *DbConnector) getTriggersToCheck(key string, count int) ([]strin
 		if err == redis.ErrNil {
 			return make([]string, 0), database.ErrNil
 		}
-		return make([]string, 0), fmt.Errorf("failed to pop trigger to check: %s", err.Error())
+		return make([]string, 0), fmt.Errorf("failed to pop trigger to check: %w", err)
 	}
 	return triggerIDs, err
 }
@@ -73,7 +73,7 @@ func (connector *DbConnector) getTriggersToCheckCount(key string) (int64, error)
 		if err == redis.ErrNil {
 			return 0, nil
 		}
-		return 0, fmt.Errorf("failed to get trigger to check count: %s", err.Error())
+		return 0, fmt.Errorf("failed to get trigger to check count: %w", err)
 	}
 	return triggersToCheckCount, nil
 }

--- a/database/redis/triggers_to_reindex.go
+++ b/database/redis/triggers_to_reindex.go
@@ -15,7 +15,7 @@ func (connector *DbConnector) FetchTriggersToReindex(from int64) ([]string, erro
 	response, err := redis.Strings(c.Do("ZRANGEBYSCORE", triggersToReindexKey, from, "+inf"))
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch triggers to reindex: %s", err.Error())
+		return nil, fmt.Errorf("failed to fetch triggers to reindex: %w", err)
 	}
 	if len(response) == 0 {
 		return make([]string, 0), nil
@@ -34,7 +34,7 @@ func (connector *DbConnector) RemoveTriggersToReindex(to int64) error {
 		if err == redis.ErrNil {
 			return nil
 		}
-		return fmt.Errorf("failed to remove triggers to reindex: %s", err.Error())
+		return fmt.Errorf("failed to remove triggers to reindex: %w", err)
 	}
 	return nil
 }

--- a/database/redis/triggers_to_reindex_test.go
+++ b/database/redis/triggers_to_reindex_test.go
@@ -148,7 +148,7 @@ func addTriggersToReindex(connector *DbConnector, triggerIDs ...string) error {
 
 	_, err := c.Do("EXEC")
 	if err != nil {
-		return fmt.Errorf("failed to add triggers to reindex: %s", err.Error())
+		return fmt.Errorf("failed to add triggers to reindex: %w", err)
 	}
 	return nil
 }

--- a/database/redis/unused_triggers.go
+++ b/database/redis/unused_triggers.go
@@ -37,7 +37,7 @@ func (connector *DbConnector) GetUnusedTriggerIDs() ([]string, error) {
 		if err == redis.ErrNil {
 			return make([]string, 0), nil
 		}
-		return nil, fmt.Errorf("failed to get all unused triggers: %s", err.Error())
+		return nil, fmt.Errorf("failed to get all unused triggers: %w", err)
 	}
 	return triggerIds, nil
 }
@@ -57,7 +57,7 @@ func (connector *DbConnector) MarkTriggersAsUsed(triggerIDs ...string) error {
 	}
 	_, err := redis.Values(c.Do("EXEC"))
 	if err != nil {
-		return fmt.Errorf("failed to mark triggers as used: %s", err.Error())
+		return fmt.Errorf("failed to mark triggers as used: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
# PR Summary

Ignore exceptions that generated by redis timeouts. This exceptions do
not have any value for users but can be generated a lot and harm users.
