### PR TITLE
Fix target validation

### DIFF
--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -120,8 +120,14 @@ func TargetVerification(targets []string, ttl time.Duration, isRemote bool) []Tr
 	for _, target := range targets {
 		functionsOfTarget := TreeOfProblems{SyntaxOk: true}
 
-		expr, _, err := parser.ParseExpr(target)
+		expr, nestedExpr, err := parser.ParseExpr(target)
 		if err != nil {
+			functionsOfTarget.SyntaxOk = false
+			functionsOfTargets = append(functionsOfTargets, functionsOfTarget)
+			continue
+		}
+		isSpaceInMetricName := nestedExpr != ""
+		if isSpaceInMetricName {
 			functionsOfTarget.SyntaxOk = false
 			functionsOfTargets = append(functionsOfTargets, functionsOfTarget)
 			continue

--- a/api/dto/target_test.go
+++ b/api/dto/target_test.go
@@ -91,6 +91,13 @@ func TestTargetVerification(t *testing.T) {
 			So(problems[0].SyntaxOk, ShouldBeTrue)
 			So(problems[0].TreeOfProblems, ShouldBeNil)
 		})
+
+		Convey("Check target with space symbol in metric name", func() {
+			targets := []string{"a b"}
+			problems := TargetVerification(targets, 0, false)
+			So(problems[0].SyntaxOk, ShouldBeFalse)
+			So(problems[0].TreeOfProblems, ShouldBeNil)
+		})
 	})
 }
 


### PR DESCRIPTION
There was a bug: user could create trigger with target with space in metric name like `a b`. Now validation doesn't allow it.