### PR TITLE
Added into filter drop_metrics_ttl attribute

### DIFF
--- a/cmd/filter/config.go
+++ b/cmd/filter/config.go
@@ -26,6 +26,8 @@ type filterConfig struct {
 	MaxParallelMatches int `yaml:"max_parallel_matches"`
 	// Period in which patterns will be reloaded from Redis.
 	PatternsUpdatePeriod string `yaml:"patterns_update_period"`
+	// DropMetricsTTL this is time window how older metric we can get from now.
+	DropMetricsTTL string `yaml:"drop_metrics_ttl"`
 }
 
 func getDefault() config {
@@ -46,6 +48,7 @@ func getDefault() config {
 			CacheCapacity:        10, //nolint
 			MaxParallelMatches:   0,
 			PatternsUpdatePeriod: "1s",
+			DropMetricsTTL:       "1h",
 		},
 		Telemetry: cmd.TelemetryConfig{
 			Listen: ":8094",

--- a/cmd/filter/main.go
+++ b/cmd/filter/main.go
@@ -118,7 +118,7 @@ func main() {
 	}
 	lineChan := listener.Listen()
 
-	patternMatcher := patterns.NewMatcher(logger, filterMetrics, patternStorage)
+	patternMatcher := patterns.NewMatcher(logger, filterMetrics, patternStorage, to.Duration(config.Filter.DropMetricsTTL))
 	metricsChan := patternMatcher.Start(config.Filter.MaxParallelMatches, lineChan)
 
 	// Start metrics matcher

--- a/database/redis/metric_test.go
+++ b/database/redis/metric_test.go
@@ -339,6 +339,7 @@ func TestRemoveMetricValues(t *testing.T) {
 func TestMetricSubscription(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")
 	dataBase := NewTestDatabase(logger)
+
 	dataBase.Flush()
 	defer dataBase.Flush()
 	metric1 := "my.test.super.metric"
@@ -392,10 +393,13 @@ func TestMetricSubscription(t *testing.T) {
 			}
 		})
 
-		dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric1: met1}) //nolint
-		dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric2: met2}) //nolint
+		err = dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric1: met1})
+		So(err, ShouldBeNil)
+		err = dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric2: met2})
+		So(err, ShouldBeNil)
 		tomb1.Kill(nil)
-		tomb1.Wait() //nolint
+		err = tomb1.Wait()
+		So(err, ShouldBeNil)
 
 		So(numberOfChecks, ShouldEqual, 3)
 	})
