### PR TITLE
Added command to transform keys to work on Redis Cluster

### DIFF
--- a/cmd/cli/cluster.go
+++ b/cmd/cli/cluster.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/database/redis"
+)
+
+var noSuchKeyError = "ERR no such key"
+var anyTagsSubscriptionsKeyOld = "moira-any-tags-subscriptions"
+var anyTagsSubscriptionsKeyNew = "{moira-tag-subscriptions}:moira-any-tags-subscriptions"
+var triggersListKeyOld = "moira-triggers-list"
+var triggersListKeyNew = "{moira-triggers-list}:moira-triggers-list"
+var remoteTriggersListKeyOld = "moira-remote-triggers-list"
+var remoteTriggersListKeyNew = "{moira-triggers-list}:moira-remote-triggers-list"
+var tagSubscriptionsKeyPrefixOld = "moira-tag-subscriptions:"
+var tagSubscriptionsKeyPrefixNew = "{moira-tag-subscriptions}:"
+var tagTriggersKeyKeyPrefixOld = "moira-tag-triggers:"
+var tagTriggersKeyKeyPrefixNew = "{moira-tag-triggers}:"
+
+func renameKey(database moira.Database, oldKey string, newKey string) error {
+	switch d := database.(type) {
+	case *redis.DbConnector:
+		err := d.Client().Rename(d.Context(), oldKey, newKey).Err()
+		if err != nil {
+			if err.Error() != noSuchKeyError {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func changeKeysPrefix(database moira.Database, oldPrefix string, newPrefix string) error {
+	switch d := database.(type) {
+	case *redis.DbConnector:
+		pipe := d.Client().TxPipeline()
+		iter := d.Client().Scan(d.Context(), 0, oldPrefix+"*", 0).Iterator()
+		for iter.Next(d.Context()) {
+			oldKey := iter.Val()
+			newKey := strings.Replace(iter.Val(), oldPrefix, newPrefix, 1)
+			pipe.Rename(d.Context(), oldKey, newKey)
+		}
+		_, err := pipe.Exec(d.Context())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func renameAnyTagsSubscriptionsKeyForwards(logger moira.Logger, database moira.Database) error {
+	err := renameKey(database, anyTagsSubscriptionsKeyOld, anyTagsSubscriptionsKeyNew)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameAnyTagsSubscriptionsKeyForwards done")
+
+	return nil
+}
+
+func renameAnyTagsSubscriptionsKeyReverse(logger moira.Logger, database moira.Database) error {
+	err := renameKey(database, anyTagsSubscriptionsKeyNew, anyTagsSubscriptionsKeyOld)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameAnyTagsSubscriptionsKeyReverse done")
+
+	return nil
+}
+
+func renameTriggersListKeyForwards(logger moira.Logger, database moira.Database) error {
+	err := renameKey(database, triggersListKeyOld, triggersListKeyNew)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameTriggersListKeyForwards done")
+
+	return nil
+}
+
+func renameTriggersListKeyReverse(logger moira.Logger, database moira.Database) error {
+	err := renameKey(database, triggersListKeyNew, triggersListKeyOld)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameTriggersListKeyReverse done")
+
+	return nil
+}
+
+func renameRemoteTriggersListKeyForwards(logger moira.Logger, database moira.Database) error {
+	err := renameKey(database, remoteTriggersListKeyOld, remoteTriggersListKeyNew)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameRemoteTriggersListKeyForwards done")
+
+	return nil
+}
+
+func renameRemoteTriggersListKeyReverse(logger moira.Logger, database moira.Database) error {
+	err := renameKey(database, remoteTriggersListKeyNew, remoteTriggersListKeyOld)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameRemoteTriggersListKeyReverse done")
+
+	return nil
+}
+
+func renameTagSubscriptionsKeyForwards(logger moira.Logger, database moira.Database) error {
+	err := changeKeysPrefix(database, tagSubscriptionsKeyPrefixOld, tagSubscriptionsKeyPrefixNew)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameTagSubscriptionsKeyForwards done")
+
+	return nil
+}
+
+func renameTagSubscriptionsKeyReverse(logger moira.Logger, database moira.Database) error {
+	err := changeKeysPrefix(database, tagSubscriptionsKeyPrefixNew, tagSubscriptionsKeyPrefixOld)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameTagSubscriptionsKeyReverse done")
+
+	return nil
+}
+
+func renameTagTriggersKeyKeyForwards(logger moira.Logger, database moira.Database) error {
+	err := changeKeysPrefix(database, tagTriggersKeyKeyPrefixOld, tagTriggersKeyKeyPrefixNew)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameTagTriggersKeyKeyForwards done")
+
+	return nil
+}
+
+func renameTagTriggersKeyKeyReverse(logger moira.Logger, database moira.Database) error {
+	err := changeKeysPrefix(database, tagTriggersKeyKeyPrefixNew, tagTriggersKeyKeyPrefixOld)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("renameTagTriggersKeyKeyReverse done")
+
+	return nil
+}
+
+func moveToClusterForwards(logger moira.Logger, database moira.Database) error {
+	err := renameAnyTagsSubscriptionsKeyForwards(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameTriggersListKeyForwards(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameRemoteTriggersListKeyForwards(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameTagSubscriptionsKeyForwards(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameTagTriggersKeyKeyForwards(logger, database)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("moveToClusterForwards done")
+
+	return nil
+}
+
+func moveToClusterReverse(logger moira.Logger, database moira.Database) error {
+	err := renameAnyTagsSubscriptionsKeyReverse(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameTriggersListKeyReverse(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameRemoteTriggersListKeyReverse(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameTagSubscriptionsKeyReverse(logger, database)
+	if err != nil {
+		return err
+	}
+
+	err = renameTagTriggersKeyKeyReverse(logger, database)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("moveToClusterReverse done")
+
+	return nil
+}

--- a/cmd/cli/cluster_test.go
+++ b/cmd/cli/cluster_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/moira-alert/moira/database/redis"
+	logging "github.com/moira-alert/moira/logging/zerolog_adapter"
+
+	"github.com/moira-alert/moira"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCluster(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	conf := getDefault()
+	logger, err := logging.ConfigureLog(conf.LogFile, "error", "cli", conf.LogPrettyFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	database := redis.NewTestDatabase(logger)
+	database.Flush()
+	defer database.Flush()
+	client := database.Client()
+	ctx := database.Context()
+
+	Convey("Test data migration forwards", t, func() {
+		Convey("Given old database", func() {
+			createDataWithOldKeys(database)
+
+			valueStoredAtKey := client.SMembers(ctx, "moira-any-tags-subscriptions").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+
+			valueStoredAtKey = client.SMembers(ctx, "moira-triggers-list").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-triggers-list").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+
+			valueStoredAtKey = client.SMembers(ctx, "moira-remote-triggers-list").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-remote-triggers-list").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+
+			valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag1").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag1").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+			valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag2").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag2").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+			valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag3").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag3").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+
+			valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag1").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag1").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+			valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag2").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag2").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+			valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag3").Val()
+			So(len(valueStoredAtKey), ShouldResemble, 3)
+			valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag3").Val()
+			So(valueStoredAtKey, ShouldBeEmpty)
+
+			Convey("When migration was applied", func() {
+				err := moveToClusterForwards(logger, database)
+				So(err, ShouldBeNil)
+
+				Convey("Database should be new", func() {
+					valueStoredAtKey = client.SMembers(ctx, "moira-any-tags-subscriptions").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+
+					valueStoredAtKey = client.SMembers(ctx, "moira-triggers-list").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-triggers-list").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+
+					valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag1").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag1").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+					valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag2").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag2").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+					valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag3").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag3").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+
+					valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag1").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag1").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+					valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag2").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag2").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+					valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag3").Val()
+					So(valueStoredAtKey, ShouldBeEmpty)
+					valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag3").Val()
+					So(len(valueStoredAtKey), ShouldResemble, 3)
+				})
+			})
+		})
+
+		Convey("Test data migration reverse", func() {
+			Convey("Given new database", func() {
+				createDataWithNewKeys(database)
+
+				valueStoredAtKey := client.SMembers(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-any-tags-subscriptions").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+
+				valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-triggers-list").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-triggers-list").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+
+				valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-remote-triggers-list").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-remote-triggers-list").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+
+				valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag1").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag1").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+				valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag2").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag2").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+				valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag3").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag3").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+
+				valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag1").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag1").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+				valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag2").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag2").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+				valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag3").Val()
+				So(len(valueStoredAtKey), ShouldResemble, 3)
+				valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag3").Val()
+				So(valueStoredAtKey, ShouldBeEmpty)
+
+				Convey("When migration was reversed", func() {
+					err := moveToClusterReverse(logger, database)
+					So(err, ShouldBeNil)
+
+					Convey("Database should be old", func() {
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-any-tags-subscriptions").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+
+						valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-triggers-list").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-triggers-list").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+
+						valueStoredAtKey = client.SMembers(ctx, "{moira-triggers-list}:moira-remote-triggers-list").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-remote-triggers-list").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag1").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag1").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag2").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag2").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-subscriptions}:tag3").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-tag-subscriptions:tag3").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag1").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag1").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag2").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag2").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+						valueStoredAtKey = client.SMembers(ctx, "{moira-tag-triggers}:tag3").Val()
+						So(valueStoredAtKey, ShouldBeEmpty)
+						valueStoredAtKey = client.SMembers(ctx, "moira-tag-triggers:tag3").Val()
+						So(len(valueStoredAtKey), ShouldResemble, 3)
+					})
+				})
+			})
+		})
+	})
+}
+
+func createDataWithOldKeys(database moira.Database) {
+	switch d := database.(type) {
+	case *redis.DbConnector:
+		d.Flush()
+		client := d.Client()
+		ctx := d.Context()
+
+		client.SAdd(ctx, "moira-any-tags-subscriptions", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "moira-any-tags-subscriptions", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "moira-any-tags-subscriptions", "subscriptionID-00000000000003")
+
+		client.SAdd(ctx, "moira-triggers-list", "triggerID-0000000000001")
+		client.SAdd(ctx, "moira-triggers-list", "triggerID-0000000000002")
+		client.SAdd(ctx, "moira-triggers-list", "triggerID-0000000000003")
+
+		client.SAdd(ctx, "moira-remote-triggers-list", "triggerID-0000000000004")
+		client.SAdd(ctx, "moira-remote-triggers-list", "triggerID-0000000000005")
+		client.SAdd(ctx, "moira-remote-triggers-list", "triggerID-0000000000006")
+
+		client.SAdd(ctx, "moira-tag-subscriptions:tag1", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag1", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag1", "subscriptionID-00000000000003")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag2", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag2", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag2", "subscriptionID-00000000000003")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag3", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag3", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "moira-tag-subscriptions:tag3", "subscriptionID-00000000000003")
+
+		client.SAdd(ctx, "moira-tag-triggers:tag1", "triggerID-0000000000001")
+		client.SAdd(ctx, "moira-tag-triggers:tag1", "triggerID-0000000000002")
+		client.SAdd(ctx, "moira-tag-triggers:tag1", "triggerID-0000000000003")
+		client.SAdd(ctx, "moira-tag-triggers:tag2", "triggerID-0000000000001")
+		client.SAdd(ctx, "moira-tag-triggers:tag2", "triggerID-0000000000002")
+		client.SAdd(ctx, "moira-tag-triggers:tag2", "triggerID-0000000000003")
+		client.SAdd(ctx, "moira-tag-triggers:tag3", "triggerID-0000000000001")
+		client.SAdd(ctx, "moira-tag-triggers:tag3", "triggerID-0000000000002")
+		client.SAdd(ctx, "moira-tag-triggers:tag3", "triggerID-0000000000003")
+	}
+}
+
+func createDataWithNewKeys(database moira.Database) {
+	switch d := database.(type) {
+	case *redis.DbConnector:
+		d.Flush()
+		client := d.Client()
+		ctx := d.Context()
+
+		client.SAdd(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:moira-any-tags-subscriptions", "subscriptionID-00000000000003")
+
+		client.SAdd(ctx, "{moira-triggers-list}:moira-triggers-list", "triggerID-0000000000001")
+		client.SAdd(ctx, "{moira-triggers-list}:moira-triggers-list", "triggerID-0000000000002")
+		client.SAdd(ctx, "{moira-triggers-list}:moira-triggers-list", "triggerID-0000000000003")
+
+		client.SAdd(ctx, "{moira-triggers-list}:moira-remote-triggers-list", "triggerID-0000000000004")
+		client.SAdd(ctx, "{moira-triggers-list}:moira-remote-triggers-list", "triggerID-0000000000005")
+		client.SAdd(ctx, "{moira-triggers-list}:moira-remote-triggers-list", "triggerID-0000000000006")
+
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag1", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag1", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag1", "subscriptionID-00000000000003")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag2", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag2", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag2", "subscriptionID-00000000000003")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag3", "subscriptionID-00000000000001")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag3", "subscriptionID-00000000000002")
+		client.SAdd(ctx, "{moira-tag-subscriptions}:tag3", "subscriptionID-00000000000003")
+
+		client.SAdd(ctx, "{moira-tag-triggers}:tag1", "triggerID-0000000000001")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag1", "triggerID-0000000000002")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag1", "triggerID-0000000000003")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag2", "triggerID-0000000000001")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag2", "triggerID-0000000000002")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag2", "triggerID-0000000000003")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag3", "triggerID-0000000000001")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag3", "triggerID-0000000000002")
+		client.SAdd(ctx, "{moira-tag-triggers}:tag3", "triggerID-0000000000003")
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -56,6 +56,11 @@ var (
 	triggerDumpFile = flag.String("trigger-dump-file", "", "File that holds trigger dump JSON from api method response")
 )
 
