### PR TITLE
Fixed trigger tags manipulation on redis cluster

### DIFF
--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -47,7 +47,7 @@ func (connector *DbConnector) GetTagTriggerIDs(tagName string) ([]string, error)
 var tagsKey = "moira-tags"
 
 func tagTriggersKey(tagName string) string {
-	return "moira-tag-triggers:" + tagName
+	return "{moira-tag-triggers}:" + tagName
 }
 
 func tagSubscriptionKey(tagName string) string {

--- a/database/redis/tag_test.go
+++ b/database/redis/tag_test.go
@@ -12,33 +12,46 @@ func TestTagStoring(t *testing.T) {
 	dataBase := newTestDatabase(logger, config)
 	dataBase.flush()
 	defer dataBase.flush()
+	client := *dataBase.client
+
 	Convey("Tags manipulation", t, func() {
 		trigger := triggers[0]
-		triggerIDs, err := dataBase.GetTagTriggerIDs(trigger.Tags[0])
-		So(err, ShouldBeNil)
-		So(triggerIDs, ShouldHaveLength, 0)
 
-		err = dataBase.SaveTrigger(trigger.ID, &trigger)
-		So(err, ShouldBeNil)
+		Convey("Get tags when they don't exist", func() {
+			triggerIDs, err := dataBase.GetTagTriggerIDs(trigger.Tags[0])
+			So(err, ShouldBeNil)
+			So(triggerIDs, ShouldHaveLength, 0)
+			valueStoredAtKey := client.SMembers(dataBase.context, "{moira-tag-triggers}:test-tag-1").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+		})
 
-		tags, err := dataBase.GetTagNames()
-		So(err, ShouldBeNil)
-		So(tags, ShouldHaveLength, 1)
+		Convey("Get tags after the trigger was created with one tag", func() {
+			err := dataBase.SaveTrigger(trigger.ID, &trigger)
+			So(err, ShouldBeNil)
 
-		triggerIDs, err = dataBase.GetTagTriggerIDs(trigger.Tags[0])
-		So(err, ShouldBeNil)
-		So(triggerIDs, ShouldHaveLength, 1)
+			tags, err := dataBase.GetTagNames()
+			So(err, ShouldBeNil)
+			So(tags, ShouldHaveLength, 1)
 
-		err = dataBase.RemoveTag(trigger.Tags[0])
-		So(err, ShouldBeNil)
+			triggerIDs, err := dataBase.GetTagTriggerIDs(trigger.Tags[0])
+			So(err, ShouldBeNil)
+			So(triggerIDs, ShouldHaveLength, 1)
+			valueStoredAtKey := client.SMembers(dataBase.context, "{moira-tag-triggers}:test-tag-1").Val()
+			So(valueStoredAtKey, ShouldResemble, []string{trigger.ID})
+		})
 
-		tags, err = dataBase.GetTagNames()
-		So(err, ShouldBeNil)
-		So(tags, ShouldHaveLength, 0)
+		Convey("Get tags after the only tag of the only trigger was removed", func() {
+			err := dataBase.RemoveTag(trigger.Tags[0])
+			So(err, ShouldBeNil)
 
-		triggerIDs, err = dataBase.GetTagTriggerIDs(trigger.Tags[0])
-		So(err, ShouldBeNil)
-		So(triggerIDs, ShouldHaveLength, 0)
+			tags, err := dataBase.GetTagNames()
+			So(err, ShouldBeNil)
+			So(tags, ShouldHaveLength, 0)
+
+			triggerIDs, err := dataBase.GetTagTriggerIDs(trigger.Tags[0])
+			So(err, ShouldBeNil)
+			So(triggerIDs, ShouldHaveLength, 0)
+		})
 	})
 }
 


### PR DESCRIPTION
There was an error in `getTriggersIdsByTags` (`SInter`) because the keys of tags were in different slots.