### PR TITLE
feat: Added retry logic to remote api request

### DIFF
--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -91,7 +91,7 @@ func getTriggerFromRequest(request *http.Request) (*dto.Trigger, *api.ErrorRespo
 			return nil, api.ErrorInvalidRequest(err)
 		case remote.ErrRemoteTriggerResponse:
 			response := api.ErrorRemoteServerUnavailable(err)
-			middleware.GetLoggerEntry(request).Error("%s : %s : %s", response.StatusText, response.ErrorText, err)
+			middleware.GetLoggerEntry(request).Errorf("%s : %s : %s", response.StatusText, response.ErrorText, err)
 			return nil, response
 		default:
 			return nil, api.ErrorInternalServer(err)

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -14,3 +14,8 @@ func NewSystemClock() *SystemClock {
 func (t *SystemClock) Now() time.Time {
 	return time.Now().UTC()
 }
+
+// Sleep pauses the current goroutine for at least the passed duration
+func (t *SystemClock) Sleep(duration time.Duration) {
+	time.Sleep(duration)
+}

--- a/cmd/checker/config.go
+++ b/cmd/checker/config.go
@@ -92,9 +92,11 @@ func getDefault() config {
 			Pprof: cmd.ProfilerConfig{Enabled: false},
 		},
 		Remote: cmd.RemoteConfig{
-			CheckInterval: "60s",
-			Timeout:       "60s",
-			MetricsTTL:    "7d",
+			CheckInterval:           "60s",
+			Timeout:                 "60s",
+			MetricsTTL:              "168h",
+			HealthCheckTimeout:      "60s",
+			HealthCheckRetrySeconds: "1 1",
 		},
 	}
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -227,4 +227,5 @@ type PlotTheme interface {
 // Clock is an interface to work with Time.
 type Clock interface {
 	Now() time.Time
+	Sleep(duration time.Duration)
 }

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -16,8 +16,11 @@ remote:
   enabled: true
   url: "http://graphite:80/render"
   check_interval: 60s
+  metrics_ttl: 168h
   timeout: 60s
-  metrics_ttl: 7d
+  retry_seconds: 1 1 1
+  health_check_timeout: 6s
+  health_check_retry_seconds: 1 1 1
 checker:
   nodata_check_interval: 60s
   check_interval: 10s

--- a/metric_source/remote/config.go
+++ b/metric_source/remote/config.go
@@ -4,13 +4,16 @@ import "time"
 
 // Config represents config from remote storage
 type Config struct {
-	URL           string
-	CheckInterval time.Duration
-	MetricsTTL    time.Duration
-	Timeout       time.Duration
-	User          string
-	Password      string
-	Enabled       bool
+	URL                     string
+	CheckInterval           time.Duration
+	MetricsTTL              time.Duration
+	Timeout                 time.Duration
+	RetrySeconds            []time.Duration
+	HealthCheckTimeout      time.Duration
+	HealthCheckRetrySeconds []time.Duration
+	User                    string
+	Password                string
+	Enabled                 bool
 }
 
 // isEnabled checks that remote config is enabled (url is defined and enabled flag is set)

--- a/metric_source/remote/remote_test.go
+++ b/metric_source/remote/remote_test.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+
+	mock_clock "github.com/moira-alert/moira/mock/clock"
 
 	metricSource "github.com/moira-alert/moira/metric_source"
 	. "github.com/smartystreets/goconvey/convey"
@@ -26,20 +31,79 @@ func TestIsConfigured(t *testing.T) {
 }
 
 func TestIsRemoteAvailable(t *testing.T) {
-	Convey("Is available", t, func() {
-		server := createServer([]byte("Some string"), http.StatusOK)
-		remote := Remote{client: server.Client(), config: &Config{URL: server.URL}}
-		isAvailable, err := remote.IsRemoteAvailable()
-		So(isAvailable, ShouldBeTrue)
-		So(err, ShouldBeEmpty)
+	mockCtrl := gomock.NewController(t)
+	systemClock := mock_clock.NewMockClock(mockCtrl)
+	systemClock.EXPECT().Sleep(time.Second).Times(0)
+	testConfigs := []Config{
+		{},
+		{HealthCheckRetrySeconds: []time.Duration{time.Second}},
+		{HealthCheckRetrySeconds: []time.Duration{time.Second}},
+		{HealthCheckRetrySeconds: []time.Duration{time.Second, time.Second}},
+		{HealthCheckRetrySeconds: []time.Duration{time.Second, time.Second}},
+		{HealthCheckRetrySeconds: []time.Duration{time.Second, time.Second, time.Second}},
+	}
+	body := []byte("Some string")
+
+	Convey("Given server returns OK response the remote is available", t, func() {
+		server := createServer(body, http.StatusOK)
+		for _, config := range testConfigs {
+			config.URL = server.URL
+			remote := Remote{client: server.Client(), config: &config}
+			isAvailable, err := remote.IsRemoteAvailable()
+			So(isAvailable, ShouldBeTrue)
+			So(err, ShouldBeEmpty)
+		}
 	})
 
-	Convey("Not available", t, func() {
-		server := createServer([]byte("Some string"), http.StatusInternalServerError)
-		remote := Remote{client: server.Client(), config: &Config{URL: server.URL}}
-		isAvailable, err := remote.IsRemoteAvailable()
-		So(isAvailable, ShouldBeFalse)
-		So(err, ShouldResemble, fmt.Errorf("bad response status %d: %s", http.StatusInternalServerError, "Some string"))
+	Convey("Given server returns Remote Unavailable responses permanently", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			server := createTestServer(TestResponse{body, statusCode})
+
+			Convey(fmt.Sprintf(
+				"request failed with %d response status code and remote is unavailable", statusCode,
+			), func() {
+				remote := Remote{client: server.Client()}
+				for _, config := range testConfigs {
+					config.URL = server.URL
+					remote.config = &config
+					systemClock := mock_clock.NewMockClock(mockCtrl)
+					systemClock.EXPECT().Sleep(time.Second).Times(len(config.HealthCheckRetrySeconds))
+					remote.clock = systemClock
+
+					isAvailable, err := remote.IsRemoteAvailable()
+					So(err, ShouldResemble, fmt.Errorf(
+						"the remote server is not available. Response status %d: %s", statusCode, string(body),
+					))
+					So(isAvailable, ShouldBeFalse)
+				}
+			})
+		}
+	})
+
+	Convey("Given server returns Remote Unavailable response temporary", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			Convey(fmt.Sprintf(
+				"the remote is available with retry after %d response", statusCode,
+			), func() {
+				for _, config := range testConfigs {
+					if len(config.HealthCheckRetrySeconds) == 0 {
+						continue
+					}
+					server := createTestServer(
+						TestResponse{body, statusCode},
+						TestResponse{body, http.StatusOK},
+					)
+					config.URL = server.URL
+					systemClock := mock_clock.NewMockClock(mockCtrl)
+					systemClock.EXPECT().Sleep(time.Second).Times(1)
+					remote := Remote{client: server.Client(), config: &config, clock: systemClock}
+
+					isAvailable, err := remote.IsRemoteAvailable()
+					So(err, ShouldBeNil)
+					So(isAvailable, ShouldBeTrue)
+				}
+			})
+		}
 	})
 }
 
@@ -47,6 +111,16 @@ func TestFetch(t *testing.T) {
 	var from int64 = 300
 	var until int64 = 500
 	target := "foo.bar" //nolint
+	testConfigs := []Config{
+		{},
+		{RetrySeconds: []time.Duration{time.Second}},
+		{RetrySeconds: []time.Duration{time.Second}},
+		{RetrySeconds: []time.Duration{time.Second, time.Second}},
+		{RetrySeconds: []time.Duration{time.Second, time.Second}},
+		{RetrySeconds: []time.Duration{time.Second, time.Second, time.Second}},
+	}
+	mockCtrl := gomock.NewController(t)
+	validBody := []byte("[{\"Target\": \"t1\",\"DataPoints\":[[1,2],[3,4]]}]")
 
 	Convey("Request success but body is invalid", t, func() {
 		server := createServer([]byte("[]"), http.StatusOK)
@@ -62,21 +136,90 @@ func TestFetch(t *testing.T) {
 		result, err := remote.Fetch(target, from, until, false)
 		So(result, ShouldBeEmpty)
 		So(err.Error(), ShouldResemble, "invalid character 'S' looking for beginning of value")
+		_, ok := err.(ErrRemoteTriggerResponse)
+		So(ok, ShouldBeTrue)
 	})
 
 	Convey("Fail request with InternalServerError", t, func() {
 		server := createServer([]byte("Some string"), http.StatusInternalServerError)
-		remote := Remote{client: server.Client(), config: &Config{URL: server.URL}}
-		result, err := remote.Fetch(target, from, until, false)
-		So(result, ShouldBeEmpty)
-		So(err.Error(), ShouldResemble, fmt.Sprintf("bad response status %d: %s", http.StatusInternalServerError, "Some string"))
+		remote := Remote{client: server.Client()}
+		for _, config := range testConfigs {
+			config.URL = server.URL
+			remote.config = &config
+			result, err := remote.Fetch(target, from, until, false)
+			So(result, ShouldBeEmpty)
+			So(err.Error(), ShouldResemble, fmt.Sprintf("bad response status %d: %s", http.StatusInternalServerError, "Some string"))
+			_, ok := err.(ErrRemoteTriggerResponse)
+			So(ok, ShouldBeTrue)
+		}
 	})
 
-	Convey("Fail make request", t, func() {
+	Convey("Client calls bad url", t, func() {
 		url := "💩%$&TR"
-		remote := Remote{config: &Config{URL: url}}
-		result, err := remote.Fetch(target, from, until, false)
-		So(result, ShouldBeEmpty)
-		So(err.Error(), ShouldResemble, "parse \"💩%$&TR\": invalid URL escape \"%$&\"")
+		for _, config := range testConfigs {
+			config.URL = url
+			remote := Remote{config: &config}
+			result, err := remote.Fetch(target, from, until, false)
+			So(result, ShouldBeEmpty)
+			So(err.Error(), ShouldResemble, "parse \"💩%$&TR\": invalid URL escape \"%$&\"")
+			_, ok := err.(ErrRemoteTriggerResponse)
+			So(ok, ShouldBeTrue)
+		}
+	})
+
+	Convey("Given server returns Remote Unavailable responses permanently", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			server := createTestServer(TestResponse{validBody, statusCode})
+
+			Convey(fmt.Sprintf(
+				"request failed with %d response status code and remote is unavailable", statusCode,
+			), func() {
+				remote := Remote{client: server.Client()}
+				for _, config := range testConfigs {
+					config.URL = server.URL
+					remote.config = &config
+					systemClock := mock_clock.NewMockClock(mockCtrl)
+					systemClock.EXPECT().Sleep(time.Second).Times(len(config.RetrySeconds))
+					remote.clock = systemClock
+
+					result, err := remote.Fetch(target, from, until, false)
+					So(err, ShouldResemble, ErrRemoteUnavailable{
+						InternalError: fmt.Errorf(
+							"the remote server is not available. Response status %d: %s", statusCode, string(validBody),
+						), Target: target,
+					})
+					So(result, ShouldBeNil)
+				}
+			})
+		}
+	})
+
+	Convey("Given server returns Remote Unavailable response temporary", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			Convey(fmt.Sprintf(
+				"the remote is available with retry after %d response", statusCode,
+			), func() {
+				for _, config := range testConfigs {
+					if len(config.RetrySeconds) == 0 {
+						continue
+					}
+					server := createTestServer(
+						TestResponse{validBody, statusCode},
+						TestResponse{validBody, http.StatusOK},
+					)
+					config.URL = server.URL
+					systemClock := mock_clock.NewMockClock(mockCtrl)
+					systemClock.EXPECT().Sleep(time.Second).Times(1)
+					remote := Remote{client: server.Client(), config: &config, clock: systemClock}
+
+					result, err := remote.Fetch(target, from, until, false)
+					So(err, ShouldBeNil)
+					So(result, ShouldNotBeNil)
+					metricsData := result.GetMetricsData()
+					So(len(metricsData), ShouldEqual, 1)
+					So(metricsData[0].Name, ShouldEqual, "t1")
+				}
+			})
+		}
 	})
 }

--- a/metric_source/remote/request_test.go
+++ b/metric_source/remote/request_test.go
@@ -5,6 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	mock_clock "github.com/moira-alert/moira/mock/clock"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -54,8 +58,9 @@ func TestMakeRequest(t *testing.T) {
 		server := createServer(body, http.StatusOK)
 		remote := Remote{client: server.Client(), config: &Config{URL: server.URL}}
 		request, _ := remote.prepareRequest(from, until, target)
-		actual, err := remote.makeRequest(request)
+		actual, isRemoteAvailable, err := remote.makeRequest(request)
 		So(err, ShouldBeNil)
+		So(isRemoteAvailable, ShouldBeTrue)
 		So(actual, ShouldResemble, body)
 	})
 
