### PR TITLE
Added cleanup abandoned tags

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -175,6 +175,14 @@ func main() { //nolint
 			log.Error(err)
 		}
 		log.Info("Cleanup abandoned triggers last checks finished")
+
+		log.Info("Cleanup abandoned tags started")
+		count, err := handleCleanUpAbandonedTags(dataBase)
+		if err != nil {
+			log.Info(fmt.Sprintf("Count of deleted tags is %d", count))
+			log.Error(err)
+		}
+		log.Info("Cleanup abandoned tags finished")
 	}
 
 	if *pushTriggerDump {

--- a/cmd/cli/metrics.go
+++ b/cmd/cli/metrics.go
@@ -32,6 +32,10 @@ func handleCleanUpAbandonedTriggerLastCheck(database moira.Database) error {
 	return database.CleanUpAbandonedTriggerLastCheck()
 }
 
+func handleCleanUpAbandonedTags(database moira.Database) (int, error) {
+	return database.CleanUpAbandonedTags()
+}
+
 func handleRemoveMetricsByPrefix(database moira.Database, prefix string) error {
 	return database.RemoveMetricsByPrefix(prefix)
 }

--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -1,8 +1,8 @@
 package redis
 
 import (
+	"context"
 	"fmt"
-
 	"github.com/go-redis/redis/v8"
 )
 
@@ -30,6 +30,17 @@ func (connector *DbConnector) RemoveTag(tagName string) error {
 	return nil
 }
 
+// AddTag adds tag to database.
+func (connector *DbConnector) AddTag(tagName string) error {
+	client := *connector.client
+	err := client.SAdd(connector.context, tagsKey, tagName).Err()
+
+	if err != nil {
+		return fmt.Errorf("failed to add tag: %s", err.Error())
+	}
+	return nil
+}
+
 // GetTagTriggerIDs gets all triggersIDs by given tagName
 func (connector *DbConnector) GetTagTriggerIDs(tagName string) ([]string, error) {
 	c := *connector.client
@@ -42,6 +53,61 @@ func (connector *DbConnector) GetTagTriggerIDs(tagName string) ([]string, error)
 		return nil, fmt.Errorf("failed to retrieve tag triggers:%s, err: %s", tagName, err.Error())
 	}
 	return triggerIDs, nil
+}
+
+// CleanUpAbandonedTags deletes tags for which triggers don't exist.
+// Returns count of deleted tags.
+func (connector *DbConnector) CleanUpAbandonedTags() (int, error) {
+	counter := 0
+	client := *connector.client
+
+	switch c := client.(type) {
+	case *redis.ClusterClient:
+		err := c.ForEachMaster(connector.context, func(ctx context.Context, shard *redis.Client) error {
+			count, err := cleanUpAbandonedTagsOnRedisNode(connector, shard)
+			if err != nil {
+				return err
+			}
+			counter += count
+
+			return nil
+		})
+		if err != nil {
+			return 0, err
+		}
+	default:
+		count, err := cleanUpAbandonedTagsOnRedisNode(connector, c)
+		if err != nil {
+			return 0, err
+		}
+		counter += count
+	}
+
+	return counter, nil
+}
+
+func cleanUpAbandonedTagsOnRedisNode(connector *DbConnector, client redis.UniversalClient) (int, error) {
+	var count int
+	iter := client.SScan(connector.context, tagsKey, 0, "*", 0).Iterator()
+	for iter.Next(connector.context) {
+		tag := iter.Val()
+
+		result, err := (*connector.client).Exists(connector.context, tagTriggersKey(tag)).Result()
+		if err != nil {
+			return 0, fmt.Errorf("failed to check tag triggers existence, error: %v", err)
+		}
+		if isTriggerExists := result == 1; !isTriggerExists {
+			err = connector.RemoveTag(tag)
+			client.SRem(connector.context, tagsKey, tag)
+
+			if err != nil {
+				return 0, err
+			}
+			count++
+		}
+	}
+
+	return count, nil
 }
 
 var tagsKey = "moira-tags"

--- a/interfaces.go
+++ b/interfaces.go
@@ -20,7 +20,9 @@ type Database interface {
 	// Tag storing
 	GetTagNames() ([]string, error)
 	RemoveTag(tagName string) error
+	AddTag(tagName string) error
 	GetTagTriggerIDs(tagName string) ([]string, error)
+	CleanUpAbandonedTags() (int, error)
 
 	// LastCheck storing
 	GetTriggerLastCheck(triggerID string) (CheckData, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -120,6 +120,20 @@ func (mr *MockDatabaseMockRecorder) AddRemoteTriggersToCheck(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteTriggersToCheck", reflect.TypeOf((*MockDatabase)(nil).AddRemoteTriggersToCheck), arg0)
 }
 
+// AddTag mocks base method.
+func (m *MockDatabase) AddTag(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTag", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddTag indicates an expected call of AddTag.
+func (mr *MockDatabaseMockRecorder) AddTag(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTag", reflect.TypeOf((*MockDatabase)(nil).AddTag), arg0)
+}
+
 // CleanUpAbandonedPatternMetrics mocks base method.
 func (m *MockDatabase) CleanUpAbandonedPatternMetrics() error {
 	m.ctrl.T.Helper()
@@ -146,6 +160,21 @@ func (m *MockDatabase) CleanUpAbandonedRetentions() error {
 func (mr *MockDatabaseMockRecorder) CleanUpAbandonedRetentions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpAbandonedRetentions", reflect.TypeOf((*MockDatabase)(nil).CleanUpAbandonedRetentions))
+}
+
+// CleanUpAbandonedTags mocks base method.
+func (m *MockDatabase) CleanUpAbandonedTags() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpAbandonedTags")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanUpAbandonedTags indicates an expected call of CleanUpAbandonedTags.
+func (mr *MockDatabaseMockRecorder) CleanUpAbandonedTags() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpAbandonedTags", reflect.TypeOf((*MockDatabase)(nil).CleanUpAbandonedTags))
 }
 
 // CleanUpAbandonedTriggerLastCheck mocks base method.


### PR DESCRIPTION
Abandoned tags are tags without triggers, so it is a trash in database and affects users in Web UI, these tags should be removed. Now tags would be removed on cleanup.