### PR TITLE
fix(filter): fix regex in series by tag parser

### DIFF
--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -39,7 +39,7 @@ type TagSpec struct {
 
 func transformWildcardToRegexpInSeriesByTag(input string) (string, bool) {
 	var (
-		result                                     = input
+		result := input
 		correctLengthOfMatchedWildcardIndexesSlice = 4
 		isTransformed                              = false
 	)

--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	tagSpecRegex          = regexp.MustCompile(`^["']([^,!=]+)\s*(!?=~?)\s*([^"]*)["']`)
+	tagSpecRegex          = regexp.MustCompile(`^["']([^,!=]+)\s*(!?=~?)\s*([^"']*)["']`)
 	tagSpecDelimiterRegex = regexp.MustCompile(`^\s*,\s*`)
 	seriesByTagRegex      = regexp.MustCompile(`^seriesByTag\((.+)\)$`)
 	wildcardExprRegex     = regexp.MustCompile(`\{(.*?)\}`)

--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -28,6 +28,8 @@ const (
 	MatchOperator TagSpecOperator = "=~"
 	// NotMatchOperator is a non-match operator which helps not to match metric by regex
 	NotMatchOperator TagSpecOperator = "!=~"
+
+	correctLengthOfMatchedWildcardIndexesSlice = 4
 )
 
 // TagSpec is a filter expression inside seriesByTag pattern
@@ -38,11 +40,9 @@ type TagSpec struct {
 }
 
 func transformWildcardToRegexpInSeriesByTag(input string) (string, bool) {
-	var (
-		result := input
-		correctLengthOfMatchedWildcardIndexesSlice = 4
-		isTransformed                              = false
-	)
+	var isTransformed = false
+
+	result := input
 
 	for {
 		matchedWildcardIndexes := wildcardExprRegex.FindStringSubmatchIndex(result)

--- a/filter/series_by_tag_pattern_index_test.go
+++ b/filter/series_by_tag_pattern_index_test.go
@@ -67,6 +67,7 @@ func TestParseSeriesByTag(t *testing.T) {
 			{`seriesByTag("respCode=~^(4|5)\d{2}")`, []TagSpec{{"respCode", MatchOperator, "^(4|5)\\d{2}"}}},
 			{`seriesByTag("a={b,c,d}", "e=f")`, []TagSpec{{"a", MatchOperator, "(b|c|d)$"}, {"e", EqualOperator, "f"}}},
 			{`seriesByTag("a!={b,c,d}", "e=f")`, []TagSpec{{"a", NotMatchOperator, "(b|c|d)$"}, {"e", EqualOperator, "f"}}},
+			{`seriesByTag('a!={b,c,d}', 'e=f')`, []TagSpec{{"a", NotMatchOperator, "(b|c|d)$"}, {"e", EqualOperator, "f"}}},
 		}
 
 		for _, validCase := range validSeriesByTagCases {

--- a/filter/series_by_tag_pattern_index_test.go
+++ b/filter/series_by_tag_pattern_index_test.go
@@ -13,28 +13,34 @@ func TestTransformTaggedWildCardToMatchOperator(t *testing.T) {
 		testCases := []struct {
 			PatternWithWildcard string
 			PatternWithRegexp   string
+			IsTransformed       bool
 		}{
 			{
-				`"responseCode={405,406,407,411,413,414,415}"`,
-				`"responseCode=~(405|406|407|411|413|414|415)$"`,
+				`{405,406,407,411,413,414,415}`,
+				`(405|406|407|411|413|414|415)$`,
+				true,
 			},
 			{
-				`"a=b, responseCode={405,406,407,411,413,414,415}"`,
-				`"a=b, responseCode=~(405|406|407|411|413|414|415)$"`,
+				`aaa.{405,406,407,411,413,414,415}.bbb`,
+				`aaa.(405|406|407|411|413|414|415).bbb$`,
+				true,
 			},
 			{
-				`"responseCode={405,406,407,411,413,414,415}, a=b"`,
-				`"responseCode=~(405|406|407|411|413|414|415)$, a=b"`,
+				`aaa.{405,406}.bbb.{301,302}`,
+				`aaa.(405|406).bbb.(301|302)$`,
+				true,
 			},
 			{
-				`"responseCode={405,406,407,411,413,414,415}, returnValue={1, 2, 3}"`,
-				`"responseCode=~(405|406|407|411|413|414|415)$, returnValue=~(1|2|3)$"`,
+				`a(b|c|d)e`,
+				`a(b|c|d)e`,
+				false,
 			},
 		}
 
 		for _, testCase := range testCases {
-			result := transformWildcardToRegexpInSeriesByTag(testCase.PatternWithWildcard)
+			result, isTransformed := transformWildcardToRegexpInSeriesByTag(testCase.PatternWithWildcard)
 			So(result, ShouldEqual, testCase.PatternWithRegexp)
+			So(isTransformed, ShouldEqual, testCase.IsTransformed)
 		}
 	})
 }
@@ -54,9 +60,13 @@ func TestParseSeriesByTag(t *testing.T) {
 			{"seriesByTag(\"a=~b\")", []TagSpec{{"a", MatchOperator, "b"}}},
 			{"seriesByTag(\"a!=~b\")", []TagSpec{{"a", NotMatchOperator, "b"}}},
 			{"seriesByTag(\"a=\")", []TagSpec{{"a", EqualOperator, ""}}},
-			{"seriesByTag(\"a=b\",\"a=c\")", []TagSpec{{"a", EqualOperator, "b"}, {"a", EqualOperator, "c"}}},
-			{"seriesByTag(\"a=b\",\"b=c\",\"c=d\")", []TagSpec{{"a", EqualOperator, "b"}, {"b", EqualOperator, "c"}, {"c", EqualOperator, "d"}}},
+			{`seriesByTag("a=b","a=c")`, []TagSpec{{"a", EqualOperator, "b"}, {"a", EqualOperator, "c"}}},
+			{`seriesByTag("a=b","b=c","c=d")`, []TagSpec{{"a", EqualOperator, "b"}, {"b", EqualOperator, "c"}, {"c", EqualOperator, "d"}}},
 			{`seriesByTag("a={b,c,d}")`, []TagSpec{{"a", MatchOperator, "(b|c|d)$"}}},
+			{`seriesByTag("a=~aa.(b|c|d)$")`, []TagSpec{{"a", MatchOperator, "aa.(b|c|d)$"}}},
+			{`seriesByTag("respCode=~^(4|5)\d{2}")`, []TagSpec{{"respCode", MatchOperator, "^(4|5)\\d{2}"}}},
+			{`seriesByTag("a={b,c,d}", "e=f")`, []TagSpec{{"a", MatchOperator, "(b|c|d)$"}, {"e", EqualOperator, "f"}}},
+			{`seriesByTag("a!={b,c,d}", "e=f")`, []TagSpec{{"a", NotMatchOperator, "(b|c|d)$"}, {"e", EqualOperator, "f"}}},
 		}
 
 		for _, validCase := range validSeriesByTagCases {


### PR DESCRIPTION
# PR Summary
This PR fix `series by tags` parser. 
1. Fix regular expression for correct work with regular expressions in tags. Example: `seriesByTag("respCode=~^(4|5)\d{2}")`
2. Now transform function applied to every tag spec. Not for whole value in `seriesByTag()`.
3. If spec was tranformed change `operator` from `equal` to `match`.

Closes #823 
