### PR TITLE
Added command to clean up outdated metrics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,5 +11,5 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.32.0
+          version: v1.45.2
           only-new-issues: true

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -16,6 +16,7 @@ type cleanupConfig struct {
 	Whitelist               []string `yaml:"whitelist"`
 	Delete                  bool     `yaml:"delete"`
 	AddAnonymousToWhitelist bool     `json:"add_anonymous_to_whitelist"`
+	CleanupMetricsDuration  string   `yaml:"cleanup_metrics_duration"`
 }
 
 func getDefault() config {
@@ -29,7 +30,8 @@ func getDefault() config {
 			DialTimeout: "500ms",
 		},
 		Cleanup: cleanupConfig{
-			Whitelist: []string{},
+			Whitelist:              []string{},
+			CleanupMetricsDuration: "-168h",
 		},
 	}
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -53,6 +53,10 @@ var (
 )
 
 var (
+	cleanUpMetrics = flag.Bool("cleanup-outdated-metrics", false, "Delete outdated metrics by duration.")
+)
+
+var (
 	pushTriggerDump = flag.Bool("push-trigger-dump", false, "Get trigger dump in JSON from stdin and save it to redis")
 	triggerDumpFile = flag.String("trigger-dump-file", "", "File that holds trigger dump JSON from api method response")
 )
@@ -143,6 +147,17 @@ func main() { //nolint
 			logger.Fatal(err)
 		}
 		logger.Info("Dump was pushed")
+	}
+
+	if *cleanUpMetrics {
+		log := logger.String(moira.LogFieldNameContext, "cleanup")
+		log.Info("Cleanup outdated metrics started")
+		err := cleanUpOutdatedMetrics(confCleanup, dataBase)
+		if err != nil {
+			log.Error(err)
+		}
+
+		log.Info("Cleanup outdated metrics finished")
 	}
 }
 

--- a/cmd/cli/metrics.go
+++ b/cmd/cli/metrics.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"time"
+
+	"github.com/moira-alert/moira"
+)
+
+func cleanUpOutdatedMetrics(config cleanupConfig, database moira.Database) error {
+	duration, err := time.ParseDuration(config.CleanupMetricsDuration)
+	if err != nil {
+		return err
+	}
+
+	err = database.CleanUpOutdatedMetrics(duration)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	mocks "github.com/moira-alert/moira/mock/moira-alert"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCleanUpOutdatedMetrics(t *testing.T) {
+	conf := getDefault()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	db := mocks.NewMockDatabase(mockCtrl)
+
+	Convey("Test cleanup", t, func() {
+		db.EXPECT().CleanupOutdatedMetrics(-168 * time.Hour).Return(nil)
+		err := cleanUpOutdatedMetrics(conf.Cleanup, db)
+		So(err, ShouldBeNil)
+	})
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -139,6 +139,9 @@ type Database interface {
 	GetTeamUsers(teamID string) ([]string, error)
 	IsTeamContainUser(teamID, userID string) (bool, error)
 	DeleteTeam(teamID, userID string) error
+
+	// Metrics management
+	CleanUpOutdatedMetrics(duration time.Duration) error
 }
 
 // Lock implements lock abstraction

--- a/local/cli.yml
+++ b/local/cli.yml
@@ -4,3 +4,6 @@ redis:
 log_file: stdout
 log_level: debug
 log_pretty_format: true
+cleanup:
+  # Default cleanup duration according to max TTL for metrics = 7 days
+  cleanup_metrics_duration: "-168h"

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -120,6 +120,20 @@ func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
+// CleanupOutdatedMetrics mocks base method.
+func (m *MockDatabase) CleanUpOutdatedMetrics(arg0 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpOutdatedMetrics", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupOutdatedMetrics indicates an expected call of CleanupOutdatedMetrics.
+func (mr *MockDatabaseMockRecorder) CleanupOutdatedMetrics(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpOutdatedMetrics", reflect.TypeOf((*MockDatabase)(nil).CleanUpOutdatedMetrics), arg0)
+}
+
 // DeleteTeam mocks base method.
 func (m *MockDatabase) DeleteTeam(arg0, arg1 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
To run command to clean up outdated metrics by default, older than 7 days:

```bash
$ ./moira-cli --config local/cli.yml -cleanup-outdated-metrics
```

You can change this option in `local/cli.yml`:
 
 ```yaml
 # Default cleanup duration according to max TTL for metrics = 7 days
 cleanup_metrics_duration: "-168h"
```