### PR TITLE
No more notifications about exceptions

### DIFF
--- a/checker/event.go
+++ b/checker/event.go
@@ -54,11 +54,18 @@ func (triggerChecker *TriggerChecker) compareTriggerStates(currentCheck moira.Ch
 	currentCheck.Suppressed = false
 	currentCheck.SuppressedState = ""
 
+	oldStateValue := getEventOldState(lastCheck.State, lastCheck.SuppressedState, lastCheck.Suppressed)
+
+	// don't send notifications about exceptions
+	if currentStateValue == moira.StateEXCEPTION || oldStateValue == moira.StateEXCEPTION {
+		return currentCheck, nil
+	}
+
 	err := triggerChecker.database.PushNotificationEvent(&moira.NotificationEvent{
 		IsTriggerEvent:   true,
 		TriggerID:        triggerChecker.triggerID,
 		State:            currentStateValue,
-		OldState:         getEventOldState(lastCheck.State, lastCheck.SuppressedState, lastCheck.Suppressed),
+		OldState:         oldStateValue,
 		Timestamp:        currentCheckTimestamp,
 		Metric:           triggerChecker.trigger.Name,
 		MessageEventInfo: eventInfo,


### PR DESCRIPTION
# No more notifications about exceptions

There are no more notifications on transition ANY STATE -> EXCEPTION and EXCEPTION -> ANY STATE. These notifications do not have any value for users.

## Notes:
Maybe it would be better to send notifications EXCEPTION -> NOT OK?
