### PR TITLE
Improved ErrLockNotAcquired

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -10,6 +10,13 @@ var (
 	ErrLockAlreadyHeld = fmt.Errorf("lock was already held")
 	// ErrLockAcquireInterrupted is returned if we cancel the acquire
 	ErrLockAcquireInterrupted = fmt.Errorf("lock's request was interrupted")
-	// ErrLockNotAcquired if we cannot acquire
-	ErrLockNotAcquired = fmt.Errorf("lock was not acquired")
 )
+
+// ErrLockNotAcquired if we cannot acquire
+type ErrLockNotAcquired struct {
+	Err error
+}
+
+func (e *ErrLockNotAcquired) Error() string {
+	return fmt.Sprintf("lock was not acquired: %v", e.Err)
+}

--- a/database/redis/locks.go
+++ b/database/redis/locks.go
@@ -39,8 +39,9 @@ func (lock *Lock) Acquire(stop <-chan struct{}) (<-chan struct{}, error) {
 			return nil, database.ErrLockAlreadyHeld
 		}
 
-		if err == database.ErrLockNotAcquired {
-			return nil, database.ErrLockNotAcquired
+		switch err.(type) {
+		case *database.ErrLockNotAcquired:
+			return nil, err
 		}
 
 		select {
@@ -79,7 +80,7 @@ func (lock *Lock) tryAcquire() (<-chan struct{}, error) {
 	}
 
 	if err := lock.mutex.Lock(); err != nil {
-		return nil, database.ErrLockNotAcquired
+		return nil, &database.ErrLockNotAcquired{Err: err}
 	}
 
 	lost := make(chan struct{})

--- a/database/redis/locks_test.go
+++ b/database/redis/locks_test.go
@@ -3,7 +3,8 @@ package redis
 import (
 	"strconv"
 
-	"github.com/go-redsync/redsync/v4"
+	"errors"
+
 	"github.com/moira-alert/moira/database"
 	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
 
@@ -78,13 +79,13 @@ func Test(t *testing.T) {
 		defer ctrl.Finish()
 
 		mutex := mock_moira_alert.NewMockMutex(ctrl)
-		mutex.EXPECT().Lock().Return(redsync.ErrFailed).AnyTimes()
+		mutex.EXPECT().Lock().Return(errors.New("some error")).AnyTimes()
 
 		lockName := "test:" + strconv.Itoa(rand.Int())
 		lock := &Lock{name: lockName, ttl: time.Second, mutex: mutex}
 
 		_, err := lock.Acquire(nil)
 		defer lock.Release()
-		So(err, ShouldEqual, database.ErrLockNotAcquired)
+		So(err.Error(), ShouldEqual, "lock was not acquired: some error")
 	})
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -38,7 +38,7 @@ func Test(t *testing.T) {
 		worker := createTestWorkerWithDefaultAction(lock)
 
 		gomock.InOrder(
-			lock.EXPECT().Acquire(gomock.Any()).Return(nil, database.ErrLockNotAcquired),
+			lock.EXPECT().Acquire(gomock.Any()).Return(nil, &database.ErrLockNotAcquired{}),
 			lock.EXPECT().Acquire(gomock.Any()).Return(nil, nil).Do(func(_ interface{}) { close(stop) }),
 			lock.EXPECT().Release(),
 		)
@@ -56,7 +56,7 @@ func Test(t *testing.T) {
 		lock := mock_moira_alert.NewMockLock(mockCtrl)
 		worker := createTestWorkerWithDefaultAction(lock)
 
-		lock.EXPECT().Acquire(gomock.Any()).Return(nil, database.ErrLockNotAcquired).Do(func(_ interface{}) { close(stop) })
+		lock.EXPECT().Acquire(gomock.Any()).Return(nil, &database.ErrLockNotAcquired{}).Do(func(_ interface{}) { close(stop) })
 
 		worker.Run(stop)
 	})


### PR DESCRIPTION
Previously, it was very uninformative: it was not clear what happened. It now contains more detailed information.

New error real example:

> lock was not acquired: 1 error occurred:\n\t* NOPERM this user has no permissions to run the 'eval' command or its subcommand\n\n