### PR TITLE
Improved metrics cleanup cli

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -184,6 +184,11 @@ func main() { //nolint
 			log.Error(err)
 		}
 
+		err = handleCleanUpAbandonedPatternMetrics(dataBase)
+		if err != nil {
+			log.Error(err)
+		}
+
 		log.Info("Cleanup finished")
 	}
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -172,20 +172,26 @@ func main() { //nolint
 
 	if *cleanUpMetrics {
 		log := logger.String(moira.LogFieldNameContext, "cleanup")
-		log.Info("Cleanup outdated metrics started")
-		err := cleanUpOutdatedMetrics(confCleanup, dataBase)
+		log.Info("Cleanup started")
+
+		err := handleCleanUpOutdatedMetrics(confCleanup, dataBase)
 		if err != nil {
 			log.Error(err)
 		}
 
-		log.Info("Cleanup outdated metrics finished")
+		err = handleCleanUpAbandonedRetentions(dataBase)
+		if err != nil {
+			log.Error(err)
+		}
+
+		log.Info("Cleanup finished")
 	}
 
 	if *cleanUpLastCheck {
 		log := logger.String(moira.LogFieldNameContext, "cleanup")
 		log.Info("Cleanup abandoned triggers last checks started")
 
-		err := cleanUpAbandonedTriggerLastCheck(dataBase)
+		err := handleCleanUpAbandonedTriggerLastCheck(dataBase)
 		if err != nil {
 			log.Error(err)
 		}

--- a/cmd/cli/metrics.go
+++ b/cmd/cli/metrics.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moira-alert/moira"
 )
 
-func cleanUpOutdatedMetrics(config cleanupConfig, database moira.Database) error {
+func handleCleanUpOutdatedMetrics(config cleanupConfig, database moira.Database) error {
 	duration, err := time.ParseDuration(config.CleanupMetricsDuration)
 	if err != nil {
 		return err
@@ -20,24 +20,18 @@ func cleanUpOutdatedMetrics(config cleanupConfig, database moira.Database) error
 	return nil
 }
 
-func cleanUpAbandonedTriggerLastCheck(database moira.Database) error {
+func handleCleanUpAbandonedRetentions(database moira.Database) error {
+	return database.CleanUpAbandonedRetentions()
+}
+
+func handleCleanUpAbandonedTriggerLastCheck(database moira.Database) error {
 	return database.CleanUpAbandonedTriggerLastCheck()
 }
 
 func handleRemoveMetricsByPrefix(database moira.Database, prefix string) error {
-	err := database.RemoveMetricsByPrefix(prefix)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return database.RemoveMetricsByPrefix(prefix)
 }
 
 func handleRemoveAllMetrics(database moira.Database) error {
-	err := database.RemoveAllMetrics()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return database.RemoveAllMetrics()
 }

--- a/cmd/cli/metrics.go
+++ b/cmd/cli/metrics.go
@@ -24,6 +24,10 @@ func handleCleanUpAbandonedRetentions(database moira.Database) error {
 	return database.CleanUpAbandonedRetentions()
 }
 
+func handleCleanUpAbandonedPatternMetrics(database moira.Database) error {
+	return database.CleanUpAbandonedPatternMetrics()
+}
+
 func handleCleanUpAbandonedTriggerLastCheck(database moira.Database) error {
 	return database.CleanUpAbandonedTriggerLastCheck()
 }

--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -18,7 +18,7 @@ func TestCleanUpOutdatedMetrics(t *testing.T) {
 
 	Convey("Test cleanup", t, func() {
 		db.EXPECT().CleanUpOutdatedMetrics(-168 * time.Hour).Return(nil)
-		err := cleanUpOutdatedMetrics(conf.Cleanup, db)
+		err := handleCleanUpOutdatedMetrics(conf.Cleanup, db)
 		So(err, ShouldBeNil)
 	})
 }

--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -317,6 +317,31 @@ func cleanUpAbandonedRetentionsOnRedisNode(connector *DbConnector, client redis.
 	return nil
 }
 
+func cleanUpAbandonedPatternMetricsOnRedisNode(connector *DbConnector, client redis.UniversalClient) error {
+	keysIter := client.Scan(connector.context, 0, patternMetricsKey("*"), 0).Iterator()
+	for keysIter.Next(connector.context) {
+		key := keysIter.Val()
+
+		metricsIter := client.SScan(connector.context, key, 0, "*", 0).Iterator()
+		for metricsIter.Next(connector.context) {
+			metric := metricsIter.Val()
+
+			existsResult, err := (*connector.client).Exists(connector.context, metricDataKey(metric)).Result()
+			if err != nil {
+				return fmt.Errorf("failed to check metric data existence, error: %v", err)
+			}
+			if isMetricExists := existsResult == 1; !isMetricExists {
+				_, err := client.SRem(connector.context, key, metric).Result()
+				if err != nil {
+					return fmt.Errorf("failed to remove pattern data, error: %v", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func (connector *DbConnector) CleanUpOutdatedMetrics(duration time.Duration) error {
 	client := *connector.client
 
@@ -364,6 +389,32 @@ func (connector *DbConnector) CleanUpAbandonedRetentions() error {
 		}
 	default:
 		err := cleanUpAbandonedRetentionsOnRedisNode(connector, c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CleanUpAbandonedPatternMetrics removes members of pattern metrics Set if no corresponding metric data.
+func (connector *DbConnector) CleanUpAbandonedPatternMetrics() error {
+	client := *connector.client
+
+	switch c := client.(type) {
+	case *redis.ClusterClient:
+		err := c.ForEachMaster(connector.context, func(ctx context.Context, shard *redis.Client) error {
+			err := cleanUpAbandonedPatternMetricsOnRedisNode(connector, shard)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	default:
+		err := cleanUpAbandonedPatternMetricsOnRedisNode(connector, c)
 		if err != nil {
 			return err
 		}

--- a/database/redis/metric_test.go
+++ b/database/redis/metric_test.go
@@ -729,6 +729,137 @@ func TestCleanupAbandonedRetention(t *testing.T) {
 	})
 }
 
+func TestCleanupAbandonedPatternMetrics(t *testing.T) {
+	logger, _ := logging.ConfigureLog("stdout", "warn", "test", true)
+	dataBase := NewTestDatabase(logger)
+	dataBase.Flush()
+	defer dataBase.Flush()
+
+	Convey("Given 3 metrics matched with pattern", t, func() {
+		const (
+			pattern = "my.test.metric*"
+			metric1 = "my.test.metric1"
+			metric2 = "my.test.metric2"
+			metric3 = "my.test.metric3"
+		)
+
+		tsNow := time.Now().UTC().Unix()
+		tsOlder := time.Now().UTC().Add(-80 * time.Second).Unix()
+		metric1Value := &moira.MatchedMetric{
+			Patterns:           []string{pattern},
+			Metric:             metric1,
+			Retention:          10,
+			RetentionTimestamp: tsOlder,
+			Timestamp:          tsOlder,
+		}
+		metric2Value := &moira.MatchedMetric{
+			Patterns:           []string{pattern},
+			Metric:             metric2,
+			Retention:          10,
+			RetentionTimestamp: tsOlder,
+			Timestamp:          tsOlder,
+		}
+		metric3Value := &moira.MatchedMetric{
+			Patterns:           []string{pattern},
+			Metric:             metric3,
+			Retention:          10,
+			RetentionTimestamp: tsOlder,
+			Timestamp:          tsOlder,
+		}
+
+		err := dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric1: metric1Value})
+		So(err, ShouldBeNil)
+
+		err = dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric2: metric2Value})
+		So(err, ShouldBeNil)
+
+		err = dataBase.SaveMetrics(map[string]*moira.MatchedMetric{metric3: metric3Value})
+		So(err, ShouldBeNil)
+
+		actualValues, err := dataBase.GetMetricsValues([]string{metric1, metric2, metric3}, 0, tsNow)
+		So(err, ShouldBeNil)
+		So(actualValues, ShouldResemble, map[string][]*moira.MetricValue{
+			metric1: {
+				&moira.MetricValue{
+					RetentionTimestamp: tsOlder,
+					Timestamp:          tsOlder,
+				},
+			},
+			metric2: {
+				&moira.MetricValue{
+					RetentionTimestamp: tsOlder,
+					Timestamp:          tsOlder,
+				},
+			},
+			metric3: {
+				&moira.MetricValue{
+					RetentionTimestamp: tsOlder,
+					Timestamp:          tsOlder,
+				},
+			},
+		})
+
+		Convey("When clean up pattern metrics was called with non-existent metric-data in database", func() {
+			client := *dataBase.client
+
+			client.Del(dataBase.context, metricDataKey(metric1))
+			client.Del(dataBase.context, metricDataKey(metric2))
+			client.Del(dataBase.context, metricDataKey(metric3))
+
+			actualValues, err = dataBase.GetMetricsValues([]string{metric1, metric2, metric3}, 0, tsNow)
+			So(err, ShouldBeNil)
+			So(actualValues, ShouldResemble, map[string][]*moira.MetricValue{
+				metric1: {},
+				metric2: {},
+				metric3: {},
+			})
+
+			err = dataBase.CleanUpAbandonedPatternMetrics()
+			So(err, ShouldBeNil)
+
+			Convey("pattern metric Set shouldn't be in database", func() {
+				key := patternMetricsKey(pattern)
+				isKeyExists := client.Exists(dataBase.context, key).Val() == 1
+				So(isKeyExists, ShouldBeFalse)
+			})
+		})
+
+		Convey("When clean up pattern metrics was called with existent and non-existent metric-data in database", func() {
+			client := *dataBase.client
+
+			client.Del(dataBase.context, metricDataKey(metric1))
+			client.Del(dataBase.context, metricDataKey(metric2))
+
+			actualValues, err = dataBase.GetMetricsValues([]string{metric1, metric2, metric3}, 0, tsNow)
+			So(err, ShouldBeNil)
+			So(actualValues, ShouldResemble, map[string][]*moira.MetricValue{
+				metric1: {},
+				metric2: {},
+				metric3: {
+					&moira.MetricValue{
+						RetentionTimestamp: tsOlder,
+						Timestamp:          tsOlder,
+					},
+				},
+			})
+
+			err = dataBase.CleanUpAbandonedPatternMetrics()
+			So(err, ShouldBeNil)
+
+			Convey("metric1 and metric2 values of set shouldn't be and metric3 value should be in database", func() {
+				key := patternMetricsKey(pattern)
+				isKeyExists := client.Exists(dataBase.context, key).Val() == 1
+				So(isKeyExists, ShouldBeTrue)
+
+				So(client.SIsMember(dataBase.context, key, metric1).Val(), ShouldBeFalse)
+				So(client.SIsMember(dataBase.context, key, metric2).Val(), ShouldBeFalse)
+
+				So(client.SIsMember(dataBase.context, key, metric3).Val(), ShouldBeTrue)
+			})
+		})
+	})
+}
+
 func TestRemoveMetricsByPrefix(t *testing.T) {
 	logger, _ := logging.ConfigureLog("stdout", "info", "test", true)
 	dataBase := NewTestDatabase(logger)

--- a/generate_mocks.cmd
+++ b/generate_mocks.cmd
@@ -10,4 +10,4 @@ mockgen -destination=mock/moira-alert/searcher.go -package=mock_moira_alert gith
 mockgen -destination=mock/metric_source/source.go  -package=mock_metric_source github.com/moira-alert/moira/metric_source MetricSource
 mockgen -destination=mock/metric_source/fetch_result.go -package=mock_metric_source github.com/moira-alert/moira/metric_source FetchResult
 mockgen -destination=mock/heartbeat/heartbeat.go -package=mock_heartbeat github.com/moira-alert/moira/notifier/selfstate/heartbeat Heartbeater
-mockgen -destination=mock/clock/clock.go -package=mock_clock github.com/moira-alert/moira/clock Clock
+mockgen -destination=mock/clock/clock.go -package=mock_clock github.com/moira-alert/moira Clock

--- a/interfaces.go
+++ b/interfaces.go
@@ -146,6 +146,7 @@ type Database interface {
 	// Metrics management
 	CleanUpOutdatedMetrics(duration time.Duration) error
 	CleanUpAbandonedRetentions() error
+	CleanUpAbandonedPatternMetrics() error
 	RemoveMetricsByPrefix(pattern string) error
 	RemoveAllMetrics() error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -98,6 +98,7 @@ type Database interface {
 	SaveMetrics(buffer map[string]*MatchedMetric) error
 	GetMetricRetention(metric string) (int64, error)
 	GetMetricsValues(metrics []string, from int64, until int64) (map[string][]*MetricValue, error)
+	RemoveMetricRetention(metric string) error
 	RemoveMetricValues(metric string, toTime int64) error
 	RemoveMetricsValues(metrics []string, toTime int64) error
 	GetMetricsTTLSeconds() int64
@@ -144,6 +145,7 @@ type Database interface {
 
 	// Metrics management
 	CleanUpOutdatedMetrics(duration time.Duration) error
+	CleanUpAbandonedRetentions() error
 	RemoveMetricsByPrefix(pattern string) error
 	RemoveAllMetrics() error
 }

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -120,6 +120,20 @@ func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
+// CleanUpAbandonedPatternMetrics mocks base method.
+func (m *MockDatabase) CleanUpAbandonedPatternMetrics() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpAbandonedPatternMetrics")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanUpAbandonedPatternMetrics indicates an expected call of CleanUpAbandonedPatternMetrics.
+func (mr *MockDatabaseMockRecorder) CleanUpAbandonedPatternMetrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpAbandonedPatternMetrics", reflect.TypeOf((*MockDatabase)(nil).CleanUpAbandonedPatternMetrics))
+}
+
 // CleanUpAbandonedRetentions mocks base method.
 func (m *MockDatabase) CleanUpAbandonedRetentions() error {
 	m.ctrl.T.Helper()

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -120,6 +120,20 @@ func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
+// CleanUpAbandonedRetentions mocks base method.
+func (m *MockDatabase) CleanUpAbandonedRetentions() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpAbandonedRetentions")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanUpAbandonedRetentions indicates an expected call of CleanUpAbandonedRetentions.
+func (mr *MockDatabaseMockRecorder) CleanUpAbandonedRetentions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpAbandonedRetentions", reflect.TypeOf((*MockDatabase)(nil).CleanUpAbandonedRetentions))
+}
+
 // CleanUpAbandonedTriggerLastCheck mocks base method.
 func (m *MockDatabase) CleanUpAbandonedTriggerLastCheck() error {
 	m.ctrl.T.Helper()
@@ -1054,6 +1068,20 @@ func (m *MockDatabase) RemoveContact(arg0 string) error {
 func (mr *MockDatabaseMockRecorder) RemoveContact(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContact", reflect.TypeOf((*MockDatabase)(nil).RemoveContact), arg0)
+}
+
+// RemoveMetricRetention mocks base method.
+func (m *MockDatabase) RemoveMetricRetention(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveMetricRetention", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveMetricRetention indicates an expected call of RemoveMetricRetention.
+func (mr *MockDatabaseMockRecorder) RemoveMetricRetention(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMetricRetention", reflect.TypeOf((*MockDatabase)(nil).RemoveMetricRetention), arg0)
 }
 
 // RemoveMetricValues mocks base method.


### PR DESCRIPTION
# Improved cleanup cli for deleting abondoned keys of database

_Abandoned/outdated keys_ are keys for metrics for which corresponding metric data key doesn't exist, so these abandoned/outdated keys are trash in database and it should be deleted for database consistency.

Added cleanup for abandoned/outdated pattern metrics and metrics retentions, move cleanup of abandoned/outdated keys to one CLI command. 