@@ -63,18 +68,188 @@ func TestMakeRequest(t *testing.T) {
 		server := createServer(body, http.StatusInternalServerError)
 		remote := Remote{client: server.Client(), config: &Config{URL: server.URL}}
 		request, _ := remote.prepareRequest(from, until, target)
-		actual, err := remote.makeRequest(request)
+		actual, isRemoteAvailable, err := remote.makeRequest(request)
 		So(err, ShouldResemble, fmt.Errorf("bad response status %d: %s", http.StatusInternalServerError, string(body)))
+		So(isRemoteAvailable, ShouldBeTrue)
 		So(actual, ShouldResemble, body)
 	})
 
 	Convey("Client calls bad url", t, func() {
 		server := createServer(body, http.StatusOK)
-		remote := Remote{client: server.Client(), config: &Config{URL: "http://bad/"}}
+		client := server.Client()
+		client.Timeout = time.Millisecond
+		remote := Remote{client: client, config: &Config{URL: "http://bad/"}}
 		request, _ := remote.prepareRequest(from, until, target)
-		actual, err := remote.makeRequest(request)
+		actual, isRemoteAvailable, err := remote.makeRequest(request)
 		So(err, ShouldNotBeEmpty)
+		So(isRemoteAvailable, ShouldBeFalse)
 		So(actual, ShouldBeEmpty)
+	})
+
+	Convey("Client returns status Remote Unavailable status codes", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			server := createServer(body, statusCode)
+			remote := Remote{client: server.Client(), config: &Config{URL: server.URL}}
+			request, _ := remote.prepareRequest(from, until, target)
+			actual, isRemoteAvailable, err := remote.makeRequest(request)
+			So(err, ShouldResemble, fmt.Errorf(
+				"the remote server is not available. Response status %d: %s", statusCode, string(body),
+			))
+			So(isRemoteAvailable, ShouldBeFalse)
+			So(actual, ShouldResemble, body)
+		}
+	})
+}
+
+func TestMakeRequestWithRetries(t *testing.T) {
+	var from int64 = 300
+	var until int64 = 500
+	target := "foo.bar"
+	body := []byte("Some string")
+	testConfigs := []Config{
+		{},
+		{RetrySeconds: []time.Duration{time.Second}},
+		{RetrySeconds: []time.Duration{time.Second}},
+		{RetrySeconds: []time.Duration{time.Second, time.Second}},
+		{RetrySeconds: []time.Duration{time.Second, time.Second}},
+		{RetrySeconds: []time.Duration{time.Second, time.Second, time.Second}},
+	}
+	mockCtrl := gomock.NewController(t)
+
+	Convey("Given server returns OK response", t, func() {
+		server := createTestServer(TestResponse{body, http.StatusOK})
+		systemClock := mock_clock.NewMockClock(mockCtrl)
+		systemClock.EXPECT().Sleep(time.Second).Times(0)
+
+		Convey("request is successful", func() {
+			remote := Remote{client: server.Client(), clock: systemClock}
+
+			for _, config := range testConfigs {
+				config.URL = server.URL
+				remote.config = &config
+				request, _ := remote.prepareRequest(from, until, target)
+				actual, isRemoteAvailable, err := remote.makeRequestWithRetries(
+					request,
+					remote.config.Timeout,
+					remote.config.RetrySeconds,
+				)
+				So(err, ShouldBeNil)
+				So(isRemoteAvailable, ShouldBeTrue)
+				So(actual, ShouldResemble, body)
+			}
+		})
+	})
+
+	Convey("Given server returns 500 response", t, func() {
+		server := createTestServer(TestResponse{body, http.StatusInternalServerError})
+		systemClock := mock_clock.NewMockClock(mockCtrl)
+		systemClock.EXPECT().Sleep(time.Second).Times(0)
+
+		Convey("request failed with 500 response and remote is available", func() {
+			remote := Remote{client: server.Client(), clock: systemClock}
+
+			for _, config := range testConfigs {
+				config.URL = server.URL
+				remote.config = &config
+				request, _ := remote.prepareRequest(from, until, target)
+				actual, isRemoteAvailable, err := remote.makeRequestWithRetries(
+					request,
+					remote.config.Timeout,
+					remote.config.RetrySeconds,
+				)
+				So(err, ShouldResemble, fmt.Errorf("bad response status %d: %s", http.StatusInternalServerError, string(body)))
+				So(isRemoteAvailable, ShouldBeTrue)
+				So(actual, ShouldResemble, body)
+			}
+		})
+	})
+
+	Convey("Given client calls bad url", t, func() {
+		server := createTestServer(TestResponse{body, http.StatusOK})
+
+		Convey("request failed and remote is unavailable", func() {
+			remote := Remote{client: server.Client()}
+			for _, config := range testConfigs {
+				config.URL = "http://bad/"
+				remote.config = &config
+				systemClock := mock_clock.NewMockClock(mockCtrl)
+				systemClock.EXPECT().Sleep(time.Second).Times(len(config.RetrySeconds))
+				remote.clock = systemClock
+
+				request, _ := remote.prepareRequest(from, until, target)
+				actual, isRemoteAvailable, err := remote.makeRequestWithRetries(
+					request,
+					time.Millisecond,
+					remote.config.RetrySeconds,
+				)
+				So(err, ShouldNotBeEmpty)
+				So(isRemoteAvailable, ShouldBeFalse)
+				So(actual, ShouldBeEmpty)
+			}
+		})
+	})
+
+	Convey("Given server returns Remote Unavailable responses permanently", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			server := createTestServer(TestResponse{body, statusCode})
+
+			Convey(fmt.Sprintf(
+				"request failed with %d response status code and remote is unavailable", statusCode,
+			), func() {
+				remote := Remote{client: server.Client()}
+				for _, config := range testConfigs {
+					config.URL = server.URL
+					remote.config = &config
+					systemClock := mock_clock.NewMockClock(mockCtrl)
+					systemClock.EXPECT().Sleep(time.Second).Times(len(config.RetrySeconds))
+					remote.clock = systemClock
+
+					request, _ := remote.prepareRequest(from, until, target)
+					actual, isRemoteAvailable, err := remote.makeRequestWithRetries(
+						request,
+						remote.config.Timeout,
+						remote.config.RetrySeconds,
+					)
+					So(err, ShouldResemble, fmt.Errorf(
+						"the remote server is not available. Response status %d: %s", statusCode, string(body),
+					))
+					So(isRemoteAvailable, ShouldBeFalse)
+					So(actual, ShouldBeNil)
+				}
+			})
+		}
+	})
+
+	Convey("Given server returns Remote Unavailable response temporary", t, func() {
+		for _, statusCode := range remoteUnavailableStatusCodes {
+			Convey(fmt.Sprintf(
+				"request is successful with retry after %d response and remote is available", statusCode,
+			), func() {
+				for _, config := range testConfigs {
+					if len(config.RetrySeconds) == 0 {
+						continue
+					}
+					server := createTestServer(
+						TestResponse{body, statusCode},
+						TestResponse{body, http.StatusOK},
+					)
+					config.URL = server.URL
+					systemClock := mock_clock.NewMockClock(mockCtrl)
+					systemClock.EXPECT().Sleep(time.Second).Times(1)
+					remote := Remote{client: server.Client(), config: &config, clock: systemClock}
+
+					request, _ := remote.prepareRequest(from, until, target)
+					actual, isRemoteAvailable, err := remote.makeRequestWithRetries(
+						request,
+						remote.config.Timeout,
+						remote.config.RetrySeconds,
+					)
+					So(err, ShouldBeNil)
+					So(isRemoteAvailable, ShouldBeTrue)
+					So(actual, ShouldResemble, body)
+				}
+			})
+		}
 	})
 }
 
