### PR TITLE
feat: Added specific metric for graphite unavailability check result

### DIFF
--- a/checker/worker/remote.go
+++ b/checker/worker/remote.go
@@ -48,6 +48,7 @@ func (worker *Checker) checkRemote() error {
 	remoteAvailable, err := source.(*remote.Remote).IsRemoteAvailable()
 	if !remoteAvailable {
 		worker.Logger.Infof("Remote API is unavailable. Stop checking remote triggers. Error: %s", err.Error())
+		worker.Metrics.RemoteAvailabilityCheckFailed.Mark(1)
 	} else {
 		worker.Logger.Debug("Checking remote triggers")
 		triggerIds, err := worker.Database.GetRemoteTriggerIDs()

--- a/metrics/checker.go
+++ b/metrics/checker.go
@@ -4,11 +4,12 @@ import "github.com/moira-alert/moira"
 
 // CheckerMetrics is a collection of metrics used in checker
 type CheckerMetrics struct {
-	LocalMetrics           *CheckMetrics
-	RemoteMetrics          *CheckMetrics
-	MetricEventsChannelLen Histogram
-	UnusedTriggersCount    Histogram
-	MetricEventsHandleTime Timer
+	LocalMetrics                  *CheckMetrics
+	RemoteMetrics                 *CheckMetrics
+	MetricEventsChannelLen        Histogram
+	UnusedTriggersCount           Histogram
+	MetricEventsHandleTime        Timer
+	RemoteAvailabilityCheckFailed Meter
 }
 
 // GetCheckMetrics return check metrics dependent on given trigger type
@@ -37,6 +38,7 @@ func ConfigureCheckerMetrics(registry Registry, remoteEnabled bool) *CheckerMetr
 	}
 	if remoteEnabled {
 		m.RemoteMetrics = configureCheckMetrics(registry, "remote")
+		m.RemoteAvailabilityCheckFailed = registry.NewMeter("remote", "unavailable")
 	}
 	return m
 }


### PR DESCRIPTION
# PR Summary

This PR adds a new internal Moira metric `moira.checker.remote.unavailable` which is supposed to show the number of graphite API call failures.
