### PR TITLE
Updated golang to 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.17.7
+          go-version: 1.18
       - uses: actions/checkout@v2
       - name: Run tests
         run: make test

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.17.7 as builder
+FROM golang:1.18 as builder
 
 COPY go.mod go.sum /go/src/github.com/moira-alert/moira/
 WORKDIR /go/src/github.com/moira-alert/moira

--- a/Dockerfile.checker
+++ b/Dockerfile.checker
@@ -1,4 +1,4 @@
-FROM golang:1.17.7 as builder
+FROM golang:1.18 as builder
 
 COPY go.mod go.sum /go/src/github.com/moira-alert/moira/
 WORKDIR /go/src/github.com/moira-alert/moira

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM golang:1.17.7 as builder
+FROM golang:1.18 as builder
 
 COPY go.mod go.sum /go/src/github.com/moira-alert/moira/
 WORKDIR /go/src/github.com/moira-alert/moira

--- a/Dockerfile.filter
+++ b/Dockerfile.filter
@@ -1,4 +1,4 @@
-FROM golang:1.17.7 as builder
+FROM golang:1.18 as builder
 
 COPY go.mod go.sum /go/src/github.com/moira-alert/moira/
 WORKDIR /go/src/github.com/moira-alert/moira

--- a/Dockerfile.notifier
+++ b/Dockerfile.notifier
@@ -1,4 +1,4 @@
-FROM golang:1.17.7 as builder
+FROM golang:1.18 as builder
 
 COPY go.mod go.sum /go/src/github.com/moira-alert/moira/
 WORKDIR /go/src/github.com/moira-alert/moira

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moira-alert/moira
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible


### PR DESCRIPTION
# Main features of Go 1.18
- Generics. We can use [constraints](https://pkg.go.dev/golang.org/x/exp/constraints)
- Type `any` is alias for `interface{}`

- Fuzzing. Is a new kind of tests, which runs tests with different input to find errors in boundary conditions

TODO:
- Use `any`
- Use Generics