### PR TITLE
Improved speed of metrics matching in filter

### DIFF
--- a/filter/metrics_parser.go
+++ b/filter/metrics_parser.go
@@ -71,6 +71,11 @@ func ParseMetric(input []byte) (*ParsedMetric, error) {
 	return parsedMetric, nil
 }
 
+// IsTagged checks that metric is tagged
+func (metric ParsedMetric) IsTagged() bool {
+	return len(metric.Labels) > 0
+}
+
 func parseNameAndLabels(metricBytes []byte) (string, map[string]string, error) {
 	metricBytesScanner := moira.NewBytesScanner(metricBytes, ';')
 	if !metricBytesScanner.HasNext() {

--- a/filter/patterns_storage.go
+++ b/filter/patterns_storage.go
@@ -84,11 +84,11 @@ func (storage *PatternStorage) ProcessIncomingMetric(lineBytes []byte) *moira.Ma
 }
 
 func (storage *PatternStorage) matchPatterns(metric *ParsedMetric) []string {
-	patternIndex := storage.PatternIndex.Load().(*PatternIndex)
-	seriesByTagPatternIndex := storage.SeriesByTagPatternIndex.Load().(*SeriesByTagPatternIndex)
+	if metric.IsTagged() {
+		seriesByTagPatternIndex := storage.SeriesByTagPatternIndex.Load().(*SeriesByTagPatternIndex)
+		return seriesByTagPatternIndex.MatchPatterns(metric.Name, metric.Labels)
+	}
 
-	matchedPatterns := make([]string, 0)
-	matchedPatterns = append(matchedPatterns, patternIndex.MatchPatterns(metric.Name)...)
-	matchedPatterns = append(matchedPatterns, seriesByTagPatternIndex.MatchPatterns(metric.Name, metric.Labels)...)
-	return matchedPatterns
+	patternIndex := storage.PatternIndex.Load().(*PatternIndex)
+	return patternIndex.MatchPatterns(metric.Name)
 }

--- a/filter/patterns_storage_test.go
+++ b/filter/patterns_storage_test.go
@@ -14,7 +14,10 @@ import (
 func TestProcessIncomingMetric(t *testing.T) {
 	testPatterns := []string{
 		"cpu.used",
+		"plain.metric",
 		"seriesByTag(\"name=cpu.used\")",
+		"seriesByTag(\"name=tag.metric\", \"tag1=val1\")",
+		"seriesByTag(\"name=name.metric\")",
 	}
 
 	mockCtrl := gomock.NewController(t)
@@ -46,20 +49,71 @@ func TestProcessIncomingMetric(t *testing.T) {
 
 	Convey("When valid non-matching metric arrives", t, func() {
 		patternsStorage.metrics = metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
-		matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used 12 1234567890"))
-		So(matchedMetrics, ShouldBeNil)
-		So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
-		So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
-		So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		Convey("For plain metric", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used 12 1234567890"))
+			So(matchedMetrics, ShouldBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		})
+
+		Convey("For tag metric", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used;tag1=val1 12 1234567890"))
+			So(matchedMetrics, ShouldBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		})
+
+		Convey("For plain metric which has the same pattern like name tag in tagged pattern", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("tag.metric 12 1234567890"))
+			So(matchedMetrics, ShouldBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		})
+
+		Convey("For tagged metric which body matches plain metric trigger pattern", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("plain.metric;tag1=val1 12 1234567890"))
+			So(matchedMetrics, ShouldBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		})
+
+		Convey("For plain metric which matches to tagged pattern which contains only name tag", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("name.metric 12 1234567890"))
+			So(matchedMetrics, ShouldBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		})
 	})
 
 	Convey("When valid matching metric arrives", t, func() {
 		patternsStorage.metrics = metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
-		matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("cpu.used 12 1234567890"))
-		So(matchedMetrics, ShouldNotBeNil)
-		So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
-		So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
-		So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 1)
+		Convey("For plain metric", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("plain.metric 12 1234567890"))
+			So(matchedMetrics, ShouldNotBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 1)
+		})
+		Convey("For tagged metric", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("tag.metric;tag1=val1 12 1234567890"))
+			So(matchedMetrics, ShouldNotBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 1)
+		})
+
+		Convey("For tagged metric which matches to tagged pattern which contains only name tag", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("name.metric;tag1=val1 12 1234567890"))
+			So(matchedMetrics, ShouldNotBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 1)
+		})
 	})
 
 	Convey("When ten valid metrics arrive match timer should be updated", t, func() {


### PR DESCRIPTION
Tag metrics are checked only on tag patterns. Plain metrics are checked only on plain patterns.