### PR TITLE
Decreased level of logging for broken contact errors to 'warning'

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -194,7 +194,7 @@ func (notifier *StandardNotifier) runSender(sender moira.Sender, ch chan Notific
 		} else {
 			switch e := err.(type) {
 			case moira.SenderBrokenContactError:
-				log.Errorf("Cannot send to broken contact: %s", e.Error())
+				log.Warningf("Cannot send to broken contact: %s", e.Error())
 
 			default:
 				log.Errorf("Cannot send notification: %s", err.Error())


### PR DESCRIPTION
# PR Summary
This PR simply decreases level of logging for broken contact errors (`SenderBrokenContactError`) in order to clean up a bit error-level logs for notifier module