### PR TITLE
Fixed error handling when getting metrics

### DIFF
--- a/metric_source/local/errors.go
+++ b/metric_source/local/errors.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ansel1/merry"
+
 	"github.com/go-graphite/carbonapi/expr/helper"
 )
 
@@ -33,7 +35,7 @@ func (err ErrUnknownFunction) Error() string {
 
 // isErrUnknownFunction checks error for carbonapi.errUnknownFunction
 func isErrUnknownFunction(err error) bool {
-	switch err.(type) {
+	switch merry.Unwrap(err).(type) {
 	case helper.ErrUnknownFunction:
 		return true
 	}


### PR DESCRIPTION
1. When carbon-api returns "no timeseries with that name", it [concatenates additional text into error](https://github.com/go-graphite/carbonapi/blob/main/expr/expr.go#L162). So we cannot compare error as "equal"
2. When  carbon-api returns "ErrUnknownFunction", it [wraps error with "merry.WithHTTPCode"](https://github.com/go-graphite/carbonapi/blob/main/expr/expr.go#L181). So, we need Unwrap error before compare it with helper.ErrUnknownFunction.