+var (
+	toClusterForwards = flag.Bool("move-to-cluster-forwards", false, "Transform database to work on cluster forwards")
+	toClusterReverse  = flag.Bool("move-to-cluster-reverse", false, "Transform database to work on cluster reverse")
+)
+
 func main() { //nolint
 	confCleanup, logger, dataBase := initApp()
 
@@ -132,6 +137,22 @@ func main() { //nolint
 			logger.Fatal(err)
 		}
 		logger.Info("Dump was pushed")
+	}
+
+	if *toClusterForwards {
+		logger.Info("Moving to cluster forwards")
+		err := moveToClusterForwards(logger, dataBase)
+		if err != nil {
+			logger.Fatalf("Failed to move to cluster forwards: %s", err.Error())
+		}
+	}
+
+	if *toClusterReverse {
+		logger.Info("Moving to cluster reverse")
+		err := moveToClusterReverse(logger, dataBase)
+		if err != nil {
+			logger.Fatalf("Failed to move to cluster reverse: %s", err.Error())
+		}
 	}
 }
 

--- a/database/redis/bot_test.go
+++ b/database/redis/bot_test.go
@@ -12,8 +12,8 @@ import (
 func TestBotDataStoring(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Messengers manipulation", t, func() {
 		Convey("Get-set usernames", func() {
@@ -61,8 +61,8 @@ func TestBotDataStoring(t *testing.T) {
 func TestBotDataStoringErrorConnection(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		actual1, err := dataBase.GetIDByUsername(messenger1, user1)
 		So(actual1, ShouldBeEmpty)

--- a/database/redis/contact_test.go
+++ b/database/redis/contact_test.go
@@ -20,8 +20,8 @@ func TestContacts(t *testing.T) {
 	dataBase := NewTestDatabase(logger)
 
 	Convey("Contacts manipulation", t, func() {
-		dataBase.flush()
-		defer dataBase.flush()
+		dataBase.Flush()
+		defer dataBase.Flush()
 
 		Convey("While no data then get contacts should be empty", func() {
 			Convey("GetAllContacts should be empty", func() {
@@ -431,8 +431,8 @@ func TestContacts(t *testing.T) {
 func TestErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Should throw error when no connection", t, func() {
 		actual1, err := dataBase.GetAllContacts()

--- a/database/redis/database.go
+++ b/database/redis/database.go
@@ -140,8 +140,8 @@ func (connector *DbConnector) manageSubscriptions(tomb *tomb.Tomb, channel strin
 	return dataChan, nil
 }
 
-// Deletes all the keys of the DB, use it only for tests
-func (connector *DbConnector) flush() {
+// Flush deletes all the keys of the DB, use it only for tests
+func (connector *DbConnector) Flush() {
 	client := *connector.client
 
 	switch c := client.(type) {
@@ -165,4 +165,12 @@ func (connector *DbConnector) getTTL(key string) time.Duration {
 // Delete the key, use it only for tests
 func (connector *DbConnector) delete(key string) {
 	(*connector.client).Del(connector.context, key)
+}
+
+func (connector *DbConnector) Client() redis.UniversalClient {
+	return *connector.client
+}
+
+func (connector *DbConnector) Context() context.Context {
+	return connector.context
 }

--- a/database/redis/database_test.go
+++ b/database/redis/database_test.go
@@ -19,8 +19,8 @@ func TestNewDatabase(t *testing.T) {
 		So(database.logger, ShouldEqual, logger)
 		So(database.context, ShouldEqual, context.Background())
 
-		database.flush()
-		defer database.flush()
+		database.Flush()
+		defer database.Flush()
 
 		Convey("Redis client must be workable", func() {
 			var ctx = context.Background()

--- a/database/redis/last_check_test.go
+++ b/database/redis/last_check_test.go
@@ -15,8 +15,8 @@ import (
 func TestLastCheck(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	var triggerMaintenanceTS int64
 
 	Convey("LastCheck manipulation", t, func() {
@@ -223,7 +223,7 @@ func TestLastCheck(t *testing.T) {
 		})
 
 		Convey("Test last check manipulations update 'triggers to reindex' list", func() {
-			dataBase.flush()
+			dataBase.Flush()
 			triggerID := uuid.Must(uuid.NewV4()).String()
 
 			// there was no trigger with such ID, so function should return true
@@ -310,8 +310,8 @@ func TestLastCheck(t *testing.T) {
 func TestRemoteLastCheck(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("LastCheck manipulation", t, func() {
 		Convey("Test read write delete", func() {
@@ -398,8 +398,8 @@ func TestRemoteLastCheck(t *testing.T) {
 func TestLastCheckErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		actual1, err := dataBase.GetTriggerLastCheck("123")
 		So(actual1, ShouldResemble, moira.CheckData{})
@@ -424,8 +424,8 @@ func TestLastCheckErrorConnection(t *testing.T) {
 func TestMaintenanceUserSave(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	var triggerMaintenanceTS int64
 
 	Convey("Check user saving for trigger maintenance", t, func() {

--- a/database/redis/locks_test.go
+++ b/database/redis/locks_test.go
@@ -19,8 +19,8 @@ import (
 func Test(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	db := NewTestDatabase(logger)
-	db.flush()
-	defer db.flush()
+	db.Flush()
+	defer db.Flush()
 
 	Convey("Acquire/Release", t, func() {
 		lockName := "test:" + strconv.Itoa(rand.Int())

--- a/database/redis/metric_test.go
+++ b/database/redis/metric_test.go
@@ -14,7 +14,7 @@ import (
 func TestMetricsStoring(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
+	dataBase.Flush()
 	metric1 := "my.test.super.metric" //nolint
 	metric2 := "my.test.super.metric2"
 	pattern := "my.test.*.metric*" //nolint
@@ -186,8 +186,8 @@ func TestRemoveMetricValues(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
 	dataBase.metricsCache = cache.New(time.Second*2, time.Minute*60)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	metric1 := "my.test.super.metric"
 	pattern := "my.test.*.metric*"
 	met1 := &moira.MatchedMetric{
@@ -337,8 +337,8 @@ func TestRemoveMetricValues(t *testing.T) {
 func TestMetricSubscription(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	metric1 := "my.test.super.metric"
 	metric2 := "my.test.super.metric2"
 	pattern := "my.test.*.metric*"
@@ -402,8 +402,8 @@ func TestMetricSubscription(t *testing.T) {
 func TestMetricsStoringErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		actual, err := dataBase.GetPatterns()
 		So(actual, ShouldBeEmpty)

--- a/database/redis/notification_event_test.go
+++ b/database/redis/notification_event_test.go
@@ -22,8 +22,8 @@ var value = float64(0)
 func TestNotificationEvents(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Notification events manipulation", t, func() {
 		Convey("Test push-get-get count-fetch", func() {
@@ -282,8 +282,8 @@ func TestNotificationEvents(t *testing.T) {
 func TestNotificationEventErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	// TODO(litleleprikon): check why notification is event created here again
 	var newNotificationEvent = moira.NotificationEvent{

--- a/database/redis/notification_test.go
+++ b/database/redis/notification_test.go
@@ -16,8 +16,8 @@ import (
 func TestScheduledNotification(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("ScheduledNotification manipulation", t, func() {
 		now := time.Now().Unix()
@@ -178,8 +178,8 @@ func addNotifications(dataBase *DbConnector, notifications []moira.ScheduledNoti
 func TestScheduledNotificationErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Should throw error when no connection", t, func() {
 		actual1, total, err := dataBase.GetNotifications(0, 1)
@@ -210,8 +210,8 @@ func TestScheduledNotificationErrorConnection(t *testing.T) {
 func TestFetchNotifications(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("FetchNotifications manipulation", t, func() {
 		now := time.Now().Unix()
@@ -294,8 +294,8 @@ func TestFetchNotifications(t *testing.T) {
 func TestNotificationsCount(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("notificationsCount in db", t, func() {
 		now := time.Now().Unix()
@@ -357,8 +357,8 @@ func TestNotificationsCount(t *testing.T) {
 func TestFetchNotificationsWithLimitDo(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("notificationsCount in db", t, func() {
 		now := time.Now().Unix()
@@ -490,8 +490,8 @@ func TestLimitNotifications(t *testing.T) { //nolint
 func TestFetchNotificationsNoLimit(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("fetchNotificationsNoLimit manipulation", t, func() {
 		now := time.Now().Unix()

--- a/database/redis/selfstate_test.go
+++ b/database/redis/selfstate_test.go
@@ -13,8 +13,8 @@ func TestSelfCheckWithWritesInChecker(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
 	dataBase.source = Checker
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Self state triggers manipulation", t, func() {
 		Convey("Empty config", func() {
 			count, err := dataBase.GetMetricsUpdatesCount()
@@ -68,8 +68,8 @@ func testSelfCheckWithWritesInDBSource(t *testing.T, dbSource DBSource) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
 	dataBase.source = dbSource
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey(fmt.Sprintf("Self state triggers manipulation in %s", dbSource), t, func() {
 		Convey("Update metrics checks updates count", func() {
 			err := dataBase.SetTriggerLastCheck("123", &lastCheckTest, false)
@@ -92,8 +92,8 @@ func testSelfCheckWithWritesInDBSource(t *testing.T, dbSource DBSource) {
 func TestSelfCheckErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		count, err := dataBase.GetMetricsUpdatesCount()
 		So(count, ShouldEqual, 0)
@@ -112,8 +112,8 @@ func TestNotifierState(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
 	emptyDataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey(fmt.Sprintf("Test on empty key '%v'", selfStateNotifierHealth), t, func() {
 		Convey("On empty database should return ERROR", func() {
 			notifierState, err := emptyDataBase.GetNotifierState()

--- a/database/redis/subscription_test.go
+++ b/database/redis/subscription_test.go
@@ -17,8 +17,8 @@ import (
 func TestSubscriptions(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	client := *dataBase.client
 
 	sub := subscriptions[0]
@@ -191,8 +191,8 @@ func TestSubscriptions(t *testing.T) {
 func TestSubscriptionData(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("SubscriptionData manipulation", t, func() {
 		Convey("Save-get-remove subscription", func() {
@@ -286,7 +286,7 @@ func TestSubscriptionData(t *testing.T) {
 		})
 
 		Convey("Test rewrite subscription", func() {
-			dataBase.flush()
+			dataBase.Flush()
 			sub := *subscriptions[0]
 
 			err := dataBase.SaveSubscription(&sub)
@@ -356,8 +356,8 @@ func TestSubscriptionData(t *testing.T) {
 func TestSubscriptionErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		actual1, err := dataBase.GetSubscription("123")
 		So(actual1, ShouldResemble, moira.SubscriptionData{ThrottlingEnabled: true})

--- a/database/redis/tag_test.go
+++ b/database/redis/tag_test.go
@@ -10,8 +10,8 @@ import (
 func TestTagStoring(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	client := *dataBase.client
 
 	Convey("Tags manipulation", t, func() {
@@ -58,8 +58,8 @@ func TestTagStoring(t *testing.T) {
 func TestTagErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		actual, err := dataBase.GetTagNames()
 		So(err, ShouldNotBeNil)

--- a/database/redis/teams_test.go
+++ b/database/redis/teams_test.go
@@ -15,8 +15,8 @@ func TestTeamStoring(t *testing.T) {
 	}
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	teamID := "testTeam"
 	teamID2 := "testTeam2"

--- a/database/redis/throttling_test.go
+++ b/database/redis/throttling_test.go
@@ -12,8 +12,8 @@ import (
 func TestThrottlingErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		t1, t2 := dataBase.GetTriggerThrottling("")
 		So(t1, ShouldResemble, time.Unix(0, 0))

--- a/database/redis/trigger_test.go
+++ b/database/redis/trigger_test.go
@@ -16,8 +16,8 @@ import (
 func TestTriggerStoring(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Trigger manipulation", t, func() {
 		Convey("Test trigger has subscriptions with AnyTag is true", func() {
@@ -462,7 +462,7 @@ func TestTriggerStoring(t *testing.T) {
 		})
 
 		Convey("Test trigger manipulations update 'triggers to reindex' list", func() {
-			dataBase.flush()
+			dataBase.Flush()
 			trigger := &triggers[0]
 
 			err := dataBase.SaveTrigger(trigger.ID, trigger)
@@ -528,8 +528,8 @@ func TestRemoteTrigger(t *testing.T) {
 		TriggerType:  moira.RisingTrigger,
 		AloneMetrics: map[string]bool{},
 	}
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	client := *dataBase.client
 
 	Convey("Saving remote trigger", t, func() {
@@ -651,8 +651,8 @@ func TestRemoteTrigger(t *testing.T) {
 func TestTriggerErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Should not throw error when no connection", t, func() {
 		actual, err := dataBase.GetTriggerChecks([]string{})

--- a/database/redis/triggers_lock_test.go
+++ b/database/redis/triggers_lock_test.go
@@ -10,8 +10,8 @@ import (
 func TestLock(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Test lock manipulation", t, func() {
 		triggerID1 := "id"
 
@@ -44,8 +44,8 @@ func TestLock(t *testing.T) {
 func TestLockErrorConnection(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		err := dataBase.AcquireTriggerCheckLock("tr1", 4)
 		So(err, ShouldNotBeNil)

--- a/database/redis/triggers_search_results_test.go
+++ b/database/redis/triggers_search_results_test.go
@@ -94,8 +94,8 @@ func TestTriggersSearchResultsStoring(t *testing.T) {
 	}
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Search Results Manipulation", t, func() {
 		err := dataBase.SaveTriggersSearchResults(searchResultsID, searchResults)
@@ -151,8 +151,8 @@ func BenchmarkSaveTriggersSearchResults(b *testing.B) {
 	}
 
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	b.ReportAllocs()
 	limits := []int{10, 100, 1000, 10000, 100000}
@@ -177,7 +177,7 @@ func BenchmarkSaveTriggersSearchResults(b *testing.B) {
 				},
 			}
 		}
-		dataBase.flush()
+		dataBase.Flush()
 		b.Run(fmt.Sprintf("Benchmark%d", limit), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				dataBase.SaveTriggersSearchResults(fmt.Sprintf("test_%d_%d", limit, n), data) //nolint

--- a/database/redis/triggers_to_check_test.go
+++ b/database/redis/triggers_to_check_test.go
@@ -12,8 +12,8 @@ import (
 func TestTriggerToCheck(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Trigger to check get and add", t, func() {
 		triggerID1 := uuid.Must(uuid.NewV4()).String()
 		triggerID2 := uuid.Must(uuid.NewV4()).String()
@@ -105,8 +105,8 @@ func TestTriggerToCheck(t *testing.T) {
 func TestRemoteTriggerToCheck(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Trigger to check get and add", t, func() {
 		triggerID1 := uuid.Must(uuid.NewV4()).String()
 		triggerID2 := uuid.Must(uuid.NewV4()).String()
@@ -197,8 +197,8 @@ func TestRemoteTriggerToCheck(t *testing.T) {
 func TestRemoteTriggerToCheckConnection(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		err := dataBase.AddRemoteTriggersToCheck([]string{"123"})
 		So(err, ShouldNotBeNil)
@@ -212,8 +212,8 @@ func TestRemoteTriggerToCheckConnection(t *testing.T) {
 func TestTriggerToCheckConnection(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		err := dataBase.AddLocalTriggersToCheck([]string{"123"})
 		So(err, ShouldNotBeNil)

--- a/database/redis/triggers_to_reindex_test.go
+++ b/database/redis/triggers_to_reindex_test.go
@@ -14,8 +14,8 @@ import (
 func TestTriggersToReindex(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Test on empty DB", t, func() {
 		actual, err := dataBase.FetchTriggersToReindex(time.Now().Unix())
@@ -121,8 +121,8 @@ func TestTriggersToReindex(t *testing.T) {
 func TestTriggerToReindexConnection(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Should throw error when no connection", t, func() {
 		triggerID, err := dataBase.FetchTriggersToReindex(time.Now().Unix())

--- a/database/redis/unused_triggers_test.go
+++ b/database/redis/unused_triggers_test.go
@@ -12,8 +12,8 @@ import (
 func TestUnusedTriggers(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabase(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 
 	Convey("Check marking unused", t, func() {
 		// Check it before any trigger is marked unused
@@ -131,7 +131,7 @@ func TestUnusedTriggers(t *testing.T) {
 		}
 
 		Convey("Very simple trigger-subscription test", func() {
-			dataBase.flush()
+			dataBase.Flush()
 
 			err := dataBase.SaveTrigger(trigger1Ver1.ID, trigger1Ver1)
 			So(err, ShouldBeNil)
@@ -176,7 +176,7 @@ func TestUnusedTriggers(t *testing.T) {
 		})
 
 		Convey("Mass operations with triggers and subscriptions", func() {
-			dataBase.flush()
+			dataBase.Flush()
 
 			triggers := []*moira.Trigger{
 				{
@@ -279,8 +279,8 @@ func TestUnusedTriggers(t *testing.T) {
 func TestUnusedTriggersConnection(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
-	dataBase.flush()
-	defer dataBase.flush()
+	dataBase.Flush()
+	defer dataBase.Flush()
 	Convey("Should throw error when no connection", t, func() {
 		err := dataBase.MarkTriggersAsUnused("123")
 		So(err, ShouldNotBeNil)


### PR DESCRIPTION
There were 5 renames of keys (2 [here](https://github.com/moira-alert/moira/pull/679),  1 [here](https://github.com/moira-alert/moira/pull/684), 2 [here](https://github.com/moira-alert/moira/pull/683)) to migrate to Redis Cluster

In this PR added a command that renames existing keys in the database.

### How to use it

1. compile cli
```bash
$ go build -o build/cli github.com/moira-alert/moira/cmd/cli
```

2. run command forwards
```bash
$ ./build/cli -config local/cli.yml -move-to-cluster-forwards
```

```bash
# time ./cli -config cli.yml -move-to-cluster-forwards
2021-12-01 09:14:23.604 cli INF Moving to cluster forwards module=cli
2021-12-01 09:14:23.606 cli INF renameAnyTagsSubscriptionsKeyForwards done module=cli
2021-12-01 09:14:23.606 cli INF renameTriggersListKeyForwards done module=cli
2021-12-01 09:14:23.606 cli INF renameRemoteTriggersListKeyForwards done module=cli
2021-12-01 09:14:39.584 cli INF renameTagSubscriptionsKeyForwards done module=cli
2021-12-01 09:14:55.416 cli INF renameTagTriggersKeyKeyForwards done module=cli
2021-12-01 09:14:55.416 cli INF moveToClusterForwards done module=cli

real    0m31.840s
user    0m8.401s
sys     0m12.451s
```

3. (run command reverse)
```bash
$ ./build/cli -config local/cli.yml -move-to-cluster-reverse
```
