### PR TITLE
Make strings.Split function available in description templates

### DIFF
--- a/templating/templating.go
+++ b/templating/templating.go
@@ -61,6 +61,7 @@ func Populate(name, description string, events []Event) (desc string, err error)
 		"stringsToUpper":    strings.ToUpper,
 		"stringsTrimPrefix": strings.TrimPrefix,
 		"stringsTrimSuffix": strings.TrimSuffix,
+		"stringsSplit":      strings.Split,
 	}
 
 	dataToExecute := notification{


### PR DESCRIPTION
Make strings.Split function available in description templates
