### PR TITLE
Added cleanup abandoned tags

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -177,6 +177,13 @@ func main() { //nolint
 			log.Error(err)
 		}
 		log.Info("Cleanup abandoned triggers last checks finished")
+
+		log.Info("Cleanup abandoned tags started")
+		count, err := handleCleanUpAbandonedTags(dataBase)
+		if err != nil {
+			log.Error(err)
+		}
+		log.Info("Cleanup abandoned tags finished. ", fmt.Sprintf("Count of deleted tags is %d", count))
 	}
 
 	if *cleanupRetentions {

--- a/cmd/cli/metrics.go
+++ b/cmd/cli/metrics.go
@@ -32,6 +32,10 @@ func handleCleanUpAbandonedTriggerLastCheck(database moira.Database) error {
 	return database.CleanUpAbandonedTriggerLastCheck()
 }
 
+func handleCleanUpAbandonedTags(database moira.Database) (int, error) {
+	return database.CleanUpAbandonedTags()
+}
+
 func handleRemoveMetricsByPrefix(database moira.Database, prefix string) error {
 	return database.RemoveMetricsByPrefix(prefix)
 }

--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -56,20 +56,20 @@ func (connector *DbConnector) CleanUpAbandonedTags() (int, error) {
 
 		result, err := client.Exists(connector.context, tagTriggersKey(tag)).Result()
 		if err != nil {
-			return 0, fmt.Errorf("failed to check tag triggers existence, error: %v", err)
+			return count, fmt.Errorf("failed to check tag triggers existence, error: %v", err)
 		}
 		isTriggerExists := result == 1
 
 		result, err = client.Exists(connector.context, tagSubscriptionKey(tag)).Result()
 		if err != nil {
-			return 0, fmt.Errorf("failed to check tag subscription existence, error: %v", err)
+			return count, fmt.Errorf("failed to check tag subscription existence, error: %v", err)
 		}
 		isSubscriptionExists := result == 1
 
 		if !isTriggerExists && !isSubscriptionExists {
 			err = client.SRem(connector.context, tagsKey, tag).Err()
 			if err != nil {
-				return 0, err
+				return count, err
 			}
 
 			count++

--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -58,22 +58,23 @@ func (connector *DbConnector) CleanUpAbandonedTags() (int, error) {
 		if err != nil {
 			return count, fmt.Errorf("failed to check tag triggers existence, error: %v", err)
 		}
-		isTriggerExists := result == 1
+		if isTriggerExists := result == 1; isTriggerExists {
+			continue
+		}
 
 		result, err = client.Exists(connector.context, tagSubscriptionKey(tag)).Result()
 		if err != nil {
 			return count, fmt.Errorf("failed to check tag subscription existence, error: %v", err)
 		}
-		isSubscriptionExists := result == 1
-
-		if !isTriggerExists && !isSubscriptionExists {
-			err = client.SRem(connector.context, tagsKey, tag).Err()
-			if err != nil {
-				return count, err
-			}
-
-			count++
+		if isSubscriptionExists := result == 1; isSubscriptionExists {
+			continue
 		}
+
+		err = client.SRem(connector.context, tagsKey, tag).Err()
+		if err != nil {
+			return count, err
+		}
+		count++
 	}
 
 	return count, nil

--- a/database/redis/tag.go
+++ b/database/redis/tag.go
@@ -44,6 +44,41 @@ func (connector *DbConnector) GetTagTriggerIDs(tagName string) ([]string, error)
 	return triggerIDs, nil
 }
 
+// CleanUpAbandonedTags deletes tags for which triggers and subscriptions don't exist.
+// Returns count of deleted tags.
+func (connector *DbConnector) CleanUpAbandonedTags() (int, error) {
+	var count int
+	client := *connector.client
+
+	iter := client.SScan(connector.context, tagsKey, 0, "*", 0).Iterator()
+	for iter.Next(connector.context) {
+		tag := iter.Val()
+
+		result, err := client.Exists(connector.context, tagTriggersKey(tag)).Result()
+		if err != nil {
+			return 0, fmt.Errorf("failed to check tag triggers existence, error: %v", err)
+		}
+		isTriggerExists := result == 1
+
+		result, err = client.Exists(connector.context, tagSubscriptionKey(tag)).Result()
+		if err != nil {
+			return 0, fmt.Errorf("failed to check tag subscription existence, error: %v", err)
+		}
+		isSubscriptionExists := result == 1
+
+		if !isTriggerExists && !isSubscriptionExists {
+			err = client.SRem(connector.context, tagsKey, tag).Err()
+			if err != nil {
+				return 0, err
+			}
+
+			count++
+		}
+	}
+
+	return count, nil
+}
+
 var tagsKey = "moira-tags"
 
 func tagTriggersKey(tagName string) string {

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,6 +21,7 @@ type Database interface {
 	GetTagNames() ([]string, error)
 	RemoveTag(tagName string) error
 	GetTagTriggerIDs(tagName string) ([]string, error)
+	CleanUpAbandonedTags() (int, error)
 
 	// LastCheck storing
 	GetTriggerLastCheck(triggerID string) (CheckData, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -148,6 +148,21 @@ func (mr *MockDatabaseMockRecorder) CleanUpAbandonedRetentions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpAbandonedRetentions", reflect.TypeOf((*MockDatabase)(nil).CleanUpAbandonedRetentions))
 }
 
+// CleanUpAbandonedTags mocks base method.
+func (m *MockDatabase) CleanUpAbandonedTags() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpAbandonedTags")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanUpAbandonedTags indicates an expected call of CleanUpAbandonedTags.
+func (mr *MockDatabaseMockRecorder) CleanUpAbandonedTags() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpAbandonedTags", reflect.TypeOf((*MockDatabase)(nil).CleanUpAbandonedTags))
+}
+
 // CleanUpAbandonedTriggerLastCheck mocks base method.
 func (m *MockDatabase) CleanUpAbandonedTriggerLastCheck() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Abandoned tags are tags without triggers and subscriptions, so it is a trash in database and affects users in Web UI, these tags should be removed. Now tags would be removed on cleanup.