### PR TITLE
Fixed subscriptions on redis cluster

### DIFF
--- a/database/redis/subscription.go
+++ b/database/redis/subscription.go
@@ -336,4 +336,4 @@ func teamSubscriptionsKey(teamID string) string {
 	return fmt.Sprintf("moira-team-subscriptions:%s", teamID)
 }
 
-const anyTagsSubscriptionsKey = "moira-any-tags-subscriptions"
+const anyTagsSubscriptionsKey = "{moira-tag-subscriptions}:moira-any-tags-subscriptions"

--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -51,5 +51,5 @@ func tagTriggersKey(tagName string) string {
 }
 
 func tagSubscriptionKey(tagName string) string {
-	return "moira-tag-subscriptions:" + tagName
+	return "{moira-tag-subscriptions}:" + tagName
 }


### PR DESCRIPTION
# Reworked subscriptions test and fixed subscriptions when Moira works on Redis Cluster

First I reworked the part of subscription_test.go, that covered this functional, and then made some changes that fix the problem.

Quote from redis cluster documentation:

> Commands performing complex multi-key operations like Set type unions or intersections are implemented as well as long as the keys all hash to the same slot.

> Redis Cluster implements a concept called hash tags that can be used in order to force certain keys to be stored in the same hash slot.

I just implemented this solution.