### PR TITLE
Refactored cluster specific code

### DIFF
--- a/database/redis/contact.go
+++ b/database/redis/contact.go
@@ -83,29 +83,18 @@ func getContactsKeysOnRedisNode(ctx context.Context, client redis.UniversalClien
 
 // GetAllContacts returns full contact list
 func (connector *DbConnector) GetAllContacts() ([]*moira.ContactData, error) {
-	client := *connector.client
 	var keys []string
 
-	switch c := client.(type) {
-	case *redis.ClusterClient:
-		err := c.ForEachMaster(connector.context, func(ctx context.Context, shard *redis.Client) error {
-			keysResult, err := getContactsKeysOnRedisNode(ctx, shard)
-			if err != nil {
-				return err
-			}
-			keys = append(keys, keysResult...)
-			return nil
-		})
-
+	err := connector.runDependent(func(connector *DbConnector, client redis.UniversalClient) error {
+		keysResult, err := getContactsKeysOnRedisNode(connector.context, client)
 		if err != nil {
-			return nil, err
+			return err
 		}
-	default:
-		keysResult, err := getContactsKeysOnRedisNode(connector.context, c)
-		if err != nil {
-			return nil, err
-		}
-		keys = keysResult
+		keys = append(keys, keysResult...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	contactIDs := make([]string, 0, len(keys))

--- a/database/redis/last_check.go
+++ b/database/redis/last_check.go
@@ -117,28 +117,7 @@ func cleanUpAbandonedTriggerLastCheckOnRedisNode(connector *DbConnector, client 
 
 // CleanUpAbandonedTriggerLastCheck cleans up abandoned triggers last check.
 func (connector *DbConnector) CleanUpAbandonedTriggerLastCheck() error {
-	client := *connector.client
-
-	switch c := client.(type) {
-	case *redis.ClusterClient:
-		err := c.ForEachMaster(connector.context, func(ctx context.Context, shard *redis.Client) error {
-			err := cleanUpAbandonedTriggerLastCheckOnRedisNode(connector, shard)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-	default:
-		err := cleanUpAbandonedTriggerLastCheckOnRedisNode(connector, c)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return connector.runDependent(cleanUpAbandonedTriggerLastCheckOnRedisNode)
 }
 
 // SetTriggerCheckMaintenance sets maintenance for whole trigger and to given metrics,


### PR DESCRIPTION
## DRY (Don't Repeat Yourself)
There was repeat of switch-case for call function on Redis cluster or standalone. Extracted method to call functions dependent of Redis client type.