### PR TITLE
Move to go-redis (database sentinel) 

### DIFF
--- a/database/goredis/config.go
+++ b/database/goredis/config.go
@@ -2,5 +2,6 @@ package goredis
 
 // Config - Redis database connection config
 type Config struct {
-	Addrs []string
+	MasterName string
+	Addrs      []string
 }


### PR DESCRIPTION
Раньше были два отдельный коннекшена: на мастер и на слейв, всё по дефолту читалось и писалось на/с коннекшн мастера, потом некоторые сущности принудительно сделали возможными для чтения со слейва, чтобы разгрузить мастер, но не все!
Горедис делает возможным ВСЁ чтение делать со слейвов, и потребность в таком принудительном разделении отпала.