### PR TITLE
Made redis timeout settings editable

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -84,8 +84,9 @@ func (config *webConfig) getSettings(isRemoteEnabled bool) ([]byte, error) {
 func getDefault() config {
 	return config{
 		Redis: cmd.RedisConfig{
-			Addrs:      "localhost:6379",
-			MetricsTTL: "1h",
+			Addrs:       "localhost:6379",
+			MetricsTTL:  "1h",
+			DialTimeout: "500ms",
 		},
 		Logger: cmd.LoggerConfig{
 			LogFile:         "stdout",

--- a/cmd/checker/config.go
+++ b/cmd/checker/config.go
@@ -63,8 +63,9 @@ func (config *checkerConfig) getSettings(logger moira.Logger) *checker.Config {
 func getDefault() config {
 	return config{
 		Redis: cmd.RedisConfig{
-			Addrs:      "localhost:6379",
-			MetricsTTL: "1h",
+			Addrs:       "localhost:6379",
+			MetricsTTL:  "1h",
+			DialTimeout: "500ms",
 		},
 		Logger: cmd.LoggerConfig{
 			LogFile:         "stdout",

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -24,8 +24,9 @@ func getDefault() config {
 		LogLevel:        "info",
 		LogPrettyFormat: false,
 		Redis: cmd.RedisConfig{
-			Addrs:      "localhost:6379",
-			MetricsTTL: "1h",
+			Addrs:       "localhost:6379",
+			MetricsTTL:  "1h",
+			DialTimeout: "500ms",
 		},
 		Cleanup: cleanupConfig{
 			Whitelist: []string{},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,16 +32,25 @@ type RedisConfig struct {
 	// Moira will delete metrics older than this value from Redis. Large values will lead to various problems everywhere.
 	// See https://github.com/moira-alert/moira/pull/519
 	MetricsTTL string `yaml:"metrics_ttl"`
+	// Dial connection timeout. Default is 500ms.
+	DialTimeout string `yaml:"dial_timeout"`
+	// Read-operation timeout. Default is 3000ms.
+	ReadTimeout string `yaml:"read_timeout"`
+	// Write-operation timeout. Default is ReadTimeout seconds.
+	WriteTimeout string `yaml:"write_timeout"`
 }
 
 // GetSettings returns redis config parsed from moira config files
 func (config *RedisConfig) GetSettings() redis.Config {
 	return redis.Config{
-		MasterName: config.MasterName,
-		Addrs:      strings.Split(config.Addrs, ","),
-		Username:   config.Username,
-		Password:   config.Password,
-		MetricsTTL: to.Duration(config.MetricsTTL),
+		MasterName:   config.MasterName,
+		Addrs:        strings.Split(config.Addrs, ","),
+		Username:     config.Username,
+		Password:     config.Password,
+		MetricsTTL:   to.Duration(config.MetricsTTL),
+		DialTimeout:  to.Duration(config.DialTimeout),
+		ReadTimeout:  to.Duration(config.ReadTimeout),
+		WriteTimeout: to.Duration(config.WriteTimeout),
 	}
 }
 

--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -31,8 +31,9 @@ type filterConfig struct {
 func getDefault() config {
 	return config{
 		Redis: cmd.RedisConfig{
-			Addrs:      "localhost:6379",
-			MetricsTTL: "1h",
+			Addrs:       "localhost:6379",
+			MetricsTTL:  "1h",
+			DialTimeout: "500ms",
 		},
 		Logger: cmd.LoggerConfig{
 			LogFile:         "stdout",

--- a/cmd/notifier/config.go
+++ b/cmd/notifier/config.go
@@ -74,8 +74,9 @@ type selfStateConfig struct {
 func getDefault() config {
 	return config{
 		Redis: cmd.RedisConfig{
-			Addrs:      "localhost:6379",
-			MetricsTTL: "1h",
+			Addrs:       "localhost:6379",
+			MetricsTTL:  "1h",
+			DialTimeout: "500ms",
 		},
 
 		Logger: cmd.LoggerConfig{

--- a/database/redis/config.go
+++ b/database/redis/config.go
@@ -4,9 +4,12 @@ import "time"
 
 // Config - Redis database connection config
 type Config struct {
-	MasterName string
-	Addrs      []string
-	Username   string
-	Password   string
-	MetricsTTL time.Duration
+	MasterName   string
+	Addrs        []string
+	Username     string
+	Password     string
+	MetricsTTL   time.Duration
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
 }

--- a/database/redis/database.go
+++ b/database/redis/database.go
@@ -52,10 +52,13 @@ type DbConnector struct {
 
 func NewDatabase(logger moira.Logger, config Config, source DBSource) *DbConnector {
 	client := redis.NewUniversalClient(&redis.UniversalOptions{
-		MasterName: config.MasterName,
-		Addrs:      config.Addrs,
-		Username:   config.Username,
-		Password:   config.Password,
+		MasterName:   config.MasterName,
+		Addrs:        config.Addrs,
+		Username:     config.Username,
+		Password:     config.Password,
+		DialTimeout:  config.DialTimeout,
+		ReadTimeout:  config.ReadTimeout,
+		WriteTimeout: config.WriteTimeout,
 	})
 
 	ctx := context.Background()


### PR DESCRIPTION
# PR Summary

Go-redis lib provides a way to configure timeouts for redis connections. Corresponsing settings have been placed in Moira config file with following defaults:
- Dial timeout: 0.5 s (current master default)
- Read timeout: 3 sec (go-redis default), infinity on current master ([default if not specified in redigo](https://github.com/gomodule/redigo/issues/372))
- Write timeout: 3 sec (go-redis default), infinity on current master (default if not specified in redigo)

