### PR TITLE
fix(checker): fix transition to ERROR state when duplicating metrics

### DIFF
--- a/checker/check.go
+++ b/checker/check.go
@@ -60,7 +60,7 @@ func (triggerChecker *TriggerChecker) Check() error {
 func (triggerChecker *TriggerChecker) handlePrepareError(checkData moira.CheckData, err error) (bool, moira.CheckData, error) {
 	switch err.(type) {
 	case ErrTriggerHasSameMetricNames:
-		checkData.State = moira.StateERROR
+		checkData.State = moira.StateEXCEPTION
 		checkData.Message = err.Error()
 		return true, checkData, nil
 	case conversion.ErrUnexpectedAloneMetric:

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -825,8 +825,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 				MetricsToTargetRelation:      map[string]string{"t1": "super.puper.metric"},
-				Score:                        100,
-				State:                        moira.StateERROR,
+				Score:                        100000,
+				State:                        moira.StateEXCEPTION,
 				Timestamp:                    triggerChecker.until,
 				EventTimestamp:               triggerChecker.until,
 				LastSuccessfulCheckTimestamp: triggerChecker.until,
@@ -835,7 +835,7 @@ func TestCheck(t *testing.T) {
 			event := moira.NotificationEvent{
 				IsTriggerEvent: true,
 				TriggerID:      triggerChecker.triggerID,
-				State:          moira.StateERROR,
+				State:          moira.StateEXCEPTION,
 				OldState:       moira.StateOK,
 				Timestamp:      67,
 				Metric:         triggerChecker.trigger.Name,
@@ -1445,7 +1445,7 @@ func TestTriggerChecker_handlePrepareError(t *testing.T) {
 			So(errReturn, ShouldBeNil)
 			So(pass, ShouldBeTrue)
 			So(checkDataReturn, ShouldResemble, moira.CheckData{
-				State:   moira.StateERROR,
+				State:   moira.StateEXCEPTION,
 				Message: err.Error(),
 			})
 		})

--- a/database/redis/last_check.go
+++ b/database/redis/last_check.go
@@ -106,7 +106,7 @@ func cleanUpAbandonedTriggerLastCheckOnRedisNode(connector *DbConnector, client 
 		triggerID := strings.TrimPrefix(lastCheckKey, metricLastCheckKey(""))
 		_, err := connector.GetTrigger(triggerID)
 		if err == database.ErrNil {
-			err := connector.RemoveTriggerLastCheck(triggerID)
+			err = connector.RemoveTriggerLastCheck(triggerID)
 			if err != nil {
 				return err
 			}

--- a/senders/pagerduty/send.go
+++ b/senders/pagerduty/send.go
@@ -18,7 +18,7 @@ const summaryMaxChars = 1024
 // SendEvents implements Sender interface Send
 func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.ContactData, trigger moira.TriggerData, plots [][]byte, throttled bool) error {
 	event := sender.buildEvent(events, contact, trigger, plots, throttled)
-	_, err := pagerduty.ManageEventWithContext(context.TODO(), event)
+	_, err := pagerduty.ManageEventWithContext(context.Background(), event)
 	if err != nil {
 		return fmt.Errorf("failed to post the event to the pagerduty contact %s : %s. ", contact.Value, err)
 	}

--- a/senders/pagerduty/send.go
+++ b/senders/pagerduty/send.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"time"
 
@@ -17,7 +18,7 @@ const summaryMaxChars = 1024
 // SendEvents implements Sender interface Send
 func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.ContactData, trigger moira.TriggerData, plots [][]byte, throttled bool) error {
 	event := sender.buildEvent(events, contact, trigger, plots, throttled)
-	_, err := pagerduty.ManageEvent(event)
+	_, err := pagerduty.ManageEventWithContext(context.TODO(), event)
 	if err != nil {
 		return fmt.Errorf("failed to post the event to the pagerduty contact %s : %s. ", contact.Value, err)
 	}


### PR DESCRIPTION
fix transition to ERROR state when duplicating metrics

Replaced the ERROR condition with EXCEPTION for duplicate names in `checker/check.go`, fixed the corresponding tests

Also fixed 2 linter errors in `database/redis` and `senders/pagerduty`
