### PR TITLE
net/http library's consts for representing http codes

### DIFF
--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -130,7 +131,7 @@ func TestCreateContact(t *testing.T) {
 			expected := CreateContact(dataBase, contact, userLogin, "")
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
-				HTTPStatusCode: 500,
+				HTTPStatusCode: http.StatusInternalServerError,
 				StatusText:     "Internal Server Error",
 				Err:            err,
 			})
@@ -202,7 +203,7 @@ func TestCreateContact(t *testing.T) {
 			expected := CreateContact(dataBase, contact, "", teamID)
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
-				HTTPStatusCode: 500,
+				HTTPStatusCode: http.StatusInternalServerError,
 				StatusText:     "Internal Server Error",
 				Err:            err,
 			})

--- a/api/error_response.go
+++ b/api/error_response.go
@@ -26,7 +26,7 @@ func (e *ErrorResponse) Render(w http.ResponseWriter, r *http.Request) error {
 func ErrorInternalServer(err error) *ErrorResponse {
 	return &ErrorResponse{
 		Err:            err,
-		HTTPStatusCode: 500, //nolint
+		HTTPStatusCode: http.StatusInternalServerError,
 		StatusText:     "Internal Server Error",
 		ErrorText:      err.Error(),
 	}
@@ -36,7 +36,7 @@ func ErrorInternalServer(err error) *ErrorResponse {
 func ErrorInvalidRequest(err error) *ErrorResponse {
 	return &ErrorResponse{
 		Err:            err,
-		HTTPStatusCode: 400, //nolint
+		HTTPStatusCode: http.StatusBadRequest,
 		StatusText:     "Invalid request",
 		ErrorText:      err.Error(),
 	}
@@ -46,7 +46,7 @@ func ErrorInvalidRequest(err error) *ErrorResponse {
 func ErrorRender(err error) *ErrorResponse {
 	return &ErrorResponse{
 		Err:            err,
-		HTTPStatusCode: 422, //nolint
+		HTTPStatusCode: http.StatusUnprocessableEntity,
 		StatusText:     "Error rendering response",
 		ErrorText:      err.Error(),
 	}
@@ -55,7 +55,7 @@ func ErrorRender(err error) *ErrorResponse {
 // ErrorNotFound return 404 with given error text
 func ErrorNotFound(errorText string) *ErrorResponse {
 	return &ErrorResponse{
-		HTTPStatusCode: 404, //nolint
+		HTTPStatusCode: http.StatusNotFound,
 		StatusText:     "Resource not found",
 		ErrorText:      errorText,
 	}
@@ -64,7 +64,7 @@ func ErrorNotFound(errorText string) *ErrorResponse {
 // ErrorForbidden return 403 with given error text
 func ErrorForbidden(errorText string) *ErrorResponse {
 	return &ErrorResponse{
-		HTTPStatusCode: 403, //nolint
+		HTTPStatusCode: http.StatusForbidden,
 		StatusText:     "Forbidden",
 		ErrorText:      errorText,
 	}
@@ -74,14 +74,14 @@ func ErrorForbidden(errorText string) *ErrorResponse {
 func ErrorRemoteServerUnavailable(err error) *ErrorResponse {
 	return &ErrorResponse{
 		Err:            err,
-		HTTPStatusCode: 503, //nolint
+		HTTPStatusCode: http.StatusServiceUnavailable,
 		StatusText:     "Remote server unavailable.",
 		ErrorText:      fmt.Sprintf("Remote server error, please contact administrator. Raw error: %s", err.Error()),
 	}
 }
 
 // ErrNotFound is default router page not found
-var ErrNotFound = &ErrorResponse{HTTPStatusCode: 404, StatusText: "Page not found."} //nolint
+var ErrNotFound = &ErrorResponse{HTTPStatusCode: http.StatusNotFound, StatusText: "Page not found."}
 
 // ErrMethodNotAllowed is default 405 router method not allowed
-var ErrMethodNotAllowed = &ErrorResponse{HTTPStatusCode: 405, StatusText: "Method not allowed."} //nolint
+var ErrMethodNotAllowed = &ErrorResponse{HTTPStatusCode: http.StatusMethodNotAllowed, StatusText: "Method not allowed."}

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -56,12 +56,12 @@ func NewHandler(db moira.Database, log moira.Logger, index moira.Searcher, confi
 func notFoundHandler(writer http.ResponseWriter, request *http.Request) {
 	writer.Header().Set("X-Content-Type-Options", "nosniff")
 	writer.Header().Set("Content-Type", "application/json")
-	writer.WriteHeader(404)                         //nolint
+	writer.WriteHeader(http.StatusNotFound)
 	render.Render(writer, request, api.ErrNotFound) //nolint
 }
 
 func methodNotAllowedHandler(writer http.ResponseWriter, request *http.Request) {
 	writer.Header().Set("Content-Type", "application/json")
-	writer.WriteHeader(405)                                 //nolint
+	writer.WriteHeader(http.StatusMethodNotAllowed)
 	render.Render(writer, request, api.ErrMethodNotAllowed) //nolint
 }

--- a/api/middleware/logger.go
+++ b/api/middleware/logger.go
@@ -101,7 +101,7 @@ func newLogEntry(logger moira.Logger, request *http.Request) *apiLoggerEntry {
 
 func (entry *apiLoggerEntry) write(status, bytes int, elapsed time.Duration, response http.ResponseWriter) {
 	if status == 0 {
-		status = 200
+		status = http.StatusOK
 	}
 	log := entry.logger
 	log.Int("http.http_status", status)
@@ -112,7 +112,7 @@ func (entry *apiLoggerEntry) write(status, bytes int, elapsed time.Duration, res
 	fmt.Fprintf(entry.buf, " %dB", bytes)
 	entry.buf.WriteString(" in ")
 	fmt.Fprintf(entry.buf, "%s", elapsed)
-	if status >= 500 { //nolint
+	if status >= http.StatusInternalServerError {
 		errorResponse := getErrorResponseIfItHas(response)
 		if errorResponse != nil {
 			fmt.Fprintf(entry.buf, " - Error : %s", errorResponse.ErrorText)

--- a/metric_source/remote/request.go
+++ b/metric_source/remote/request.go
@@ -42,7 +42,7 @@ func (remote *Remote) makeRequest(req *http.Request) ([]byte, error) {
 		return body, err
 	}
 
-	if resp.StatusCode != 200 { //nolint
+	if resp.StatusCode != http.StatusOK {
 		return body, fmt.Errorf("bad response status %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/senders/msteams/msteams_test.go
+++ b/senders/msteams/msteams_test.go
@@ -1,6 +1,7 @@
 package msteams
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -62,7 +63,7 @@ some other text _italic text_`,
 			defer gock.Off()
 			gock.New("https://outlook.office.com/webhook/foo").
 				Post("/").
-				Reply(200).
+				Reply(http.StatusOK).
 				BodyString("1")
 			contact := moira.ContactData{Value: "https://outlook.office.com/webhook/foo"}
 			err := sender.SendEvents([]moira.NotificationEvent{event}, contact, trigger, make([][]byte, 0, 1), false)
@@ -73,7 +74,7 @@ some other text _italic text_`,
 			defer gock.Off()
 			gock.New("https://outlook.office.com/webhook/foo").
 				Post("/").
-				Reply(200).
+				Reply(http.StatusOK).
 				BodyString("Some error")
 			contact := moira.ContactData{Value: "https://outlook.office.com/webhook/foo"}
 			err := sender.SendEvents([]moira.NotificationEvent{event}, contact, trigger, make([][]byte, 0, 1), false)
@@ -84,7 +85,7 @@ some other text _italic text_`,
 			defer gock.Off()
 			gock.New("https://outlook.office.com/webhook/foo").
 				Post("/").
-				Reply(500).
+				Reply(http.StatusInternalServerError).
 				BodyString("Some error")
 			contact := moira.ContactData{Value: "https://outlook.office.com/webhook/foo"}
 			err := sender.SendEvents([]moira.NotificationEvent{event}, contact, trigger, make([][]byte, 0, 1), false)

--- a/senders/victorops/api/alert.go
+++ b/senders/victorops/api/alert.go
@@ -57,7 +57,7 @@ func (client *Client) CreateAlert(routingKey string, alert CreateAlertRequest) e
 		return fmt.Errorf("error while making the request to victorops: %s", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 { //nolint
+	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("victorops API request resulted in error with status %v: %v", resp.StatusCode, string(body))
 	}

--- a/senders/webhook/webhook.go
+++ b/senders/webhook/webhook.go
@@ -90,5 +90,5 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 }
 
 func isAllowedResponseCode(responseCode int) bool {
-	return (responseCode >= 200) && (responseCode <= 299)
+	return (responseCode >= http.StatusOK) && (responseCode < http.StatusMultipleChoices)
 }


### PR DESCRIPTION
# Http codes

Using http package consts instead bare numbers for http codes
