### PR TITLE
Decreased log-level for too old metric

### DIFF
--- a/filter/patterns_storage.go
+++ b/filter/patterns_storage.go
@@ -71,7 +71,7 @@ func (storage *PatternStorage) ProcessIncomingMetric(lineBytes []byte, maxTTL ti
 		storage.logger.Clone().
 			String(moira.LogFieldNameMetricName, parsedMetric.Name).
 			String(moira.LogFieldNameMetricTimestamp, fmt.Sprint(parsedMetric.Timestamp)).
-			Info("metric is too old")
+			Debug("metric is too old")
 		return nil
 	}
 


### PR DESCRIPTION
Decreased log-level for too old metric, because it make much noise in logs now.