### PR TITLE
Added shared test configuration for GoLand

### DIFF
--- a/.run/go test moira.run.xml
+++ b/.run/go test moira.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="go test moira" type="GoTestRunConfiguration" factoryName="Go Test" nameIsGenerated="true">
+    <module name="moira" />
+    <working_directory value="$PROJECT_DIR$" />
+    <parameters value="-p 1" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/moira-alert/moira" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$" />
+    <framework value="gotest" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
The number of tests that run simultaneously in parallel is the current value of `GOMAXPROCS` (normally the number of CPUs available) by default.
It can cause some tests to fail (for reason reading/writing values from one database).

To avoid such a situation, you need to specify a parameter `-p n`  (the number of programs, such as build commands or test binaries, that can be run in parallel).

So that everyone does not have to customize the launch of tests, added [GoLand shared test run configuration](https://www.jetbrains.com/help/go/run-debug-configuration.html#share-configurations).