### PR TITLE
Fixed plotting error in notifier

### DIFF
--- a/plotting/curve.go
+++ b/plotting/curve.go
@@ -1,7 +1,6 @@
 package plotting
 
 import (
-	"math"
 	"time"
 
 	"github.com/beevee/go-chart"
@@ -61,7 +60,7 @@ func describePlotCurves(metricData metricSource.MetricData) []plotCurve {
 
 	for valInd := start; valInd < len(metricData.Values); valInd++ {
 		pointValue := metricData.Values[valInd]
-		if !math.IsNaN(pointValue) {
+		if moira.IsValidFloat64(pointValue) {
 			timeStampValue := moira.Int64ToTime(timeStamp)
 			curves[curvesInd].timeStamps = append(curves[curvesInd].timeStamps, timeStampValue)
 			curves[curvesInd].values = append(curves[curvesInd].values, pointValue)
@@ -81,7 +80,7 @@ func resolveFirstPoint(metricData metricSource.MetricData) (int, int64) {
 	start := 0
 	startTime := metricData.StartTime
 	for _, metricVal := range metricData.Values {
-		if math.IsNaN(metricVal) {
+		if !moira.IsValidFloat64(metricVal) {
 			start++
 			startTime += metricData.StepTime
 		} else {

--- a/plotting/curve_test.go
+++ b/plotting/curve_test.go
@@ -17,11 +17,14 @@ var (
 		StopTime:  100,
 		StepTime:  10,
 	}
-	firstValIsAbsentVals = []float64{
+	firstValIsNanVals = []float64{
 		math.NaN(), math.NaN(), 32, math.NaN(), 54, 20, 43, 56, 2, 79, 76,
 	}
+	firstValIsInfVals = []float64{
+		math.Inf(-1), -1, math.NaN(), math.Inf(1), 20, 43, 56, 2, 79, 76, 99,
+	}
 	firstValIsPresentVals = []float64{
-		11, 23, 45, math.NaN(), 47, math.NaN(), 32, 65, 78, 76, 74,
+		11, 23, 45, math.NaN(), 47, math.NaN(), 32, 65, math.Inf(1), 76, 74,
 	}
 )
 
@@ -31,7 +34,7 @@ func TestGeneratePlotCurves(t *testing.T) {
 	Convey("First value is absent", t, func() {
 		metricName := "metric.firstValueIsAbsent"
 		metricData.Name = metricName
-		metricData.Values = firstValIsAbsentVals
+		metricData.Values = firstValIsNanVals
 		curveSeries := generatePlotCurves(metricData, chart.Style{}, chart.Style{})
 		So(len(curveSeries), ShouldEqual, 2)
 		So(curveSeries[0].Name, ShouldEqual, metricName)
@@ -56,7 +59,7 @@ func TestGeneratePlotCurves(t *testing.T) {
 		metricData.Name = metricName
 		metricData.Values = firstValIsPresentVals
 		curveSeries := generatePlotCurves(metricData, chart.Style{}, chart.Style{})
-		So(len(curveSeries), ShouldEqual, 3)
+		So(len(curveSeries), ShouldEqual, 4)
 		So(curveSeries[0].Name, ShouldEqual, metricName)
 		So(curveSeries[0].YValues, ShouldResemble, []float64{11, 23, 45})
 		So(curveSeries[0].XValues, ShouldResemble, []time.Time{
@@ -69,12 +72,13 @@ func TestGeneratePlotCurves(t *testing.T) {
 		So(curveSeries[1].XValues, ShouldResemble, []time.Time{
 			moira.Int64ToTime(40),
 		})
-		So(curveSeries[2].Name, ShouldEqual, metricName)
-		So(curveSeries[2].YValues, ShouldResemble, []float64{32, 65, 78, 76, 74})
+		So(curveSeries[2].YValues, ShouldResemble, []float64{32, 65})
 		So(curveSeries[2].XValues, ShouldResemble, []time.Time{
 			moira.Int64ToTime(60),
 			moira.Int64ToTime(70),
-			moira.Int64ToTime(80),
+		})
+		So(curveSeries[3].YValues, ShouldResemble, []float64{76, 74})
+		So(curveSeries[3].XValues, ShouldResemble, []time.Time{
 			moira.Int64ToTime(90),
 			moira.Int64ToTime(100),
 		})
@@ -84,8 +88,8 @@ func TestGeneratePlotCurves(t *testing.T) {
 // TestDescribePlotCurves tests describePlotCurves returns collection of
 // n PlotCurves from timeseries with n-1 gaps (IsAbsent values)
 func TestDescribePlotCurves(t *testing.T) {
-	Convey("First value is absent", t, func() {
-		metricData.Values = firstValIsAbsentVals
+	Convey("First value is not a number", t, func() {
+		metricData.Values = firstValIsNanVals
 		plotCurves := describePlotCurves(metricData)
 		So(len(plotCurves), ShouldEqual, 2)
 		So(plotCurves[0].values, ShouldResemble, []float64{32})
@@ -103,10 +107,29 @@ func TestDescribePlotCurves(t *testing.T) {
 			moira.Int64ToTime(100),
 		})
 	})
+	Convey("First value is infinity", t, func() {
+		metricData.Values = firstValIsInfVals
+		plotCurves := describePlotCurves(metricData)
+		So(len(plotCurves), ShouldEqual, 2)
+		So(plotCurves[0].values, ShouldResemble, []float64{-1})
+		So(plotCurves[0].timeStamps, ShouldResemble, []time.Time{
+			moira.Int64ToTime(10),
+		})
+		So(plotCurves[1].values, ShouldResemble, []float64{20, 43, 56, 2, 79, 76, 99})
+		So(plotCurves[1].timeStamps, ShouldResemble, []time.Time{
+			moira.Int64ToTime(40),
+			moira.Int64ToTime(50),
+			moira.Int64ToTime(60),
+			moira.Int64ToTime(70),
+			moira.Int64ToTime(80),
+			moira.Int64ToTime(90),
+			moira.Int64ToTime(100),
+		})
+	})
 	Convey("First value is present", t, func() {
 		metricData.Values = firstValIsPresentVals
 		plotCurves := describePlotCurves(metricData)
-		So(len(plotCurves), ShouldEqual, 3)
+		So(len(plotCurves), ShouldEqual, 4)
 		So(plotCurves[0].values, ShouldResemble, []float64{11, 23, 45})
 		So(plotCurves[0].timeStamps, ShouldResemble, []time.Time{
 			moira.Int64ToTime(0),
@@ -117,11 +140,13 @@ func TestDescribePlotCurves(t *testing.T) {
 		So(plotCurves[1].timeStamps, ShouldResemble, []time.Time{
 			moira.Int64ToTime(40),
 		})
-		So(plotCurves[2].values, ShouldResemble, []float64{32, 65, 78, 76, 74})
+		So(plotCurves[2].values, ShouldResemble, []float64{32, 65})
 		So(plotCurves[2].timeStamps, ShouldResemble, []time.Time{
 			moira.Int64ToTime(60),
 			moira.Int64ToTime(70),
-			moira.Int64ToTime(80),
+		})
+		So(plotCurves[3].values, ShouldResemble, []float64{76, 74})
+		So(plotCurves[3].timeStamps, ShouldResemble, []time.Time{
 			moira.Int64ToTime(90),
 			moira.Int64ToTime(100),
 		})
@@ -131,11 +156,17 @@ func TestDescribePlotCurves(t *testing.T) {
 // TestResolveFirstPoint tests resolveFirstPoint returns correct start time
 // for given MetricData whether IsAbsent[0] is true or false
 func TestResolveFirstPoint(t *testing.T) {
-	Convey("First value is absent", t, func() {
-		metricData.Values = firstValIsAbsentVals
+	Convey("First value is not a number", t, func() {
+		metricData.Values = firstValIsNanVals
 		firstPointInd, startTime := resolveFirstPoint(metricData)
 		So(firstPointInd, ShouldEqual, 2)
 		So(startTime, ShouldEqual, 20)
+	})
+	Convey("First value is infinity", t, func() {
+		metricData.Values = firstValIsInfVals
+		firstPointInd, startTime := resolveFirstPoint(metricData)
+		So(firstPointInd, ShouldEqual, 1)
+		So(startTime, ShouldEqual, 10)
 	})
 	Convey("First value is present", t, func() {
 		metricData.Values = firstValIsPresentVals

--- a/plotting/limits.go
+++ b/plotting/limits.go
@@ -1,7 +1,6 @@
 package plotting
 
 import (
-	"math"
 	"time"
 
 	"github.com/beevee/go-chart"
@@ -34,7 +33,7 @@ func resolveLimits(metricsData []metricSource.MetricData) plotLimits {
 	allTimes := make([]time.Time, 0)
 	for _, metricData := range metricsData {
 		for _, metricValue := range metricData.Values {
-			if !math.IsNaN(metricValue) {
+			if moira.IsValidFloat64(metricValue) {
 				allValues = append(allValues, metricValue)
 			}
 		}

--- a/plotting/limits_test.go
+++ b/plotting/limits_test.go
@@ -1,6 +1,7 @@
 package plotting
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -51,6 +52,30 @@ func TestResolveLimits(t *testing.T) {
 		So(limits.lowest, ShouldNotEqual, 0)
 		So(limits.highest, ShouldNotEqual, 0)
 		So(limits.lowest, ShouldNotEqual, limits.highest)
+		So(limits.lowest, ShouldEqual, expectedLowest)
+		So(limits.highest, ShouldEqual, expectedHighest)
+	})
+
+	metricsData[0].Values[2], metricsData[0].Values[3], metricsData[0].Values[4] = math.NaN(), math.Inf(-1), math.Inf(1)
+	// So we're actually using elementsToUse x elementsToUse MetricsData with values like:
+	// [-1                 10000              NaN                -Inf                +Inf
+	// [1491.4815658695925 3528.452470599303  296.78548099273524 2048.473675536235
+	// [1961.4869744066652 574.2827161848164  1757.8304749568863 2406.1508870508073
+	// [2075.6933900571207 3393.385674988974  3234.9526818050126 5602.5371761246915
+	// [384.016924791711   9066.931651012908  563.0027804705013  5100.243298996324
+	// [519.4539685177408  6029.673742973381  243.3464382654782  2590.9614772639184
+	// [3712.024207074801  8137.757246113409  3653.0361832312265 632.2809306369263
+	// ...
+	Convey("Resolve limits for collection of random MetricData which includes NaN and Inf", t, func() {
+		expectedFrom := moira.Int64ToTime(startTime)
+		expectedTo := expectedFrom.Add(time.Duration(elementsToUse) * time.Minute)
+		expectedIncrement := percentsOfRange(float64(minValue), float64(maxValue), defaultYAxisRangePercent)
+		expectedLowest := float64(minValue) - expectedIncrement
+		expectedHighest := float64(maxValue) + expectedIncrement
+		limits := resolveLimits(metricsData)
+		So(limits.from, ShouldResemble, expectedFrom)
+		So(limits.to, ShouldResemble, expectedTo)
+		So(limits.lowest, ShouldNotEqual, 0)
 		So(limits.lowest, ShouldEqual, expectedLowest)
 		So(limits.highest, ShouldEqual, expectedHighest)
 	})

--- a/plotting/plot_test.go
+++ b/plotting/plot_test.go
@@ -441,49 +441,75 @@ var plotsHashDistancesTestCases = []plotsHashDistancesTestCase{
 
 // generateTestMetricsData generates metricData array for tests
 func generateTestMetricsData(useHumanizedValues bool) []metricSource.MetricData {
-	metricData := metricSource.MetricData{
-		Name:      "MetricName",
-		StartTime: 0,
-		StepTime:  10,
-		StopTime:  100,
-		Values:    []float64{12, 34, 23, 45, 76, 64, 32, 13, 34, 130, 70},
-	}
-	metricData2 := metricSource.MetricData{
-		Name:      "CategoryCounterType.MetricName",
-		StartTime: 0,
-		StepTime:  10,
-		StopTime:  100,
-		Values:    []float64{math.NaN(), 15, 32, math.NaN(), 54, 20, 43, 56, 2, 79, 76},
-	}
-	metricData3 := metricSource.MetricData{
-		Name:      "CategoryCounterName.CategoryCounterType.MetricName",
-		StartTime: 0,
-		StepTime:  10,
-		StopTime:  100,
-		Values:    []float64{11, 23, 45, math.NaN(), 45, math.NaN(), 32, 65, 78, 76, 74},
-	}
-	metricData4 := metricSource.MetricData{
-		Name:      "CategoryName.CategoryCounterName.CategoryCounterType.MetricName",
-		StartTime: 0,
-		StepTime:  10,
-		StopTime:  100,
-		Values:    []float64{11, 23, 10, 9, 17, 10, 25, 12, 10, 15, 30},
+	metricsData := []metricSource.MetricData{
+		{
+			Name:      "MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values:    []float64{12, 34, 23, 45, 76, 64, 32, 13, 34, 130, 70, math.Inf(-1)},
+		},
+		{
+			Name:      "CategoryCounterType.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values:    []float64{math.NaN(), 15, 32, math.NaN(), 54, 20, 43, 56, 2, 79, 76},
+		},
+		{
+			Name:      "CategoryCounterName.CategoryCounterType.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values:    []float64{11, 23, 45, math.NaN(), 45, math.NaN(), 32, 65, 78, 76, 74},
+		},
+		{
+			Name:      "CategoryName.CategoryCounterName.CategoryCounterType.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values:    []float64{11, 23, 10, 9, 17, 10, 25, 12, 10, 15, 30},
+		},
+		{
+			Name:      "CategoryName.CategoryCounterName.CategoryCounterType.MetricType.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values:    []float64{math.Inf(-1), 23, 10, 9, 17, 10, 25, 12, math.Inf(1), 15, 30},
+		},
+		{
+			Name:      "CategoryName.CategoryCounterName.MetricType.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values:    []float64{23, 10, 9, math.Inf(-1), 10, math.NaN(), 12, 15, 30, 45},
+		},
+		{
+			Name:      "CategoryCounterName.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values: []float64{
+				math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+			},
+		},
+		{
+			Name:      "CategoryCounterType.MetricType.MetricName",
+			StartTime: 0,
+			StepTime:  10,
+			StopTime:  100,
+			Values: []float64{
+				math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(-1), math.Inf(-1), math.Inf(-1), math.Inf(1), math.Inf(-1), math.Inf(1), math.Inf(-1),
+			},
+		},
 	}
 	if !useHumanizedValues {
-		for valInd, value := range metricData.Values {
-			metricData.Values[valInd] = plotTestOuterPointMultiplier * value
-		}
-		for valInd, value := range metricData2.Values {
-			metricData2.Values[valInd] = plotTestOuterPointMultiplier * value
-		}
-		for valInd, value := range metricData3.Values {
-			metricData3.Values[valInd] = plotTestOuterPointMultiplier * value
-		}
-		for valInd, value := range metricData4.Values {
-			metricData4.Values[valInd] = plotTestOuterPointMultiplier * value
+		for _, metricData := range metricsData {
+			for valInd, value := range metricData.Values {
+				metricData.Values[valInd] = plotTestOuterPointMultiplier * value
+			}
 		}
 	}
-	metricsData := []metricSource.MetricData{metricData, metricData2, metricData3, metricData4}
 	return metricsData
 }
 


### PR DESCRIPTION
# Infinity metric values are filtered on plotting in notifier

There was a gap in filtering of metric values and Ininity values were passed to further processing, particularly to plotting. That causes errors ike:
```
Can't build notification package plot for {trigger.id}: infinite y-range delta
```
Now filtering is added in.
