### PR TITLE
Sharded channels

### DIFF
--- a/database/redis/database.go
+++ b/database/redis/database.go
@@ -132,6 +132,7 @@ func (connector *DbConnector) manageSubscriptions(tomb *tomb.Tomb, channels []st
 				connector.logger.Info("Reconnected to subscription")
 				psc = newPsc
 				<-time.After(receiveErrorSleepDuration)
+				continue
 			}
 			switch data := raw.(type) {
 			case *redis.Message:

--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -3,7 +3,9 @@ package redis
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strconv"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/moira-alert/moira"
@@ -128,7 +130,9 @@ func (connector *DbConnector) SaveMetrics(metrics map[string]*moira.MatchedMetri
 				continue
 			}
 
-			if err = c.Publish(ctx, metricEventKey, event).Err(); err != nil {
+			rand.Seed(time.Now().UnixNano())
+			var metricEventsChannel = metricEventsChannels[rand.Intn(len(metricEventsChannels))]
+			if err = c.Publish(ctx, metricEventsChannel, event).Err(); err != nil {
 				return err
 			}
 		}
@@ -139,7 +143,7 @@ func (connector *DbConnector) SaveMetrics(metrics map[string]*moira.MatchedMetri
 // SubscribeMetricEvents creates subscription for new metrics and return channel for this events
 func (connector *DbConnector) SubscribeMetricEvents(tomb *tomb.Tomb) (<-chan *moira.MetricEvent, error) {
 	metricsChannel := make(chan *moira.MetricEvent, pubSubWorkerChannelSize)
-	dataChannel, err := connector.manageSubscriptions(tomb, metricEventKey)
+	dataChannel, err := connector.manageSubscriptions(tomb, metricEventsChannels)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +268,13 @@ func (connector *DbConnector) needRemoveMetrics(metric string) bool {
 }
 
 var patternsListKey = "moira-pattern-list"
-var metricEventKey = "metric-event"
+
+var metricEventsChannels = []string{
+	"metric-event-0",
+	"metric-event-1",
+	"metric-event-2",
+	"metric-event-3",
+}
 
 func patternMetricsKey(pattern string) string {
 	return "moira-pattern-metrics:" + pattern

--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -102,6 +102,8 @@ func (connector *DbConnector) SaveMetrics(metrics map[string]*moira.MatchedMetri
 	c := *connector.client
 	ctx := connector.context
 
+	rand.Seed(time.Now().UnixNano())
+
 	for _, metric := range metrics {
 		metricValue := fmt.Sprintf("%v %v", metric.Timestamp, metric.Value)
 		z := &redis.Z{Score: float64(metric.RetentionTimestamp), Member: metricValue}
@@ -130,7 +132,6 @@ func (connector *DbConnector) SaveMetrics(metrics map[string]*moira.MatchedMetri
 				continue
 			}
 
-			rand.Seed(time.Now().UnixNano())
 			var metricEventsChannel = metricEventsChannels[rand.Intn(len(metricEventsChannels))]
 			if err = c.Publish(ctx, metricEventsChannel, event).Err(); err != nil {
 				return err


### PR DESCRIPTION
In the case of Redis Cluster, which node the channel hit, it becomes very loaded. To avoid this situation, the channel was sharded. Also made some refactoring to keep logic in the `master` branch.