### PR TITLE
fix(api): Fixed setting trigger check maintenance

### DIFF
--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -11,6 +11,8 @@ import (
 	"github.com/moira-alert/moira/support"
 )
 
+const maxTriggerLockAttempts = 10
+
 // UpdateTrigger update trigger data and trigger metrics in last state
 func UpdateTrigger(dataBase moira.Database, trigger *dto.TriggerModel, triggerID string, timeSeriesNames map[string]bool) (*dto.SaveTriggerResponse, *api.ErrorResponse) {
 	_, err := dataBase.GetTrigger(triggerID)
@@ -25,7 +27,7 @@ func UpdateTrigger(dataBase moira.Database, trigger *dto.TriggerModel, triggerID
 
 // saveTrigger create or update trigger data and update trigger metrics in last state
 func saveTrigger(dataBase moira.Database, trigger *moira.Trigger, triggerID string, timeSeriesNames map[string]bool) (*dto.SaveTriggerResponse, *api.ErrorResponse) {
-	if err := dataBase.AcquireTriggerCheckLock(triggerID, 10); err != nil {
+	if err := dataBase.AcquireTriggerCheckLock(triggerID, maxTriggerLockAttempts); err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}
 	defer dataBase.DeleteTriggerCheckLock(triggerID) //nolint
@@ -159,6 +161,10 @@ func DeleteTriggerThrottling(database moira.Database, triggerID string) *api.Err
 
 // SetTriggerMaintenance sets maintenance to metrics and whole trigger
 func SetTriggerMaintenance(database moira.Database, triggerID string, triggerMaintenance dto.TriggerMaintenance, userLogin string, timeCallMaintenance int64) *api.ErrorResponse {
+	if err := database.AcquireTriggerCheckLock(triggerID, maxTriggerLockAttempts); err != nil {
+		return api.ErrorInternalServer(err)
+	}
+	defer database.DeleteTriggerCheckLock(triggerID) //nolint
 	if err := database.SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, userLogin, timeCallMaintenance); err != nil {
 		return api.ErrorInternalServer(err)
 	}

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -164,7 +164,7 @@ func SetTriggerMaintenance(database moira.Database, triggerID string, triggerMai
 	if err := database.AcquireTriggerCheckLock(triggerID, maxTriggerLockAttempts); err != nil {
 		return api.ErrorInternalServer(err)
 	}
-	defer database.DeleteTriggerCheckLock(triggerID) //nolint
+	defer database.ReleaseTriggerCheckLock(triggerID)
 	if err := database.SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, userLogin, timeCallMaintenance); err != nil {
 		return api.ErrorInternalServer(err)
 	}

--- a/api/controller/trigger_metrics.go
+++ b/api/controller/trigger_metrics.go
@@ -85,7 +85,7 @@ func deleteTriggerMetrics(dataBase moira.Database, metricName string, triggerID 
 		return api.ErrorInternalServer(err)
 	}
 
-	if err = dataBase.AcquireTriggerCheckLock(triggerID, 10); err != nil {
+	if err = dataBase.AcquireTriggerCheckLock(triggerID, maxTriggerLockAttempts); err != nil {
 		return api.ErrorInternalServer(err)
 	}
 	defer dataBase.DeleteTriggerCheckLock(triggerID) //nolint

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -420,6 +420,8 @@ func TestSetTriggerMaintenance(t *testing.T) {
 	var maintenanceTS int64 = 12347
 
 	Convey("Success setting metrics maintenance only", t, func() {
+		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(nil)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldBeNil)
@@ -428,6 +430,8 @@ func TestSetTriggerMaintenance(t *testing.T) {
 	Convey("Success setting trigger maintenance only", t, func() {
 		triggerMaintenance.Trigger = &maintenanceTS
 		triggerMaintenance.Metrics = dto.MetricsMaintenance{}
+		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(nil)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldBeNil)
@@ -436,6 +440,8 @@ func TestSetTriggerMaintenance(t *testing.T) {
 	Convey("Success setting metrics and trigger maintenance at once", t, func() {
 		triggerMaintenance.Trigger = &maintenanceTS
 		triggerMaintenance.Metrics = metricsMaintenance
+		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(nil)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldBeNil)
@@ -443,6 +449,8 @@ func TestSetTriggerMaintenance(t *testing.T) {
 
 	Convey("Error", t, func() {
 		expected := fmt.Errorf("oooops! Error set")
+		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
+		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(expected)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldResemble, api.ErrorInternalServer(expected))

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -421,7 +421,7 @@ func TestSetTriggerMaintenance(t *testing.T) {
 
 	Convey("Success setting metrics maintenance only", t, func() {
 		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
-		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+		dataBase.EXPECT().ReleaseTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(nil)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldBeNil)
@@ -431,7 +431,7 @@ func TestSetTriggerMaintenance(t *testing.T) {
 		triggerMaintenance.Trigger = &maintenanceTS
 		triggerMaintenance.Metrics = dto.MetricsMaintenance{}
 		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
-		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+		dataBase.EXPECT().ReleaseTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(nil)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldBeNil)
@@ -441,7 +441,7 @@ func TestSetTriggerMaintenance(t *testing.T) {
 		triggerMaintenance.Trigger = &maintenanceTS
 		triggerMaintenance.Metrics = metricsMaintenance
 		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
-		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+		dataBase.EXPECT().ReleaseTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(nil)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldBeNil)
@@ -450,7 +450,7 @@ func TestSetTriggerMaintenance(t *testing.T) {
 	Convey("Error", t, func() {
 		expected := fmt.Errorf("oooops! Error set")
 		dataBase.EXPECT().AcquireTriggerCheckLock(triggerID, 10)
-		dataBase.EXPECT().DeleteTriggerCheckLock(triggerID)
+		dataBase.EXPECT().ReleaseTriggerCheckLock(triggerID)
 		dataBase.EXPECT().SetTriggerCheckMaintenance(triggerID, triggerMaintenance.Metrics, triggerMaintenance.Trigger, "", int64(0)).Return(expected)
 		err := SetTriggerMaintenance(dataBase, triggerID, triggerMaintenance, "", 0)
 		So(err, ShouldResemble, api.ErrorInternalServer(expected))

--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -17,7 +17,7 @@ func TestCleanUpOutdatedMetrics(t *testing.T) {
 	db := mocks.NewMockDatabase(mockCtrl)
 
 	Convey("Test cleanup", t, func() {
-		db.EXPECT().CleanupOutdatedMetrics(-168 * time.Hour).Return(nil)
+		db.EXPECT().CleanUpOutdatedMetrics(-168 * time.Hour).Return(nil)
 		err := cleanUpOutdatedMetrics(conf.Cleanup, db)
 		So(err, ShouldBeNil)
 	})

--- a/database/redis/last_check.go
+++ b/database/redis/last_check.go
@@ -89,7 +89,6 @@ func (connector *DbConnector) RemoveTriggerLastCheck(triggerID string) error {
 }
 
 // SetTriggerCheckMaintenance sets maintenance for whole trigger and to given metrics,
-// If during the update lastCheck was updated from another place, try update again
 // If CheckData does not contain one of given metrics it will ignore this metric
 func (connector *DbConnector) SetTriggerCheckMaintenance(triggerID string, metrics map[string]int64, triggerMaintenance *int64, userLogin string, timeCallMaintenance int64) error {
 	ctx := connector.context
@@ -97,47 +96,38 @@ func (connector *DbConnector) SetTriggerCheckMaintenance(triggerID string, metri
 	var readingErr error
 
 	lastCheckString, readingErr := c.Get(ctx, metricLastCheckKey(triggerID)).Result()
-	if readingErr != nil && readingErr != redis.Nil {
-		return readingErr
-	}
-
-	for readingErr != redis.Nil {
-		var lastCheck = moira.CheckData{}
-		err := json.Unmarshal([]byte(lastCheckString), &lastCheck)
-		if err != nil {
-			return fmt.Errorf("failed to parse lastCheck json %s: %s", lastCheckString, err.Error())
-		}
-		metricsCheck := lastCheck.Metrics
-		if len(metricsCheck) > 0 {
-			for metric, value := range metrics {
-				data, ok := metricsCheck[metric]
-				if !ok {
-					continue
-				}
-				moira.SetMaintenanceUserAndTime(&data, value, userLogin, timeCallMaintenance)
-				metricsCheck[metric] = data
-			}
-		}
-		if triggerMaintenance != nil {
-			moira.SetMaintenanceUserAndTime(&lastCheck, *triggerMaintenance, userLogin, timeCallMaintenance)
-		}
-		newLastCheck, err := json.Marshal(lastCheck)
-		if err != nil {
-			return err
-		}
-
-		var prev string
-		prev, readingErr = c.GetSet(ctx, metricLastCheckKey(triggerID), newLastCheck).Result()
-		if readingErr != nil && readingErr != redis.Nil {
+	if readingErr != nil {
+		if readingErr != redis.Nil {
 			return readingErr
 		}
-		if prev == lastCheckString {
-			break
-		}
-		lastCheckString = prev
+		return nil
 	}
 
-	return nil
+	var lastCheck = moira.CheckData{}
+	err := json.Unmarshal([]byte(lastCheckString), &lastCheck)
+	if err != nil {
+		return fmt.Errorf("failed to parse lastCheck json %s: %s", lastCheckString, err.Error())
+	}
+	metricsCheck := lastCheck.Metrics
+	if len(metricsCheck) > 0 {
+		for metric, value := range metrics {
+			data, ok := metricsCheck[metric]
+			if !ok {
+				continue
+			}
+			moira.SetMaintenanceUserAndTime(&data, value, userLogin, timeCallMaintenance)
+			metricsCheck[metric] = data
+		}
+	}
+	if triggerMaintenance != nil {
+		moira.SetMaintenanceUserAndTime(&lastCheck, *triggerMaintenance, userLogin, timeCallMaintenance)
+	}
+	newLastCheck, err := json.Marshal(lastCheck)
+	if err != nil {
+		return err
+	}
+
+	return c.Set(ctx, metricLastCheckKey(triggerID), newLastCheck, redis.KeepTTL).Err()
 }
 
 // checkDataScoreChanged returns true if checkData.Score changed since last check

--- a/database/redis/triggers_lock.go
+++ b/database/redis/triggers_lock.go
@@ -51,6 +51,13 @@ func (connector *DbConnector) DeleteTriggerCheckLock(triggerID string) error {
 	return nil
 }
 
+// ReleaseTriggerCheckLock deletes trigger check lock for given triggerID and logs an error if needed
+func (connector *DbConnector) ReleaseTriggerCheckLock(triggerID string) {
+	if err := connector.DeleteTriggerCheckLock(triggerID); err != nil {
+		connector.logger.Warningf("Error on releasing trigger check lock: %s", err)
+	}
+}
+
 func metricCheckLockKey(triggerID string) string {
 	return "moira-metric-check-lock:" + triggerID
 }

--- a/database/redis/triggers_lock.go
+++ b/database/redis/triggers_lock.go
@@ -8,14 +8,14 @@ import (
 )
 
 // AcquireTriggerCheckLock sets trigger lock by given id. If lock does not take, try again and repeat it for given attempts
-func (connector *DbConnector) AcquireTriggerCheckLock(triggerID string, timeout int) error {
+func (connector *DbConnector) AcquireTriggerCheckLock(triggerID string, maxAttemptsCount int) error {
 	acquired, err := connector.SetTriggerCheckLock(triggerID)
 	if err != nil {
 		return err
 	}
-	count := 0
-	for !acquired && count < timeout {
-		count++
+	attemptsCount := 0
+	for !acquired && attemptsCount < maxAttemptsCount {
+		attemptsCount++
 		<-time.After(time.Millisecond * 500) //nolint
 		acquired, err = connector.SetTriggerCheckLock(triggerID)
 		if err != nil {
@@ -23,7 +23,7 @@ func (connector *DbConnector) AcquireTriggerCheckLock(triggerID string, timeout 
 		}
 	}
 	if !acquired {
-		return fmt.Errorf("can not acquire trigger lock in %v seconds", timeout)
+		return fmt.Errorf("can not acquire trigger lock in %v attempts", maxAttemptsCount)
 	}
 	return nil
 }

--- a/database/redis/triggers_lock_test.go
+++ b/database/redis/triggers_lock_test.go
@@ -3,6 +3,9 @@ package redis
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+
 	logging "github.com/moira-alert/moira/logging/zerolog_adapter"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -56,5 +59,17 @@ func TestLockErrorConnection(t *testing.T) {
 
 		err = dataBase.DeleteTriggerCheckLock("tr1")
 		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestLockErrorLogging(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	logger := mock_moira_alert.NewMockLogger(mockCtrl)
+	dataBase := NewTestDatabaseWithIncorrectConfig(logger)
+	dataBase.Flush()
+	defer dataBase.Flush()
+	Convey("Should log error on releasing the lock", t, func() {
+		logger.EXPECT().Warningf(gomock.Any(), gomock.Any())
+		dataBase.ReleaseTriggerCheckLock("tr1")
 	})
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -113,6 +113,7 @@ type Database interface {
 	AcquireTriggerCheckLock(triggerID string, maxAttemptsCount int) error
 	DeleteTriggerCheckLock(triggerID string) error
 	SetTriggerCheckLock(triggerID string) (bool, error)
+	ReleaseTriggerCheckLock(triggerID string)
 
 	// Bot data storing
 	GetIDByUsername(messenger, username string) (string, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -110,7 +110,7 @@ type Database interface {
 	GetRemoteTriggersToCheckCount() (int64, error)
 
 	// TriggerCheckLock storing
-	AcquireTriggerCheckLock(triggerID string, timeout int) error
+	AcquireTriggerCheckLock(triggerID string, maxAttemptsCount int) error
 	DeleteTriggerCheckLock(triggerID string) error
 	SetTriggerCheckLock(triggerID string) (bool, error)
 

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -120,7 +120,7 @@ func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
-// CleanupOutdatedMetrics mocks base method.
+// CleanUpOutdatedMetrics mocks base method.
 func (m *MockDatabase) CleanUpOutdatedMetrics(arg0 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanUpOutdatedMetrics", arg0)
@@ -128,8 +128,8 @@ func (m *MockDatabase) CleanUpOutdatedMetrics(arg0 time.Duration) error {
 	return ret0
 }
 
-// CleanupOutdatedMetrics indicates an expected call of CleanupOutdatedMetrics.
-func (mr *MockDatabaseMockRecorder) CleanupOutdatedMetrics(arg0 interface{}) *gomock.Call {
+// CleanUpOutdatedMetrics indicates an expected call of CleanUpOutdatedMetrics.
+func (mr *MockDatabaseMockRecorder) CleanUpOutdatedMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpOutdatedMetrics", reflect.TypeOf((*MockDatabase)(nil).CleanUpOutdatedMetrics), arg0)
 }
@@ -972,6 +972,18 @@ func (m *MockDatabase) PushNotificationEvent(arg0 *moira.NotificationEvent, arg1
 func (mr *MockDatabaseMockRecorder) PushNotificationEvent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushNotificationEvent", reflect.TypeOf((*MockDatabase)(nil).PushNotificationEvent), arg0, arg1)
+}
+
+// ReleaseTriggerCheckLock mocks base method.
+func (m *MockDatabase) ReleaseTriggerCheckLock(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ReleaseTriggerCheckLock", arg0)
+}
+
+// ReleaseTriggerCheckLock indicates an expected call of ReleaseTriggerCheckLock.
+func (mr *MockDatabaseMockRecorder) ReleaseTriggerCheckLock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseTriggerCheckLock", reflect.TypeOf((*MockDatabase)(nil).ReleaseTriggerCheckLock), arg0)
 }
 
 // RemoveAllNotificationEvents mocks base method.


### PR DESCRIPTION
This PR fixes an issue with infinite loop on setting trigger to maintenance. The solution is the using of trigger locks, which are already part of other trigger related functions like `saveTrigger` and `deleteTriggerMetrics`.