### PR TITLE
Add trigger ID validation

### DIFF
--- a/api/controller/triggers.go
+++ b/api/controller/triggers.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"math"
+	"regexp"
 
 	"github.com/gofrs/uuid"
 
@@ -13,6 +14,8 @@ import (
 )
 
 const pageSizeUnlimited int64 = -1
+
+var idValidationPattern = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
 
 // CreateTrigger creates new trigger
 func CreateTrigger(dataBase moira.Database, trigger *dto.TriggerModel, timeSeriesNames map[string]bool) (*dto.SaveTriggerResponse, *api.ErrorResponse) {
@@ -29,6 +32,9 @@ func CreateTrigger(dataBase moira.Database, trigger *dto.TriggerModel, timeSerie
 		}
 		if exists {
 			return nil, api.ErrorInvalidRequest(fmt.Errorf("trigger with this ID already exists"))
+		}
+		if !idValidationPattern.MatchString(trigger.ID) {
+			return nil, api.ErrorInvalidRequest(fmt.Errorf("trigger ID contains invalid characters"))
 		}
 	}
 	resp, err := saveTrigger(dataBase, trigger.ToMoiraTrigger(), trigger.ID, timeSeriesNames)

--- a/api/controller/triggers_test.go
+++ b/api/controller/triggers_test.go
@@ -47,6 +47,31 @@ func TestCreateTrigger(t *testing.T) {
 		So(resp.ID, ShouldResemble, triggerID)
 	})
 
+	Convey("Success with custom valid trigger", t, func() {
+		triggerID := "Valid_Custom_Trigger_Name-42"
+		triggerModel := dto.TriggerModel{ID: triggerID}
+		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
+		dataBase.EXPECT().AcquireTriggerCheckLock(gomock.Any(), 10)
+		dataBase.EXPECT().DeleteTriggerCheckLock(gomock.Any())
+		dataBase.EXPECT().GetTriggerLastCheck(gomock.Any()).Return(moira.CheckData{}, database.ErrNil)
+		dataBase.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		dataBase.EXPECT().SaveTrigger(gomock.Any(), triggerModel.ToMoiraTrigger()).Return(nil)
+		resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))
+		So(err, ShouldBeNil)
+		So(resp.Message, ShouldResemble, "trigger created")
+		So(resp.ID, ShouldResemble, triggerID)
+	})
+
+	Convey("Error with invalid triggerID", t, func() {
+		triggerID := "Foo#"
+		triggerModel := dto.TriggerModel{ID: triggerID}
+		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
+		resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))
+		expected := api.ErrorInvalidRequest(fmt.Errorf("trigger ID contains invalid characters"))
+		So(err, ShouldResemble, expected)
+		So(resp, ShouldBeNil)
+	})
+
 	Convey("Trigger already exists", t, func() {
 		triggerModel := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String()}
 		trigger := triggerModel.ToMoiraTrigger()


### PR DESCRIPTION
User could crate triggers with custom name that contains invalid characters. Added validation in trigger controller.

Add tests for cases with correct and incorrect trigger ID.