@@ -454,11 +458,13 @@ func TestCleanupOutdatedMetrics(t *testing.T) {
 	dataBase.Flush()
 	defer dataBase.Flush()
 
-	const metric1 = "my.test.super.metric"
-	const metric2 = "my.test.super.metric2"
-	const pattern = "my.test.*.metric*"
-
 	Convey("Given 2 metrics with 2 values older then 1 minute and 2 values younger then 1 minute", t, func() {
+		const (
+			metric1 = "my.test.super.metric"
+			metric2 = "my.test.super.metric2"
+			pattern = "my.test.*.metric*"
+		)
+
 		tsOlder1 := time.Now().UTC().Add(-80 * time.Second).Unix()
 		tsOlder2 := time.Now().UTC().Add(-70 * time.Second).Unix()
 		tsYounger1 := time.Now().UTC().Add(-50 * time.Second).Unix()

--- a/filter/matched_metrics/metrics.go
+++ b/filter/matched_metrics/metrics.go
@@ -21,7 +21,13 @@ type MetricsMatcher struct {
 }
 
 // NewMetricsMatcher creates new MetricsMatcher
-func NewMetricsMatcher(metrics *metrics.FilterMetrics, logger moira.Logger, database moira.Database, cacheStorage *filter.Storage, cacheCapacity int) *MetricsMatcher {
+func NewMetricsMatcher(
+	metrics *metrics.FilterMetrics,
+	logger moira.Logger,
+	database moira.Database,
+	cacheStorage *filter.Storage,
+	cacheCapacity int,
+) *MetricsMatcher {
 	return &MetricsMatcher{
 		metrics:       metrics,
 		logger:        logger,

--- a/filter/metrics_parser.go
+++ b/filter/metrics_parser.go
@@ -94,6 +94,11 @@ func (metric ParsedMetric) IsTagged() bool {
 	return len(metric.Labels) > 0
 }
 
+// IsTooOld checks that metric is old to parse it.
+func (metric ParsedMetric) IsTooOld(maxTTL time.Duration, now time.Time) bool {
+	return moira.Int64ToTime(metric.Timestamp).Add(maxTTL).Before(now)
+}
+
 func parseNameAndLabels(metricBytes []byte) (string, map[string]string, error) {
 	metricBytesScanner := moira.NewBytesScanner(metricBytes, ';')
 	if !metricBytesScanner.HasNext() {

--- a/filter/metrics_parser_test.go
+++ b/filter/metrics_parser_test.go
@@ -204,3 +204,23 @@ func TestRestoreMetricStringByNameAndLabels(t *testing.T) {
 		})
 	})
 }
+
+func TestParsedMetric_IsTooOld(t *testing.T) {
+	now := time.Date(2022, 6, 16, 10, 0, 0, 0, time.UTC)
+	maxTTL := time.Hour
+
+	Convey("When metric is old, return true", t, func() {
+		metric := ParsedMetric{
+			Name:      "too old metric",
+			Timestamp: time.Date(2022, 6, 16, 8, 59, 0, 0, time.UTC).Unix(),
+		}
+		So(metric.IsTooOld(maxTTL, now), ShouldBeTrue)
+	})
+	Convey("When metric is young, return false", t, func() {
+		metric := ParsedMetric{
+			Name:      "too old metric",
+			Timestamp: time.Date(2022, 6, 16, 9, 00, 0, 0, time.UTC).Unix(),
+		}
+		So(metric.IsTooOld(maxTTL, now), ShouldBeFalse)
+	})
+}

--- a/filter/patterns_storage_test.go
+++ b/filter/patterns_storage_test.go
@@ -3,6 +3,9 @@ package filter
 import (
 	"fmt"
 	"testing"
+	"time"
+
+	mock_clock "github.com/moira-alert/moira/mock/clock"
 
 	"github.com/golang/mock/gomock"
 	logging "github.com/moira-alert/moira/logging/zerolog_adapter"
@@ -22,24 +25,27 @@ func TestProcessIncomingMetric(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	database := mock_moira_alert.NewMockDatabase(mockCtrl)
-	logger, _ := logging.GetLogger("Scheduler")
+	logger, _ := logging.ConfigureLog("stdout", "warn", "test", true)
 
 	Convey("Create new pattern storage, GetPatterns returns error, should error", t, func() {
 		database.EXPECT().GetPatterns().Return(nil, fmt.Errorf("some error here"))
-		metrics := metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
-		_, err := NewPatternStorage(database, metrics, logger)
+		filterMetrics := metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
+		_, err := NewPatternStorage(database, filterMetrics, logger)
 		So(err, ShouldBeError, fmt.Errorf("some error here"))
 	})
 
 	database.EXPECT().GetPatterns().Return(testPatterns, nil)
 	patternsStorage, err := NewPatternStorage(database, metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry()), logger)
+	systemClock := mock_clock.NewMockClock(mockCtrl)
+	systemClock.EXPECT().Now().Return(time.Date(2009, 2, 13, 23, 31, 30, 0, time.UTC)).AnyTimes()
+	patternsStorage.clock = systemClock
 
 	Convey("Create new pattern storage, should no error", t, func() {
 		So(err, ShouldBeEmpty)
 	})
 
 	Convey("When invalid metric arrives, should be properly counted", t, func() {
-		matchedMetrics := patternsStorage.ProcessIncomingMetric(nil)
+		matchedMetrics := patternsStorage.ProcessIncomingMetric(nil, time.Hour)
 		So(matchedMetrics, ShouldBeNil)
 		So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 		So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 0)
@@ -49,7 +55,7 @@ func TestProcessIncomingMetric(t *testing.T) {
 	Convey("When valid non-matching metric arrives", t, func() {
 		patternsStorage.metrics = metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
 		Convey("For plain metric", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
@@ -57,7 +63,7 @@ func TestProcessIncomingMetric(t *testing.T) {
 		})
 
 		Convey("For tag metric", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used;tag1=val1 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used;tag1=val1 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
@@ -65,7 +71,7 @@ func TestProcessIncomingMetric(t *testing.T) {
 		})
 
 		Convey("For plain metric which has the same pattern like name tag in tagged pattern", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("tag.metric 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("tag.metric 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
@@ -73,7 +79,7 @@ func TestProcessIncomingMetric(t *testing.T) {
 		})
 
 		Convey("For tagged metric which body matches plain metric trigger pattern", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("plain.metric;tag1=val1 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("plain.metric;tag1=val1 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
@@ -81,10 +87,18 @@ func TestProcessIncomingMetric(t *testing.T) {
 		})
 
 		Convey("For plain metric which matches to tagged pattern which contains only name tag", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("name.metric 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("name.metric 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
+		})
+
+		Convey("For too old metric should miss it", func() {
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("disk.used 12 123"), time.Hour)
+			So(matchedMetrics, ShouldBeNil)
+			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
+			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 0)
 			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 0)
 		})
 	})
@@ -92,14 +106,14 @@ func TestProcessIncomingMetric(t *testing.T) {
 	Convey("When valid matching metric arrives", t, func() {
 		patternsStorage.metrics = metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
 		Convey("For plain metric", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("plain.metric 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("plain.metric 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldNotBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.MatchingMetricsReceived.Count(), ShouldEqual, 1)
 		})
 		Convey("For tagged metric", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("tag.metric;tag1=val1 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("tag.metric;tag1=val1 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldNotBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
@@ -107,7 +121,7 @@ func TestProcessIncomingMetric(t *testing.T) {
 		})
 
 		Convey("For tagged metric which matches to tagged pattern which contains only name tag", func() {
-			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("name.metric;tag1=val1 12 1234567890"))
+			matchedMetrics := patternsStorage.ProcessIncomingMetric([]byte("name.metric;tag1=val1 12 1234567890"), time.Hour)
 			So(matchedMetrics, ShouldNotBeNil)
 			So(patternsStorage.metrics.TotalMetricsReceived.Count(), ShouldEqual, 1)
 			So(patternsStorage.metrics.ValidMetricsReceived.Count(), ShouldEqual, 1)
@@ -118,7 +132,8 @@ func TestProcessIncomingMetric(t *testing.T) {
 	Convey("When ten valid metrics arrive match timer should be updated", t, func() {
 		patternsStorage.metrics = metrics.ConfigureFilterMetrics(metrics.NewDummyRegistry())
 		for i := 0; i < 10; i++ {
-			patternsStorage.ProcessIncomingMetric([]byte("cpu.used 12 1234567890"))
+			// 1234567890 = Saturday, 14 February 2009 г., 4:31:30 GMT+05:00
+			patternsStorage.ProcessIncomingMetric([]byte("cpu.used 12 1234567890"), time.Hour)
 		}
 		So(patternsStorage.metrics.MatchingTimer.Count(), ShouldEqual, 1)
 	})

--- a/log_fields.go
+++ b/log_fields.go
@@ -1,13 +1,14 @@
 package moira
 
 const (
-	LogFieldNameCheckpoint     = "moira.checkpoint"
-	LogFieldNameContactID      = "moira.contact.id"
-	LogFieldNameContactType    = "moira.contact.type"
-	LogFieldNameContactValue   = "moira.contact.value"
-	LogFieldNameContext        = "moira.context"
-	LogFieldNameMetricName     = "moira.metric.name"
-	LogFieldNameTriggerID      = "moira.trigger.id"
-	LogFieldNameTriggerName    = "moira.trigger.name"
-	LogFieldNameSubscriptionID = "moira.subscription.id"
+	LogFieldNameCheckpoint      = "moira.checkpoint"
+	LogFieldNameContactID       = "moira.contact.id"
+	LogFieldNameContactType     = "moira.contact.type"
+	LogFieldNameContactValue    = "moira.contact.value"
+	LogFieldNameContext         = "moira.context"
+	LogFieldNameMetricName      = "moira.metric.name"
+	LogFieldNameMetricTimestamp = "moira.metric.timestamp"
+	LogFieldNameTriggerID       = "moira.trigger.id"
+	LogFieldNameTriggerName     = "moira.trigger.name"
+	LogFieldNameSubscriptionID  = "moira.subscription.id"
 )

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -86,7 +86,7 @@ type prometheusTimer struct {
 }
 
 func (source *prometheusTimer) UpdateSince(ts time.Time) {
-	source.histogram.Observe(float64(int64(time.Since(ts))))
+	source.histogram.Observe(float64(time.Since(ts)))
 	atomic.AddInt64(&source.count, 1)
 }
 

--- a/perfomance_tests/filter/performance_test_utils.go
+++ b/perfomance_tests/filter/performance_test_utils.go
@@ -53,7 +53,7 @@ func runBenchmark(b *testing.B, patternsStorage *filter.PatternStorage, testMetr
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testMetricLine := (*testMetricsLines)[rand.Intn(len(*testMetricsLines))]
-		patternsStorage.ProcessIncomingMetric([]byte(testMetricLine))
+		patternsStorage.ProcessIncomingMetric([]byte(testMetricLine), time.Hour)
 	}
 }
 

--- a/support/trigger.go
+++ b/support/trigger.go
@@ -79,7 +79,12 @@ func HandlePushTrigger(logger moira.Logger, database moira.Database, trigger *mo
 	return nil
 }
 
-func HandlePushTriggerMetrics(logger moira.Logger, database moira.Database, triggerID string, patternsMetrics []dto.PatternMetrics) error {
+func HandlePushTriggerMetrics(
+	logger moira.Logger,
+	database moira.Database,
+	triggerID string,
+	patternsMetrics []dto.PatternMetrics,
+) error {
 	logger.Info("Save trigger metrics")
 
 	buffer := make(map[string]*moira.MatchedMetric, len(patternsMetrics))


### PR DESCRIPTION
If metric_timestamp + drop_metrics_ttl before now, we don`t save this metric. In other way we will use this metric for further work.