### PR TITLE
Reworked command to add/remove Redis Cluster support

### DIFF
--- a/cmd/cli/cluster.go
+++ b/cmd/cli/cluster.go
@@ -162,7 +162,7 @@ func renameTagTriggersKeyKeyReverse(logger moira.Logger, database moira.Database
 	return nil
 }
 
-func moveToClusterForwards(logger moira.Logger, database moira.Database) error {
+func addRedisClusterSupport(logger moira.Logger, database moira.Database) error {
 	err := renameAnyTagsSubscriptionsKeyForwards(logger, database)
 	if err != nil {
 		return err
@@ -188,12 +188,12 @@ func moveToClusterForwards(logger moira.Logger, database moira.Database) error {
 		return err
 	}
 
-	logger.Info("moveToClusterForwards done")
+	logger.Info("addRedisClusterSupport done")
 
 	return nil
 }
 
-func moveToClusterReverse(logger moira.Logger, database moira.Database) error {
+func removeRedisClusterSupport(logger moira.Logger, database moira.Database) error {
 	err := renameAnyTagsSubscriptionsKeyReverse(logger, database)
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func moveToClusterReverse(logger moira.Logger, database moira.Database) error {
 		return err
 	}
 
-	logger.Info("moveToClusterReverse done")
+	logger.Info("removeRedisClusterSupport done")
 
 	return nil
 }

--- a/cmd/cli/cluster_test.go
+++ b/cmd/cli/cluster_test.go
@@ -74,7 +74,7 @@ func TestCluster(t *testing.T) {
 			So(valueStoredAtKey, ShouldBeEmpty)
 
 			Convey("When migration was applied", func() {
-				err := moveToClusterForwards(logger, database)
+				err := addRedisClusterSupport(logger, database)
 				So(err, ShouldBeNil)
 
 				Convey("Database should be new", func() {
@@ -163,7 +163,7 @@ func TestCluster(t *testing.T) {
 				So(valueStoredAtKey, ShouldBeEmpty)
 
 				Convey("When migration was reversed", func() {
-					err := moveToClusterReverse(logger, database)
+					err := removeRedisClusterSupport(logger, database)
 					So(err, ShouldBeNil)
 
 					Convey("Database should be old", func() {

--- a/cmd/cli/from_2.6_to_2.7.go
+++ b/cmd/cli/from_2.6_to_2.7.go
@@ -1,0 +1,27 @@
+package main
+
+import "github.com/moira-alert/moira"
+
+func updateFrom26(logger moira.Logger, dataBase moira.Database) error {
+	logger.Info("Update 2.6 -> 2.7 was started")
+
+	logger.Info("Adding Redis Cluster support was started")
+	if err := addRedisClusterSupport(logger, dataBase); err != nil {
+		return err
+	}
+
+	logger.Info("Update 2.6 -> 2.7 was finished")
+	return nil
+}
+
+func downgradeTo26(logger moira.Logger, dataBase moira.Database) error {
+	logger.Info("Downgrade 2.7 -> 2.6 started")
+
+	logger.Info("Removing Redis Cluster support was started")
+	if err := removeRedisClusterSupport(logger, dataBase); err != nil {
+		return err
+	}
+
+	logger.Info("Downgrade 2.7 -> 2.6 was finished")
+	return nil
+}


### PR DESCRIPTION
To upgrade to version 2.7 with Redis Cluster support:

`% ./build/cli --config local/cli.yml --update --from-version=2.6`

To downgrade to previous version 2.6 without Redis Cluster support:

`% ./build/cli --config local/cli.yml --downgrade --to-version=2.6 `