### PR TITLE
Added logging for not matched metrics

### DIFF
--- a/filter/patterns_storage.go
+++ b/filter/patterns_storage.go
@@ -93,6 +93,10 @@ func (storage *PatternStorage) ProcessIncomingMetric(lineBytes []byte, maxTTL ti
 			Retention:          60, //nolint
 		}
 	}
+
+	storage.logger.Clone().
+		Debugf("metric %s is not matched with prefix tree", parsedMetric.Metric)
+
 	return nil
 }
 


### PR DESCRIPTION
There is case when users have problems, so we need to make sure that metrics is not matched.