@@ -83,4 +258,43 @@ func createServer(body []byte, statusCode int) *httptest.Server {
 		rw.WriteHeader(statusCode)
 		rw.Write(body) //nolint
 	}))
+}
+
+func createTestServer(testResponses ...TestResponse) *httptest.Server {
+	responseWriter := NewTestResponseWriter(testResponses)
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		response := responseWriter.GetResponse()
+		rw.WriteHeader(response.statusCode)
+		rw.Write(response.body) //nolint
+	}))
+}
+
+type TestResponse struct {
+	body       []byte
+	statusCode int
+}
+
+type TestResponseWriter struct {
+	responses []TestResponse
+	count     int
+}
+
+func NewTestResponseWriter(testResponses []TestResponse) *TestResponseWriter {
+	responseWriter := new(TestResponseWriter)
+	responseWriter.responses = testResponses
+	responseWriter.count = 0
+	return responseWriter
+}
+
+func (responseWriter *TestResponseWriter) GetResponse() TestResponse {
+	response := responseWriter.responses[responseWriter.count%len(responseWriter.responses)]
+	responseWriter.count++
+	return response
+}
+
+var remoteUnavailableStatusCodes = []int{
+	http.StatusUnauthorized,
+	http.StatusBadGateway,
+	http.StatusServiceUnavailable,
+	http.StatusGatewayTimeout,
 }

