### PR TITLE
fix(ci): Fix ubuntu image for linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Run linter


### PR DESCRIPTION
We make image for running linters as "fixed" version. We don't use latest verstion.