### PR TITLE
Fixed trigger list manipulations on redis cluster

### DIFF
--- a/database/redis/trigger.go
+++ b/database/redis/trigger.go
@@ -342,8 +342,8 @@ func (connector *DbConnector) triggerHasSubscriptions(trigger *moira.Trigger) (b
 	return false, nil
 }
 
-var triggersListKey = "moira-triggers-list"
-var remoteTriggersListKey = "moira-remote-triggers-list"
+var triggersListKey = "{moira-triggers-list}:moira-triggers-list"
+var remoteTriggersListKey = "{moira-triggers-list}:moira-remote-triggers-list"
 
 func triggerKey(triggerID string) string {
 	return "moira-trigger:" + triggerID

--- a/database/redis/trigger_test.go
+++ b/database/redis/trigger_test.go
@@ -530,6 +530,7 @@ func TestRemoteTrigger(t *testing.T) {
 	}
 	dataBase.flush()
 	defer dataBase.flush()
+	client := *dataBase.client
 
 	Convey("Saving remote trigger", t, func() {
 		Convey("Trigger should be saved correctly", func() {
@@ -543,6 +544,8 @@ func TestRemoteTrigger(t *testing.T) {
 			ids, err := dataBase.GetAllTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
+			valueStoredAtKey := client.SMembers(dataBase.context, "{moira-triggers-list}:moira-triggers-list").Val()
+			So(valueStoredAtKey, ShouldResemble, []string{trigger.ID})
 		})
 		Convey("Trigger should not be added to local triggers collection", func() {
 			ids, err := dataBase.GetLocalTriggerIDs()
@@ -553,6 +556,8 @@ func TestRemoteTrigger(t *testing.T) {
 			ids, err := dataBase.GetRemoteTriggerIDs()
 			So(err, ShouldBeNil)
 			So(ids, ShouldResemble, []string{trigger.ID})
+			valueStoredAtKey := client.SMembers(dataBase.context, "{moira-triggers-list}:moira-remote-triggers-list").Val()
+			So(valueStoredAtKey, ShouldResemble, []string{trigger.ID})
 		})
 		Convey("Trigger should not be added to patterns collection", func() {
 			ids, err := dataBase.GetPatternTriggerIDs(pattern)


### PR DESCRIPTION
There was a message like this in console:

```
checker ERR NODATA check failed: failed to get triggers-list: CROSSSLOT Keys in request don't hash to the same slot module=checker
```

Error was in `GetLocalTriggerIDs` (`SDiff`)