### PR TITLE
fix(api): Widen range of valid ids

### DIFF
--- a/api/controller/triggers.go
+++ b/api/controller/triggers.go
@@ -15,7 +15,7 @@ import (
 
 const pageSizeUnlimited int64 = -1
 
-var idValidationPattern = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
+var idValidationPattern = regexp.MustCompile(`^[ \p{L}0-9\.\-\|_~:]+$`)
 
 // CreateTrigger creates new trigger
 func CreateTrigger(dataBase moira.Database, trigger *dto.TriggerModel, timeSeriesNames map[string]bool) (*dto.SaveTriggerResponse, *api.ErrorResponse) {

--- a/api/controller/triggers_test.go
+++ b/api/controller/triggers_test.go
@@ -48,7 +48,7 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Success with custom valid trigger", t, func() {
-		triggerID := "Valid_Custom_Trigger_Name-42"
+		triggerID := "Valid.Custom_Trig ger~Na|me-4:2"
 		triggerModel := dto.TriggerModel{ID: triggerID}
 		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
 		dataBase.EXPECT().AcquireTriggerCheckLock(gomock.Any(), 10)
@@ -63,13 +63,14 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Error with invalid triggerID", t, func() {
-		triggerID := "Foo#"
-		triggerModel := dto.TriggerModel{ID: triggerID}
-		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
-		resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))
-		expected := api.ErrorInvalidRequest(fmt.Errorf("trigger ID contains invalid characters"))
-		So(err, ShouldResemble, expected)
-		So(resp, ShouldBeNil)
+		for _, triggerID := range []string{"Foo#", "Foo%", "Foo^"} {
+			triggerModel := dto.TriggerModel{ID: triggerID}
+			dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(moira.Trigger{}, database.ErrNil)
+			resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))
+			expected := api.ErrorInvalidRequest(fmt.Errorf("trigger ID contains invalid characters"))
+			So(err, ShouldResemble, expected)
+			So(resp, ShouldBeNil)
+		}
 	})
 
 	Convey("Trigger already exists", t, func() {


### PR DESCRIPTION
Original validation was too strict. It prohibited some trigger ids that were actually in use
 
- It turned out to be too difficult to create exhaustive character blacklist.
- Some symbols that are allowed by rfc break our webpage (e.g. `&` or `$'` combintation)

So I've decided to update the whitelist to include all the cases that we know of. I've downloaded and validated all triggers in producation database, to make shure no currently used trigger will be affected