### PR TITLE
Validate trigger target on create/update

### DIFF
--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -154,9 +154,9 @@ func TargetVerification(targets []string, ttl time.Duration, isRemote bool) []Tr
 	return functionsOfTargets
 }
 
-// HaveTreesError checks that at least one node of tree has a problem with error type.
+// DoesAnyTreeHaveError checks that at least one node of tree has a problem with error type.
 // It is wrapper to handle slice of trees.
-func HaveTreesError(trees []TreeOfProblems) bool {
+func DoesAnyTreeHaveError(trees []TreeOfProblems) bool {
 	for _, tree := range trees {
 		if tree.TreeOfProblems.hasError() {
 			return true

--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -17,8 +17,8 @@ func init() {
 type typeOfProblem string
 
 const (
-	IsWarn typeOfProblem = "warn"
-	IsBad  typeOfProblem = "bad"
+	isWarn typeOfProblem = "warn"
+	isBad  typeOfProblem = "bad"
 )
 
 var (
@@ -156,7 +156,7 @@ func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *
 
 		problemFunction.Problems = append(problemFunction.Problems, ProblemOfTarget{
 			Argument: argument,
-			Type:     IsBad,
+			Type:     isBad,
 			Position: 1,
 			Description: fmt.Sprintf(
 				"The function %s has a time sampling parameter %s larger than allowed by the config:%s",
@@ -187,7 +187,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isUnstable := unstableFunctions[funcName]; isUnstable {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        IsBad,
+			Type:        isBad,
 			Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
 		}
 	}
@@ -195,7 +195,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isFalseNotification := falseNotificationsFunctions[funcName]; isFalseNotification {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        IsWarn,
+			Type:        isWarn,
 			Description: "This function shows and hides entire metric series based on their values. Moira will send frequent false NODATA notifications.",
 		}
 	}
@@ -203,7 +203,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isVisual := visualFunctions[funcName]; isVisual {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        IsWarn,
+			Type:        isWarn,
 			Description: "This function affects only visual graph representation. It is meaningless in Moira.",
 		}
 	}
@@ -211,7 +211,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if !isRemote && !funcIsSupported(funcName) {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        IsBad,
+			Type:        isBad,
 			Description: "Function is not supported, if you want to use it, switch to remote",
 			Position:    0,
 			Problems:    nil,
@@ -273,7 +273,7 @@ func AreTreesHaveError(trees []TreeOfProblems) bool {
 }
 
 func isTreeHasError(tree *ProblemOfTarget) bool {
-	if tree.Type == IsBad {
+	if tree.Type == isBad {
 		return true
 	}
 

--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -100,17 +100,17 @@ var (
 	}
 )
 
-type problemOfTarget struct {
+type ProblemOfTarget struct {
 	Argument    string            `json:"argument"`
 	Type        typeOfProblem     `json:"type,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Position    int               `json:"position"`
-	Problems    []problemOfTarget `json:"problems,omitempty"`
+	Problems    []ProblemOfTarget `json:"problems,omitempty"`
 }
 
 type TreeOfProblems struct {
 	SyntaxOk       bool             `json:"syntax_ok"`
-	TreeOfProblems *problemOfTarget `json:"tree_of_problems,omitempty"`
+	TreeOfProblems *ProblemOfTarget `json:"tree_of_problems,omitempty"`
 }
 
 // TargetVerification validates trigger targets.
@@ -141,7 +141,7 @@ func TargetVerification(targets []string, ttl time.Duration, isRemote bool) []Tr
 }
 
 // checkExpression validates expression.
-func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *problemOfTarget {
+func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *ProblemOfTarget {
 	if !expression.IsFunc() {
 		return nil
 	}
@@ -151,10 +151,10 @@ func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *
 
 	if argument, ok := functionArgumentsInTheRangeTTL(expression, ttl); !ok {
 		if problemFunction == nil {
-			problemFunction = &problemOfTarget{Argument: funcName}
+			problemFunction = &ProblemOfTarget{Argument: funcName}
 		}
 
-		problemFunction.Problems = append(problemFunction.Problems, problemOfTarget{
+		problemFunction.Problems = append(problemFunction.Problems, ProblemOfTarget{
 			Argument: argument,
 			Type:     isBad,
 			Position: 1,
@@ -173,7 +173,7 @@ func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *
 			badFunc.Position = position
 
 			if problemFunction == nil {
-				problemFunction = &problemOfTarget{Argument: funcName}
+				problemFunction = &ProblemOfTarget{Argument: funcName}
 			}
 
 			problemFunction.Problems = append(problemFunction.Problems, *badFunc)
@@ -183,9 +183,9 @@ func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *
 	return problemFunction
 }
 
-func checkFunction(funcName string, isRemote bool) *problemOfTarget {
+func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isUnstable := unstableFunctions[funcName]; isUnstable {
-		return &problemOfTarget{
+		return &ProblemOfTarget{
 			Argument:    funcName,
 			Type:        isBad,
 			Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
@@ -193,7 +193,7 @@ func checkFunction(funcName string, isRemote bool) *problemOfTarget {
 	}
 
 	if _, isFalseNotification := falseNotificationsFunctions[funcName]; isFalseNotification {
-		return &problemOfTarget{
+		return &ProblemOfTarget{
 			Argument:    funcName,
 			Type:        isWarn,
 			Description: "This function shows and hides entire metric series based on their values. Moira will send frequent false NODATA notifications.",
@@ -201,7 +201,7 @@ func checkFunction(funcName string, isRemote bool) *problemOfTarget {
 	}
 
 	if _, isVisual := visualFunctions[funcName]; isVisual {
-		return &problemOfTarget{
+		return &ProblemOfTarget{
 			Argument:    funcName,
 			Type:        isWarn,
 			Description: "This function affects only visual graph representation. It is meaningless in Moira.",
@@ -209,7 +209,7 @@ func checkFunction(funcName string, isRemote bool) *problemOfTarget {
 	}
 
 	if !isRemote && !funcIsSupported(funcName) {
-		return &problemOfTarget{
+		return &ProblemOfTarget{
 			Argument:    funcName,
 			Type:        isBad,
 			Description: "Function is not supported, if you want to use it, switch to remote",

--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -17,8 +17,8 @@ func init() {
 type typeOfProblem string
 
 const (
-	isWarn typeOfProblem = "warn"
-	isBad  typeOfProblem = "bad"
+	IsWarn typeOfProblem = "warn"
+	IsBad  typeOfProblem = "bad"
 )
 
 var (
@@ -156,7 +156,7 @@ func checkExpression(expression parser.Expr, ttl time.Duration, isRemote bool) *
 
 		problemFunction.Problems = append(problemFunction.Problems, ProblemOfTarget{
 			Argument: argument,
-			Type:     isBad,
+			Type:     IsBad,
 			Position: 1,
 			Description: fmt.Sprintf(
 				"The function %s has a time sampling parameter %s larger than allowed by the config:%s",
@@ -187,7 +187,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isUnstable := unstableFunctions[funcName]; isUnstable {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        isBad,
+			Type:        IsBad,
 			Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
 		}
 	}
@@ -195,7 +195,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isFalseNotification := falseNotificationsFunctions[funcName]; isFalseNotification {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        isWarn,
+			Type:        IsWarn,
 			Description: "This function shows and hides entire metric series based on their values. Moira will send frequent false NODATA notifications.",
 		}
 	}
@@ -203,7 +203,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if _, isVisual := visualFunctions[funcName]; isVisual {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        isWarn,
+			Type:        IsWarn,
 			Description: "This function affects only visual graph representation. It is meaningless in Moira.",
 		}
 	}
@@ -211,7 +211,7 @@ func checkFunction(funcName string, isRemote bool) *ProblemOfTarget {
 	if !isRemote && !funcIsSupported(funcName) {
 		return &ProblemOfTarget{
 			Argument:    funcName,
-			Type:        isBad,
+			Type:        IsBad,
 			Description: "Function is not supported, if you want to use it, switch to remote",
 			Position:    0,
 			Problems:    nil,
@@ -260,4 +260,28 @@ func positiveDuration(argument parser.Expr) (string, time.Duration) {
 	}
 
 	return value, secondTimeDuration
+}
+
+func AreTreesHaveError(trees []TreeOfProblems) bool {
+	for _, problem := range trees {
+		if isTreeHasError(problem.TreeOfProblems) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isTreeHasError(tree *ProblemOfTarget) bool {
+	if tree.Type == IsBad {
+		return true
+	}
+
+	for _, t := range tree.Problems {
+		if isTreeHasError(&t) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -108,6 +108,20 @@ type ProblemOfTarget struct {
 	Problems    []ProblemOfTarget `json:"problems,omitempty"`
 }
 
+func (p *ProblemOfTarget) hasError() bool {
+	if p.Type == isBad {
+		return true
+	}
+
+	for _, pp := range p.Problems {
+		if pp.hasError() {
+			return true
+		}
+	}
+
+	return false
+}
+
 type TreeOfProblems struct {
 	SyntaxOk       bool             `json:"syntax_ok"`
 	TreeOfProblems *ProblemOfTarget `json:"tree_of_problems,omitempty"`
@@ -138,6 +152,18 @@ func TargetVerification(targets []string, ttl time.Duration, isRemote bool) []Tr
 	}
 
 	return functionsOfTargets
+}
+
+// HaveTreesError checks that at least one node of tree has a problem with error type.
+// It is wrapper to handle slice of trees.
+func HaveTreesError(trees []TreeOfProblems) bool {
+	for _, tree := range trees {
+		if tree.TreeOfProblems.hasError() {
+			return true
+		}
+	}
+
+	return false
 }
 
 // checkExpression validates expression.
@@ -260,28 +286,4 @@ func positiveDuration(argument parser.Expr) (string, time.Duration) {
 	}
 
 	return value, secondTimeDuration
-}
-
-func AreTreesHaveError(trees []TreeOfProblems) bool {
-	for _, problem := range trees {
-		if isTreeHasError(problem.TreeOfProblems) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isTreeHasError(tree *ProblemOfTarget) bool {
-	if tree.Type == isBad {
-		return true
-	}
-
-	for _, t := range tree.Problems {
-		if isTreeHasError(&t) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -392,6 +392,7 @@ func (*ThrottlingResponse) Render(http.ResponseWriter, *http.Request) error {
 type SaveTriggerResponse struct {
 	ID      string `json:"id"`
 	Message string `json:"message"`
+	Targets []TreeOfProblems
 }
 
 func (*SaveTriggerResponse) Render(http.ResponseWriter, *http.Request) error {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -352,7 +352,7 @@ func (trigger *Trigger) PopulatedDescription(events moira.NotificationEvents) er
 	return nil
 }
 
-type TriggerCheckResult struct {
+type TriggerCheckResponse struct {
 	// Graphite-like targets: t1, t2, ...
 	Targets []TreeOfProblems `json:"targets,omitempty"`
 }
@@ -390,9 +390,9 @@ func (*ThrottlingResponse) Render(http.ResponseWriter, *http.Request) error {
 }
 
 type SaveTriggerResponse struct {
-	ID          string             `json:"id"`
-	Message     string             `json:"message"`
-	CheckResult TriggerCheckResult `json:"checkResult,omitempty"`
+	ID      string               `json:"id"`
+	Message string               `json:"message"`
+	Check   TriggerCheckResponse `json:"checkResult,omitempty"`
 }
 
 func (*SaveTriggerResponse) Render(http.ResponseWriter, *http.Request) error {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -390,9 +390,9 @@ func (*ThrottlingResponse) Render(http.ResponseWriter, *http.Request) error {
 }
 
 type SaveTriggerResponse struct {
-	ID      string               `json:"id"`
-	Message string               `json:"message"`
-	Check   TriggerCheckResponse `json:"check,omitempty"`
+	ID          string               `json:"id"`
+	Message     string               `json:"message"`
+	CheckResult TriggerCheckResponse `json:"checkResult,omitempty"`
 }
 
 func (*SaveTriggerResponse) Render(http.ResponseWriter, *http.Request) error {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -390,9 +390,9 @@ func (*ThrottlingResponse) Render(http.ResponseWriter, *http.Request) error {
 }
 
 type SaveTriggerResponse struct {
-	ID      string `json:"id"`
-	Message string `json:"message"`
-	Targets []TreeOfProblems
+	ID          string             `json:"id"`
+	Message     string             `json:"message"`
+	CheckResult TriggerCheckResult `json:"checkResult,omitempty"`
 }
 
 func (*SaveTriggerResponse) Render(http.ResponseWriter, *http.Request) error {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -392,7 +392,7 @@ func (*ThrottlingResponse) Render(http.ResponseWriter, *http.Request) error {
 type SaveTriggerResponse struct {
 	ID      string               `json:"id"`
 	Message string               `json:"message"`
-	Check   TriggerCheckResponse `json:"checkResult,omitempty"`
+	Check   TriggerCheckResponse `json:"check,omitempty"`
 }
 
 func (*SaveTriggerResponse) Render(http.ResponseWriter, *http.Request) error {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -30,7 +30,7 @@ type TriggersList struct {
 	List  []moira.TriggerCheck `json:"list"`
 }
 
-func (*TriggersList) Render(w http.ResponseWriter, r *http.Request) error {
+func (*TriggersList) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }
 
@@ -332,7 +332,7 @@ func checkSimpleModeFields(trigger *Trigger) error {
 	return nil
 }
 
-func (*Trigger) Render(w http.ResponseWriter, r *http.Request) error {
+func (*Trigger) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }
 
@@ -352,7 +352,7 @@ func (trigger *Trigger) PopulatedDescription(events moira.NotificationEvents) er
 	return nil
 }
 
-type TriggerCheckResponse struct {
+type TriggerCheckResult struct {
 	// Graphite-like targets: t1, t2, ...
 	Targets []TreeOfProblems `json:"targets,omitempty"`
 }
@@ -362,13 +362,13 @@ type TriggerCheck struct {
 	TriggerID string `json:"trigger_id"`
 }
 
-func (*TriggerCheck) Render(w http.ResponseWriter, r *http.Request) error {
+func (*TriggerCheck) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }
 
 type MetricsMaintenance map[string]int64
 
-func (*MetricsMaintenance) Bind(r *http.Request) error {
+func (*MetricsMaintenance) Bind(*http.Request) error {
 	return nil
 }
 
@@ -377,7 +377,7 @@ type TriggerMaintenance struct {
 	Metrics map[string]int64 `json:"metrics"`
 }
 
-func (*TriggerMaintenance) Bind(r *http.Request) error {
+func (*TriggerMaintenance) Bind(*http.Request) error {
 	return nil
 }
 
@@ -385,7 +385,7 @@ type ThrottlingResponse struct {
 	Throttling int64 `json:"throttling"`
 }
 
-func (*ThrottlingResponse) Render(w http.ResponseWriter, r *http.Request) error {
+func (*ThrottlingResponse) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }
 
@@ -394,13 +394,13 @@ type SaveTriggerResponse struct {
 	Message string `json:"message"`
 }
 
-func (*SaveTriggerResponse) Render(w http.ResponseWriter, r *http.Request) error {
+func (*SaveTriggerResponse) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }
 
 type TriggerMetrics map[string]map[string][]moira.MetricValue
 
-func (*TriggerMetrics) Render(w http.ResponseWriter, r *http.Request) error {
+func (*TriggerMetrics) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }
 
@@ -421,6 +421,6 @@ type TriggersSearchResultDeleteResponse struct {
 	PagerID string `json:"pager_id"`
 }
 
-func (TriggersSearchResultDeleteResponse) Render(w http.ResponseWriter, r *http.Request) error {
+func (TriggersSearchResultDeleteResponse) Render(http.ResponseWriter, *http.Request) error {
 	return nil
 }

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -56,7 +56,7 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if problems != nil {
-		response.Check.Targets = problems
+		response.CheckResult.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {
@@ -87,7 +87,7 @@ func validateTargets(request *http.Request, trigger *dto.Trigger) (problems []dt
 
 func writeErrorSaveResponse(writer http.ResponseWriter, request *http.Request, treesOfProblems []dto.TreeOfProblems) {
 	response := dto.SaveTriggerResponse{
-		Check: dto.TriggerCheckResponse{
+		CheckResult: dto.TriggerCheckResponse{
 			Targets: treesOfProblems,
 		},
 	}

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -42,11 +42,9 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	var problems []dto.TreeOfProblems
 	if isNeedValidate(request) {
 		problems = validateTargets(request, trigger)
-		if problems != nil {
-			if dto.AreTreesHaveError(problems) {
-				writeTargets(writer, request, problems)
-				return
-			}
+		if problems != nil && dto.AreTreesHaveError(problems) {
+			writeTargets(writer, request, problems)
+			return
 		}
 	}
 

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -39,11 +39,14 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	var problems []dto.TreeOfProblems
 	if isNeedValidate(request) {
-		problems := validateTargets(request, trigger)
+		problems = validateTargets(request, trigger)
 		if problems != nil {
-			writeProblems(writer, request, problems)
-			return
+			if dto.AreTreesHaveError(problems) {
+				writeTargets(writer, request, problems)
+				return
+			}
 		}
 	}
 
@@ -52,6 +55,10 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		render.Render(writer, request, err) //nolint
 		return
+	}
+
+	if problems != nil {
+		response.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {
@@ -80,7 +87,7 @@ func validateTargets(request *http.Request, trigger *dto.Trigger) (problems []dt
 	return nil
 }
 
-func writeProblems(writer http.ResponseWriter, request *http.Request, treesOfProblems []dto.TreeOfProblems) {
+func writeTargets(writer http.ResponseWriter, request *http.Request, treesOfProblems []dto.TreeOfProblems) {
 	result := dto.TriggerCheckResult{
 		Targets: treesOfProblems,
 	}

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -40,9 +40,9 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	var problems []dto.TreeOfProblems
-	if isNeedValidate(request) {
+	if needValidate(request) {
 		problems = validateTargets(request, trigger)
-		if problems != nil && dto.HaveTreesError(problems) {
+		if problems != nil && dto.DoesAnyTreeHaveError(problems) {
 			writeErrorSaveResponse(writer, request, problems)
 			return
 		}
@@ -65,7 +65,7 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 }
 
-func isNeedValidate(request *http.Request) bool {
+func needValidate(request *http.Request) bool {
 	const validateFlag = "validate"
 	return request.URL.Query().Has(validateFlag)
 }

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -86,12 +86,12 @@ func validateTargets(request *http.Request, trigger *dto.Trigger) (problems []dt
 }
 
 func writeErrorSaveResponse(writer http.ResponseWriter, request *http.Request, treesOfProblems []dto.TreeOfProblems) {
+	render.Status(request, http.StatusBadRequest)
 	response := dto.SaveTriggerResponse{
 		CheckResult: dto.TriggerCheckResponse{
 			Targets: treesOfProblems,
 		},
 	}
-	writer.WriteHeader(http.StatusBadRequest)
 	render.JSON(writer, request, response)
 }
 

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -42,7 +42,7 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	var problems []dto.TreeOfProblems
 	if isNeedValidate(request) {
 		problems = validateTargets(request, trigger)
-		if problems != nil && dto.AreTreesHaveError(problems) {
+		if problems != nil && dto.HaveTreesError(problems) {
 			writeErrorSaveResponse(writer, request, problems)
 			return
 		}

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -58,7 +58,7 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if problems != nil {
-		response.Targets = problems
+		response.CheckResult.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -43,7 +43,7 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	if isNeedValidate(request) {
 		problems = validateTargets(request, trigger)
 		if problems != nil && dto.AreTreesHaveError(problems) {
-			writeTargets(writer, request, problems)
+			writeErrorSaveResponse(writer, request, problems)
 			return
 		}
 	}
@@ -56,7 +56,7 @@ func updateTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if problems != nil {
-		response.CheckResult.Targets = problems
+		response.Check.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {
@@ -85,12 +85,14 @@ func validateTargets(request *http.Request, trigger *dto.Trigger) (problems []dt
 	return nil
 }
 
-func writeTargets(writer http.ResponseWriter, request *http.Request, treesOfProblems []dto.TreeOfProblems) {
-	result := dto.TriggerCheckResult{
-		Targets: treesOfProblems,
+func writeErrorSaveResponse(writer http.ResponseWriter, request *http.Request, treesOfProblems []dto.TreeOfProblems) {
+	response := dto.SaveTriggerResponse{
+		Check: dto.TriggerCheckResponse{
+			Targets: treesOfProblems,
+		},
 	}
 	writer.WriteHeader(http.StatusBadRequest)
-	render.JSON(writer, request, result)
+	render.JSON(writer, request, response)
 }
 
 func removeTrigger(writer http.ResponseWriter, request *http.Request) {

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -289,7 +289,7 @@ func TestUpdateTrigger(t *testing.T) {
 						},
 					},
 				}
-				So(actual.Check.Targets, ShouldResemble, expectedTargets)
+				So(actual.CheckResult.Targets, ShouldResemble, expectedTargets)
 				const expected = "trigger updated"
 				So(actual.Message, ShouldEqual, expected)
 			})
@@ -355,7 +355,7 @@ func TestUpdateTrigger(t *testing.T) {
 				_ = json.Unmarshal(contentBytes, &actual)
 
 				expected := dto.SaveTriggerResponse{
-					Check: dto.TriggerCheckResponse{
+					CheckResult: dto.TriggerCheckResponse{
 						Targets: []dto.TreeOfProblems{
 							{
 								SyntaxOk: true,

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -292,7 +292,7 @@ func TestUpdateTrigger(t *testing.T) {
 						},
 					},
 				}
-				So(actual.Targets, ShouldResemble, expectedTargets)
+				So(actual.CheckResult.Targets, ShouldResemble, expectedTargets)
 				const expected = "trigger updated"
 				So(actual.Message, ShouldEqual, expected)
 			})

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -292,7 +292,7 @@ func TestUpdateTrigger(t *testing.T) {
 						},
 					},
 				}
-				So(actual.CheckResult.Targets, ShouldResemble, expectedTargets)
+				So(actual.Check.Targets, ShouldResemble, expectedTargets)
 				const expected = "trigger updated"
 				So(actual.Message, ShouldEqual, expected)
 			})
@@ -357,10 +357,10 @@ func TestUpdateTrigger(t *testing.T) {
 				contents := string(contentBytes)
 				fmt.Println(contents)
 
-				actual := dto.TriggerCheckResult{}
+				actual := dto.TriggerCheckResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
-				expected := dto.TriggerCheckResult{
+				expected := dto.TriggerCheckResponse{
 					Targets: []dto.TreeOfProblems{
 						{
 							SyntaxOk: true,

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -178,13 +178,15 @@ func TestUpdateTrigger(t *testing.T) {
 		for _, url := range urls {
 			triggerWarnValue := float64(10)
 			triggerErrorValue := float64(15)
-			trigger := moira.Trigger{
-				Name:       "Test trigger",
-				Tags:       []string{"123"},
-				WarnValue:  &triggerWarnValue,
-				ErrorValue: &triggerErrorValue,
-				Targets:    []string{},
-				IsRemote:   false,
+			trigger := dto.Trigger{
+				TriggerModel: dto.TriggerModel{
+					Name:       "Test trigger",
+					Tags:       []string{"123"},
+					WarnValue:  &triggerWarnValue,
+					ErrorValue: &triggerErrorValue,
+					Targets:    []string{},
+					IsRemote:   false,
+				},
 			}
 
 			jsonTrigger, _ := json.Marshal(trigger)
@@ -213,7 +215,7 @@ func TestUpdateTrigger(t *testing.T) {
 			Tags:       []string{"123"},
 			WarnValue:  &triggerWarnValue,
 			ErrorValue: &triggerErrorValue,
-			Targets:    []string{"consolidateBy(Sales.widgets.largeBlue, 'sum')"},
+			Targets:    []string{"alias(consolidateBy(Sales.widgets.largeBlue, 'sum'), 'alias to test nesting')"},
 			IsRemote:   false,
 		}
 
@@ -245,6 +247,13 @@ func TestUpdateTrigger(t *testing.T) {
 		})
 
 		Convey("with validate", func() {
+			mockDb.EXPECT().GetTrigger(gomock.Any()).Return(trigger, nil)
+			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
+			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
+			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
+			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
+			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
+
 			request := httptest.NewRequest("", fmt.Sprintf("/trigger?%s", validateFlag), bytes.NewBuffer(jsonTrigger))
 			request.Header.Add("content-type", "application/json")
 			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
@@ -254,33 +263,38 @@ func TestUpdateTrigger(t *testing.T) {
 			responseWriter := httptest.NewRecorder()
 			updateTrigger(responseWriter, request)
 
-			Convey("should return 400 and tree of problems", func() {
+			Convey("should return 200 and tree of problems", func() {
 				response := responseWriter.Result()
 				defer response.Body.Close()
 
-				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
 
 				contentBytes, _ := io.ReadAll(response.Body)
 				contents := string(contentBytes)
 				fmt.Println(contents)
 
-				actual := dto.TriggerCheckResult{}
+				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
-				expected := dto.TriggerCheckResult{
-					Targets: []dto.TreeOfProblems{
-						{
-							SyntaxOk: true,
-							TreeOfProblems: &dto.ProblemOfTarget{
-								Argument:    "consolidateBy",
-								Type:        "warn",
-								Description: "This function affects only visual graph representation. It is meaningless in Moira.",
-								Position:    0,
+				So(actual.ID, ShouldEqual, triggerID)
+				expectedTargets := []dto.TreeOfProblems{
+					{
+						SyntaxOk: true,
+						TreeOfProblems: &dto.ProblemOfTarget{
+							Argument: "alias",
+							Problems: []dto.ProblemOfTarget{
+								{
+									Argument:    "consolidateBy",
+									Type:        "warn",
+									Description: "This function affects only visual graph representation. It is meaningless in Moira.",
+								},
 							},
 						},
 					},
 				}
-				So(actual, ShouldResemble, expected)
+				So(actual.Targets, ShouldResemble, expectedTargets)
+				const expected = "trigger updated"
+				So(actual.Message, ShouldEqual, expected)
 			})
 		})
 	})
@@ -293,7 +307,7 @@ func TestUpdateTrigger(t *testing.T) {
 			Tags:       []string{"123"},
 			WarnValue:  &triggerWarnValue,
 			ErrorValue: &triggerErrorValue,
-			Targets:    []string{"summarize(my.metric, '5min')"},
+			Targets:    []string{"alias(summarize(my.metric, '5min'), 'alias to test nesting')"},
 			IsRemote:   false,
 		}
 		jsonTrigger, _ := json.Marshal(trigger)
@@ -351,10 +365,14 @@ func TestUpdateTrigger(t *testing.T) {
 						{
 							SyntaxOk: true,
 							TreeOfProblems: &dto.ProblemOfTarget{
-								Argument:    "summarize",
-								Type:        "bad",
-								Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
-								Position:    0,
+								Argument: "alias",
+								Problems: []dto.ProblemOfTarget{
+									{
+										Argument:    "summarize",
+										Type:        "bad",
+										Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
+									},
+								},
 							},
 						},
 					},

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,9 +12,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api/dto"
 	"github.com/moira-alert/moira/api/middleware"
+	metricSource "github.com/moira-alert/moira/metric_source"
+	mock_metric_source "github.com/moira-alert/moira/mock/metric_source"
 	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/xiam/to"
 )
 
 func TestGetTrigger(t *testing.T) {
@@ -94,4 +100,276 @@ func TestGetTrigger(t *testing.T) {
 			So(contents, ShouldEqual, expected)
 		})
 	})
+}
+
+func TestUpdateTrigger(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	localSource := mock_metric_source.NewMockMetricSource(mockCtrl)
+	remoteSource := mock_metric_source.NewMockMetricSource(mockCtrl)
+	sourceProvider := metricSource.CreateMetricSourceProvider(localSource, remoteSource)
+
+	localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes()
+	localSource.EXPECT().GetMetricsTTLSeconds().Return(int64(3600)).AnyTimes()
+	fetchResult := mock_metric_source.NewMockFetchResult(mockCtrl)
+	localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil).AnyTimes()
+	fetchResult.EXPECT().GetPatterns().Return(make([]string, 0), nil).AnyTimes()
+	fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)}).AnyTimes()
+
+	const validateFlag = "validate"
+
+	mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
+	database = mockDb
+
+	const triggerIDKey = "triggerID"
+	const triggerID = "test"
+
+	Convey("When updateTrigger was called with normal input", t, func() {
+		urls := []string{
+			"/",
+			fmt.Sprintf("/trigger?%s", validateFlag),
+		}
+
+		for _, url := range urls {
+			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
+			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
+			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
+			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
+			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
+
+			triggerWarnValue := float64(10)
+			triggerErrorValue := float64(15)
+			trigger := moira.Trigger{
+				Name:       "Test trigger",
+				Tags:       []string{"123"},
+				WarnValue:  &triggerWarnValue,
+				ErrorValue: &triggerErrorValue,
+				Targets:    []string{"my.metric"},
+				IsRemote:   false,
+			}
+			mockDb.EXPECT().GetTrigger(gomock.Any()).Return(trigger, nil)
+
+			jsonTrigger, _ := json.Marshal(trigger)
+			testRequest := httptest.NewRequest("", url, bytes.NewBuffer(jsonTrigger))
+			testRequest.Header.Add("content-type", "application/json")
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "localMetricTTL", to.Duration("65m")))
+
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), triggerIDKey, triggerID))
+
+			responseWriter := httptest.NewRecorder()
+			updateTrigger(responseWriter, testRequest)
+
+			Convey(fmt.Sprintf("should return success message, url=%s", url), func() {
+				response := responseWriter.Result()
+				defer response.Body.Close()
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+				So(isTriggerUpdated(response), ShouldBeTrue)
+			})
+		}
+	})
+
+	Convey("When updateTrigger was called with empty targets", t, func() {
+		urls := []string{
+			"/",
+			fmt.Sprintf("/trigger?%s", validateFlag),
+		}
+
+		for _, url := range urls {
+			triggerWarnValue := float64(10)
+			triggerErrorValue := float64(15)
+			trigger := moira.Trigger{
+				Name:       "Test trigger",
+				Tags:       []string{"123"},
+				WarnValue:  &triggerWarnValue,
+				ErrorValue: &triggerErrorValue,
+				Targets:    []string{},
+				IsRemote:   false,
+			}
+
+			jsonTrigger, _ := json.Marshal(trigger)
+			request := httptest.NewRequest("", url, bytes.NewBuffer(jsonTrigger))
+			request.Header.Add("content-type", "application/json")
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "localMetricTTL", to.Duration("65m")))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), triggerIDKey, triggerID))
+
+			responseWriter := httptest.NewRecorder()
+			updateTrigger(responseWriter, request)
+
+			Convey(fmt.Sprintf("should return 400, url=%s", url), func() {
+				response := responseWriter.Result()
+				defer response.Body.Close()
+				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+			})
+		}
+	})
+
+	Convey("When updateTrigger was called with target with warning function", t, func() {
+		triggerWarnValue := float64(10)
+		triggerErrorValue := float64(15)
+		trigger := moira.Trigger{
+			Name:       "Test trigger",
+			Tags:       []string{"123"},
+			WarnValue:  &triggerWarnValue,
+			ErrorValue: &triggerErrorValue,
+			Targets:    []string{"consolidateBy(Sales.widgets.largeBlue, 'sum')"},
+			IsRemote:   false,
+		}
+
+		jsonTrigger, _ := json.Marshal(trigger)
+
+		Convey("without validate like before", func() {
+			mockDb.EXPECT().GetTrigger(gomock.Any()).Return(trigger, nil)
+			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
+			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
+			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
+			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
+			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
+
+			request := httptest.NewRequest("", "/", bytes.NewBuffer(jsonTrigger))
+			request.Header.Add("content-type", "application/json")
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "localMetricTTL", to.Duration("65m")))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), triggerIDKey, triggerID))
+
+			responseWriter := httptest.NewRecorder()
+			updateTrigger(responseWriter, request)
+
+			Convey("should return 200", func() {
+				response := responseWriter.Result()
+				defer response.Body.Close()
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+				So(isTriggerUpdated(response), ShouldBeTrue)
+			})
+		})
+
+		Convey("with validate", func() {
+			request := httptest.NewRequest("", fmt.Sprintf("/trigger?%s", validateFlag), bytes.NewBuffer(jsonTrigger))
+			request.Header.Add("content-type", "application/json")
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "localMetricTTL", to.Duration("65m")))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), triggerIDKey, triggerID))
+
+			responseWriter := httptest.NewRecorder()
+			updateTrigger(responseWriter, request)
+
+			Convey("should return 400 and tree of problems", func() {
+				response := responseWriter.Result()
+				defer response.Body.Close()
+
+				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+
+				contentBytes, _ := io.ReadAll(response.Body)
+				contents := string(contentBytes)
+				fmt.Println(contents)
+
+				actual := dto.TriggerCheckResult{}
+				_ = json.Unmarshal(contentBytes, &actual)
+
+				expected := dto.TriggerCheckResult{
+					Targets: []dto.TreeOfProblems{
+						{
+							SyntaxOk: true,
+							TreeOfProblems: &dto.ProblemOfTarget{
+								Argument:    "consolidateBy",
+								Type:        "warn",
+								Description: "This function affects only visual graph representation. It is meaningless in Moira.",
+								Position:    0,
+							},
+						},
+					},
+				}
+				So(actual, ShouldResemble, expected)
+			})
+		})
+	})
+
+	Convey("When updateTrigger was called with target with bad (error) function", t, func() {
+		triggerWarnValue := float64(10)
+		triggerErrorValue := float64(15)
+		trigger := moira.Trigger{
+			Name:       "Test trigger",
+			Tags:       []string{"123"},
+			WarnValue:  &triggerWarnValue,
+			ErrorValue: &triggerErrorValue,
+			Targets:    []string{"summarize(my.metric, '5min')"},
+			IsRemote:   false,
+		}
+		jsonTrigger, _ := json.Marshal(trigger)
+
+		Convey("without validate like before", func() {
+			mockDb.EXPECT().GetTrigger(gomock.Any()).Return(trigger, nil)
+			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
+			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
+			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
+			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
+			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
+
+			request := httptest.NewRequest("", "/", bytes.NewBuffer(jsonTrigger))
+			request.Header.Add("content-type", "application/json")
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "localMetricTTL", to.Duration("65m")))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), triggerIDKey, triggerID))
+
+			responseWriter := httptest.NewRecorder()
+			updateTrigger(responseWriter, request)
+
+			Convey("should return 200", func() {
+				response := responseWriter.Result()
+				defer response.Body.Close()
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+				So(isTriggerUpdated(response), ShouldBeTrue)
+			})
+		})
+
+		Convey("with validate", func() {
+			request := httptest.NewRequest("", fmt.Sprintf("/trigger?%s", validateFlag), bytes.NewBuffer(jsonTrigger))
+			request.Header.Add("content-type", "application/json")
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "localMetricTTL", to.Duration("65m")))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), triggerIDKey, triggerID))
+
+			responseWriter := httptest.NewRecorder()
+			updateTrigger(responseWriter, request)
+
+			Convey("should return 400 and tree of problems", func() {
+				response := responseWriter.Result()
+				defer response.Body.Close()
+
+				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+
+				contentBytes, _ := io.ReadAll(response.Body)
+				contents := string(contentBytes)
+				fmt.Println(contents)
+
+				actual := dto.TriggerCheckResult{}
+				_ = json.Unmarshal(contentBytes, &actual)
+
+				expected := dto.TriggerCheckResult{
+					Targets: []dto.TreeOfProblems{
+						{
+							SyntaxOk: true,
+							TreeOfProblems: &dto.ProblemOfTarget{
+								Argument:    "summarize",
+								Type:        "bad",
+								Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
+								Position:    0,
+							},
+						},
+					},
+				}
+				So(actual, ShouldResemble, expected)
+			})
+		})
+	})
+}
+
+func isTriggerUpdated(response *http.Response) bool {
+	contentBytes, _ := io.ReadAll(response.Body)
+	actual := dto.SaveTriggerResponse{}
+	_ = json.Unmarshal(contentBytes, &actual)
+	const expected = "trigger updated"
+
+	return actual.Message == expected
 }

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -270,9 +270,6 @@ func TestUpdateTrigger(t *testing.T) {
 				So(response.StatusCode, ShouldEqual, http.StatusOK)
 
 				contentBytes, _ := io.ReadAll(response.Body)
-				contents := string(contentBytes)
-				fmt.Println(contents)
-
 				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
@@ -354,9 +351,6 @@ func TestUpdateTrigger(t *testing.T) {
 				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 
 				contentBytes, _ := io.ReadAll(response.Body)
-				contents := string(contentBytes)
-				fmt.Println(contents)
-
 				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -357,20 +357,22 @@ func TestUpdateTrigger(t *testing.T) {
 				contents := string(contentBytes)
 				fmt.Println(contents)
 
-				actual := dto.TriggerCheckResponse{}
+				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
-				expected := dto.TriggerCheckResponse{
-					Targets: []dto.TreeOfProblems{
-						{
-							SyntaxOk: true,
-							TreeOfProblems: &dto.ProblemOfTarget{
-								Argument: "alias",
-								Problems: []dto.ProblemOfTarget{
-									{
-										Argument:    "summarize",
-										Type:        "bad",
-										Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
+				expected := dto.SaveTriggerResponse{
+					Check: dto.TriggerCheckResponse{
+						Targets: []dto.TreeOfProblems{
+							{
+								SyntaxOk: true,
+								TreeOfProblems: &dto.ProblemOfTarget{
+									Argument: "alias",
+									Problems: []dto.ProblemOfTarget{
+										{
+											Argument:    "summarize",
+											Type:        "bad",
+											Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
+										},
 									},
 								},
 							},

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -134,7 +134,7 @@ func getMetricTTLByTrigger(request *http.Request, trigger *dto.Trigger) time.Dur
 
 func triggerCheck(writer http.ResponseWriter, request *http.Request) {
 	trigger := &dto.Trigger{}
-	result := dto.TriggerCheckResponse{}
+	response := dto.TriggerCheckResponse{}
 
 	if err := render.Bind(request, trigger); err != nil {
 		switch err.(type) {
@@ -150,10 +150,10 @@ func triggerCheck(writer http.ResponseWriter, request *http.Request) {
 	ttl := getMetricTTLByTrigger(request, trigger)
 
 	if len(trigger.Targets) > 0 {
-		result.Targets = dto.TargetVerification(trigger.Targets, ttl, trigger.IsRemote)
+		response.Targets = dto.TargetVerification(trigger.Targets, ttl, trigger.IsRemote)
 	}
 
-	render.JSON(writer, request, result)
+	render.JSON(writer, request, response)
 }
 
 func searchTriggers(writer http.ResponseWriter, request *http.Request) {

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -60,9 +60,9 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	var problems []dto.TreeOfProblems
-	if isNeedValidate(request) {
+	if needValidate(request) {
 		problems = validateTargets(request, trigger)
-		if problems != nil && dto.HaveTreesError(problems) {
+		if problems != nil && dto.DoesAnyTreeHaveError(problems) {
 			writeErrorSaveResponse(writer, request, problems)
 			return
 		}

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -85,7 +85,7 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if problems != nil {
-		response.Check.Targets = problems
+		response.CheckResult.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -59,11 +59,14 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	var problems []dto.TreeOfProblems
 	if isNeedValidate(request) {
-		problems := validateTargets(request, trigger)
+		problems = validateTargets(request, trigger)
 		if problems != nil {
-			writeProblems(writer, request, problems)
-			return
+			if dto.AreTreesHaveError(problems) {
+				writeTargets(writer, request, problems)
+				return
+			}
 		}
 	}
 
@@ -81,6 +84,10 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		render.Render(writer, request, err) //nolint
 		return
+	}
+
+	if problems != nil {
+		response.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -139,8 +139,14 @@ func triggerCheck(writer http.ResponseWriter, request *http.Request) {
 	result := dto.TriggerCheckResult{}
 
 	if err := render.Bind(request, trigger); err != nil {
-		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
-		return
+		switch err.(type) {
+		case expression.ErrInvalidExpression, local.ErrParseExpr, local.ErrEvalExpr, local.ErrUnknownFunction:
+			// TODO write comment, why errors are ignored, it is not obvious.
+			// In getTriggerFromRequest these types of errors lead to 400.
+		default:
+			render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+			return
+		}
 	}
 
 	ttl := getMetricTTLByTrigger(request, trigger)

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -63,7 +63,7 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	if isNeedValidate(request) {
 		problems = validateTargets(request, trigger)
 		if problems != nil && dto.AreTreesHaveError(problems) {
-			writeTargets(writer, request, problems)
+			writeErrorSaveResponse(writer, request, problems)
 			return
 		}
 	}
@@ -85,7 +85,7 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if problems != nil {
-		response.CheckResult.Targets = problems
+		response.Check.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {
@@ -134,7 +134,7 @@ func getMetricTTLByTrigger(request *http.Request, trigger *dto.Trigger) time.Dur
 
 func triggerCheck(writer http.ResponseWriter, request *http.Request) {
 	trigger := &dto.Trigger{}
-	result := dto.TriggerCheckResult{}
+	result := dto.TriggerCheckResponse{}
 
 	if err := render.Bind(request, trigger); err != nil {
 		switch err.(type) {

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -120,24 +120,20 @@ func getMetricTTLByTrigger(request *http.Request, trigger *dto.Trigger) time.Dur
 
 func triggerCheck(writer http.ResponseWriter, request *http.Request) {
 	trigger := &dto.Trigger{}
-	response := dto.TriggerCheckResponse{}
+	result := dto.TriggerCheckResult{}
 
 	if err := render.Bind(request, trigger); err != nil {
-		switch err.(type) {
-		case expression.ErrInvalidExpression, local.ErrParseExpr, local.ErrEvalExpr, local.ErrUnknownFunction:
-		default:
-			render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
-			return
-		}
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+		return
 	}
 
 	ttl := getMetricTTLByTrigger(request, trigger)
 
 	if len(trigger.Targets) > 0 {
-		response.Targets = dto.TargetVerification(trigger.Targets, ttl, trigger.IsRemote)
+		result.Targets = dto.TargetVerification(trigger.Targets, ttl, trigger.IsRemote)
 	}
 
-	render.JSON(writer, request, response)
+	render.JSON(writer, request, result)
 }
 
 func searchTriggers(writer http.ResponseWriter, request *http.Request) {

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -87,7 +87,7 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	if problems != nil {
-		response.Targets = problems
+		response.CheckResult.Targets = problems
 	}
 
 	if err := render.Render(writer, request, response); err != nil {

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -62,11 +62,9 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	var problems []dto.TreeOfProblems
 	if isNeedValidate(request) {
 		problems = validateTargets(request, trigger)
-		if problems != nil {
-			if dto.AreTreesHaveError(problems) {
-				writeTargets(writer, request, problems)
-				return
-			}
+		if problems != nil && dto.AreTreesHaveError(problems) {
+			writeTargets(writer, request, problems)
+			return
 		}
 	}
 

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -59,24 +59,10 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	const validateFlag = "validate"
-	needValidate := request.URL.Query().Has(validateFlag)
-	if needValidate {
-		ttl := getMetricTTLByTrigger(request, trigger)
-		treesOfProblems := dto.TargetVerification(trigger.Targets, ttl, trigger.IsRemote)
-		var isInvalid bool
-		for _, tree := range treesOfProblems {
-			if tree.TreeOfProblems != nil {
-				isInvalid = true
-			}
-		}
-		if isInvalid {
-			result := dto.TriggerCheckResult{
-				Targets: treesOfProblems,
-			}
-			writer.WriteHeader(http.StatusBadRequest)
-			render.JSON(writer, request, result)
-
+	if isNeedValidate(request) {
+		problems := validateTargets(request, trigger)
+		if problems != nil {
+			writeProblems(writer, request, problems)
 			return
 		}
 	}

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -62,7 +62,7 @@ func createTrigger(writer http.ResponseWriter, request *http.Request) {
 	var problems []dto.TreeOfProblems
 	if isNeedValidate(request) {
 		problems = validateTargets(request, trigger)
-		if problems != nil && dto.AreTreesHaveError(problems) {
+		if problems != nil && dto.HaveTreesError(problems) {
 			writeErrorSaveResponse(writer, request, problems)
 			return
 		}

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -501,20 +501,22 @@ func TestCreateTriggerHandler(t *testing.T) {
 				contents := string(contentBytes)
 				fmt.Println(contents)
 
-				actual := dto.TriggerCheckResponse{}
+				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
-				expected := dto.TriggerCheckResponse{
-					Targets: []dto.TreeOfProblems{
-						{
-							SyntaxOk: true,
-							TreeOfProblems: &dto.ProblemOfTarget{
-								Argument: "alias",
-								Problems: []dto.ProblemOfTarget{
-									{
-										Argument:    "summarize",
-										Type:        "bad",
-										Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
+				expected := dto.SaveTriggerResponse{
+					Check: dto.TriggerCheckResponse{
+						Targets: []dto.TreeOfProblems{
+							{
+								SyntaxOk: true,
+								TreeOfProblems: &dto.ProblemOfTarget{
+									Argument: "alias",
+									Problems: []dto.ProblemOfTarget{
+										{
+											Argument:    "summarize",
+											Type:        "bad",
+											Description: "This function is unstable: it can return different historical values with each evaluation. Moira will show unexpected values that you don't see on your graphs.",
+										},
 									},
 								},
 							},

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -492,6 +492,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 				response := responseWriter.Result()
 				defer response.Body.Close()
 
+				So(response.Header.Get("Content-Type"), ShouldEqual, "application/json; charset=utf-8")
 				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 
 				contentBytes, _ := io.ReadAll(response.Body)

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -437,7 +437,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 						},
 					},
 				}
-				So(actual.CheckResult.Targets, ShouldResemble, expectedTargets)
+				So(actual.Check.Targets, ShouldResemble, expectedTargets)
 				const expected = "trigger created"
 				So(actual.Message, ShouldEqual, expected)
 			})
@@ -501,10 +501,10 @@ func TestCreateTriggerHandler(t *testing.T) {
 				contents := string(contentBytes)
 				fmt.Println(contents)
 
-				actual := dto.TriggerCheckResult{}
+				actual := dto.TriggerCheckResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
-				expected := dto.TriggerCheckResult{
+				expected := dto.TriggerCheckResponse{
 					Targets: []dto.TreeOfProblems{
 						{
 							SyntaxOk: true,

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -437,7 +437,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 						},
 					},
 				}
-				So(actual.Targets, ShouldResemble, expectedTargets)
+				So(actual.CheckResult.Targets, ShouldResemble, expectedTargets)
 				const expected = "trigger created"
 				So(actual.Message, ShouldEqual, expected)
 			})

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -434,7 +434,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 						},
 					},
 				}
-				So(actual.Check.Targets, ShouldResemble, expectedTargets)
+				So(actual.CheckResult.Targets, ShouldResemble, expectedTargets)
 				const expected = "trigger created"
 				So(actual.Message, ShouldEqual, expected)
 			})
@@ -499,7 +499,7 @@ func TestCreateTriggerHandler(t *testing.T) {
 				_ = json.Unmarshal(contentBytes, &actual)
 
 				expected := dto.SaveTriggerResponse{
-					Check: dto.TriggerCheckResponse{
+					CheckResult: dto.TriggerCheckResponse{
 						Targets: []dto.TreeOfProblems{
 							{
 								SyntaxOk: true,

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -416,9 +416,6 @@ func TestCreateTriggerHandler(t *testing.T) {
 				So(response.StatusCode, ShouldEqual, http.StatusOK)
 
 				contentBytes, _ := io.ReadAll(response.Body)
-				contents := string(contentBytes)
-				fmt.Println(contents)
-
 				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 
@@ -498,9 +495,6 @@ func TestCreateTriggerHandler(t *testing.T) {
 				So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 
 				contentBytes, _ := io.ReadAll(response.Body)
-				contents := string(contentBytes)
-				fmt.Println(contents)
-
 				actual := dto.SaveTriggerResponse{}
 				_ = json.Unmarshal(contentBytes, &actual)
 


### PR DESCRIPTION
There is a problem that client sides should call /trigger/check/ API for validation, but obviously it is not necessary. As a result we have invalid triggers in DB. The plan consists of next steps:

1. Test current createTrigger and updateTrigger API.
2. Add new version of createTrigger and updateTrigger API with validation and test it. New version should not affect prev version, It is important for backward compatibility, because Moira is follows API first approach.

Then in another PRs update client sides to use new version of APIs.