--- a/mock/clock/clock.go
+++ b/mock/clock/clock.go
@@ -47,3 +47,15 @@ func (mr *MockClockMockRecorder) Now() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Now", reflect.TypeOf((*MockClock)(nil).Now))
 }
+
+// Sleep mocks base method.
+func (m *MockClock) Sleep(arg0 time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Sleep", arg0)
+}
+
+// Sleep indicates an expected call of Sleep.
+func (mr *MockClockMockRecorder) Sleep(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sleep", reflect.TypeOf((*MockClock)(nil).Sleep), arg0)
+}


### PR DESCRIPTION
# PR Summary

- New error type is added `ErrRemoteUnavailable`. This error is supposed to be used for cases when Remote API is unavailable, e.g. repetitively returns following errors: _401, 502, 503, 504, transport errors, timeouts_
- New config settings are added to `Remote` section in checker, api and notifier configs: 
    - RetrySeconds  `json: retry_seconds` - defines time intervals in seconds for retry calls for _errors above_, ex.: `'1 10 30'`, `'1 1`
    - HealthCheckTimeout `json: health_check_timeout` - defines timeout for calls for health check, ex.: `5s`
    - HealthCheckRetrySeconds `json: health_check_retry_seconds` defines time intervals in seconds for health check retry calls, ex.: `5 5`
- New method `makeRequestWithRetries` is added to perform calls with retries in case of getting errors from the list above. This method is applied in both health check call and fetching trigger metrics call.


# Future work
There will be follow-up [PR](https://github.com/moira-alert/moira/pull/765) for including logic of handling of `ErrRemoteUnavailable` error in trigger check processing and [PR](https://github.com/moira-alert/moira/pull/766) for adding new metric for monitoring of graphite unavailability
