### PR TITLE
fix(senders): remove telegram token from error message

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -3,6 +3,7 @@ package moira
 import (
 	"bytes"
 	"math"
+	"strings"
 	"time"
 )
 
@@ -202,4 +203,17 @@ func MaxInt64(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+// ReplaceSubstring removes one substring between the beg and end substrings and replaces it with a rep
+func ReplaceSubstring(str, beg, end, rep string) string {
+	result := str
+	startIndex := strings.Index(str, beg)
+	if startIndex != -1 {
+		endIndex := strings.Index(str[startIndex:], end) + len(str[:startIndex])
+		if endIndex != -1 {
+			result = str[:startIndex] + rep + str[endIndex:]
+		}
+	}
+	return result
 }

--- a/helpers.go
+++ b/helpers.go
@@ -210,8 +210,9 @@ func ReplaceSubstring(str, beg, end, rep string) string {
 	result := str
 	startIndex := strings.Index(str, beg)
 	if startIndex != -1 {
-		endIndex := strings.Index(str[startIndex:], end) + len(str[:startIndex])
+		endIndex := strings.Index(str[startIndex:], end)
 		if endIndex != -1 {
+			endIndex += len(str[:startIndex])
 			result = str[:startIndex] + rep + str[endIndex:]
 		}
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -243,9 +243,20 @@ func testRounding(baseTimestamp, retention int64) {
 
 func TestReplaceSubstring(t *testing.T) {
 	Convey("test replace substring", t, func() {
-		So(ReplaceSubstring("https://api.telegram.org/botXXX/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/[DELETED]/getMe")
-		So(ReplaceSubstring("botXXX/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "[DELETED]/getMe")
-		So(ReplaceSubstring("https://api.telegram.org/botXXX/", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/[DELETED]/")
-		So(ReplaceSubstring("https://api.telegram.org/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/getMe")
+		Convey("replacement string in the middle", func() {
+			So(ReplaceSubstring("https://api.telegram.org/botXXX/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/[DELETED]/getMe")
+		})
+
+		Convey("replacement string at the beginning", func() {
+			So(ReplaceSubstring("botXXX/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "[DELETED]/getMe")
+		})
+
+		Convey("replacement string at the end", func() {
+			So(ReplaceSubstring("https://api.telegram.org/botXXX/", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/[DELETED]/")
+		})
+
+		Convey("no replacement string", func() {
+			So(ReplaceSubstring("https://api.telegram.org/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/getMe")
+		})
 	})
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -258,5 +258,9 @@ func TestReplaceSubstring(t *testing.T) {
 		Convey("no replacement string", func() {
 			So(ReplaceSubstring("https://api.telegram.org/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/getMe")
 		})
+
+		Convey("there is the beginning of replacement string, but no end", func() {
+			So(ReplaceSubstring("https://api.telegram.org/botXXX error", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/botXXX error")
+		})
 	})
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -240,3 +240,12 @@ func testRounding(baseTimestamp, retention int64) {
 	So(RoundToNearestRetention(baseTimestamp-1, retention), ShouldEqual, baseTimestamp)
 	So(RoundToNearestRetention(baseTimestamp-halfRetention, retention), ShouldEqual, baseTimestamp)
 }
+
+func TestReplaceSubstring(t *testing.T) {
+	Convey("test replace substring", t, func() {
+		So(ReplaceSubstring("https://api.telegram.org/botXXX/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/[DELETED]/getMe")
+		So(ReplaceSubstring("botXXX/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "[DELETED]/getMe")
+		So(ReplaceSubstring("https://api.telegram.org/botXXX/", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/[DELETED]/")
+		So(ReplaceSubstring("https://api.telegram.org/getMe", "bot", "/", "[DELETED]"), ShouldResemble, "https://api.telegram.org/getMe")
+	})
+}

--- a/senders/telegram/handle_message.go
+++ b/senders/telegram/handle_message.go
@@ -1,12 +1,10 @@
 package telegram
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/moira-alert/moira"
 	"gopkg.in/tucnak/telebot.v2"
 )
 
@@ -18,11 +16,8 @@ func (sender *Sender) handleMessage(message *telebot.Message) error {
 	}
 	if responseMessage != "" {
 		_, err = sender.bot.Send(message.Chat, responseMessage)
-		if strings.Contains(err.Error(), sender.bot.URL) {
-			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
-		}
 	}
-	return err
+	return removeTokenFromError(err, sender.bot)
 }
 
 func (sender *Sender) getResponseMessage(message *telebot.Message) (string, error) {

--- a/senders/telegram/handle_message.go
+++ b/senders/telegram/handle_message.go
@@ -18,7 +18,7 @@ func (sender *Sender) handleMessage(message *telebot.Message) error {
 	}
 	if responseMessage != "" {
 		_, err = sender.bot.Send(message.Chat, responseMessage)
-		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+		if strings.Contains(err.Error(), telegramAPIUrl) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 	}

--- a/senders/telegram/handle_message.go
+++ b/senders/telegram/handle_message.go
@@ -1,10 +1,12 @@
 package telegram
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/moira-alert/moira"
 	"gopkg.in/tucnak/telebot.v2"
 )
 
@@ -16,6 +18,10 @@ func (sender *Sender) handleMessage(message *telebot.Message) error {
 	}
 	if responseMessage != "" {
 		_, err = sender.bot.Send(message.Chat, responseMessage)
+		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+			hidden := "[DATA DELETED]"
+			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
+		}
 	}
 	return err
 }

--- a/senders/telegram/handle_message.go
+++ b/senders/telegram/handle_message.go
@@ -18,7 +18,7 @@ func (sender *Sender) handleMessage(message *telebot.Message) error {
 	}
 	if responseMessage != "" {
 		_, err = sender.bot.Send(message.Chat, responseMessage)
-		if strings.Contains(err.Error(), telegramAPIUrl) {
+		if strings.Contains(err.Error(), sender.bot.URL) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 	}

--- a/senders/telegram/handle_message.go
+++ b/senders/telegram/handle_message.go
@@ -19,7 +19,6 @@ func (sender *Sender) handleMessage(message *telebot.Message) error {
 	if responseMessage != "" {
 		_, err = sender.bot.Send(message.Chat, responseMessage)
 		if strings.Contains(err.Error(), "https://api.telegram.org/") {
-			hidden := "[DATA DELETED]"
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 	}

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -18,7 +18,6 @@ const (
 	messenger        = "telegram"
 	telegramLockTTL  = 30 * time.Second
 	hidden           = "[DATA DELETED]"
-	telegramAPIUrl   = "https://api.telegram.org/"
 )
 
 var (
@@ -69,7 +68,7 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 		Poller: &telebot.LongPoller{Timeout: pollerTimeout},
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), telegramAPIUrl) {
+		if strings.Contains(err.Error(), sender.bot.URL) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return err

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -1,7 +1,9 @@
 package telegram
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -65,6 +67,10 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 		Poller: &telebot.LongPoller{Timeout: pollerTimeout},
 	})
 	if err != nil {
+		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+			hidden := "[DATA DELETED]"
+			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the link
+		}
 		return err
 	}
 

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -18,6 +18,7 @@ const (
 	messenger        = "telegram"
 	telegramLockTTL  = 30 * time.Second
 	hidden           = "[DATA DELETED]"
+	telegramAPIUrl   = "https://api.telegram.org/"
 )
 
 var (
@@ -68,7 +69,7 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 		Poller: &telebot.LongPoller{Timeout: pollerTimeout},
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+		if strings.Contains(err.Error(), telegramAPIUrl) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return err

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -69,7 +69,7 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 	if err != nil {
 		if strings.Contains(err.Error(), "https://api.telegram.org/") {
 			hidden := "[DATA DELETED]"
-			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the link
+			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return err
 	}

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -17,6 +17,7 @@ const (
 	workerName       = "Telebot"
 	messenger        = "telegram"
 	telegramLockTTL  = 30 * time.Second
+	hidden           = "[DATA DELETED]"
 )
 
 var (
@@ -68,7 +69,6 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "https://api.telegram.org/") {
-			hidden := "[DATA DELETED]"
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return err

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -114,7 +114,6 @@ func (sender *Sender) getChat(username string) (*telebot.Chat, error) {
 	chat, err := sender.bot.ChatByID(uid)
 	if err != nil {
 		if strings.Contains(err.Error(), "https://api.telegram.org/") {
-			hidden := "[DATA DELETED]"
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return nil, fmt.Errorf("can't find recipient %s: %s", uid, err.Error())
@@ -136,7 +135,6 @@ func (sender *Sender) sendAsMessage(chat *telebot.Chat, message string) error {
 	_, err := sender.bot.Send(chat, message)
 	if err != nil {
 		if strings.Contains(err.Error(), "https://api.telegram.org/") {
-			hidden := "[DATA DELETED]"
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		sender.logger.Debug().
@@ -207,7 +205,6 @@ func (sender *Sender) sendAsAlbum(chat *telebot.Chat, plots [][]byte, caption st
 	_, err := sender.bot.SendAlbum(chat, album)
 	if err != nil {
 		if strings.Contains(err.Error(), "https://api.telegram.org/") {
-			hidden := "[DATA DELETED]"
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		sender.logger.Debug().

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -113,7 +113,7 @@ func (sender *Sender) getChat(username string) (*telebot.Chat, error) {
 	}
 	chat, err := sender.bot.ChatByID(uid)
 	if err != nil {
-		if strings.Contains(err.Error(), telegramAPIUrl) {
+		if strings.Contains(err.Error(), sender.bot.URL) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return nil, fmt.Errorf("can't find recipient %s: %s", uid, err.Error())
@@ -134,7 +134,7 @@ func (sender *Sender) talk(chat *telebot.Chat, message string, plots [][]byte, m
 func (sender *Sender) sendAsMessage(chat *telebot.Chat, message string) error {
 	_, err := sender.bot.Send(chat, message)
 	if err != nil {
-		if strings.Contains(err.Error(), telegramAPIUrl) {
+		if strings.Contains(err.Error(), sender.bot.URL) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		sender.logger.Debug().
@@ -204,7 +204,7 @@ func (sender *Sender) sendAsAlbum(chat *telebot.Chat, plots [][]byte, caption st
 
 	_, err := sender.bot.SendAlbum(chat, album)
 	if err != nil {
-		if strings.Contains(err.Error(), telegramAPIUrl) {
+		if strings.Contains(err.Error(), sender.bot.URL) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		sender.logger.Debug().

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -113,7 +113,7 @@ func (sender *Sender) getChat(username string) (*telebot.Chat, error) {
 	}
 	chat, err := sender.bot.ChatByID(uid)
 	if err != nil {
-		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+		if strings.Contains(err.Error(), telegramAPIUrl) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		return nil, fmt.Errorf("can't find recipient %s: %s", uid, err.Error())
@@ -134,7 +134,7 @@ func (sender *Sender) talk(chat *telebot.Chat, message string, plots [][]byte, m
 func (sender *Sender) sendAsMessage(chat *telebot.Chat, message string) error {
 	_, err := sender.bot.Send(chat, message)
 	if err != nil {
-		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+		if strings.Contains(err.Error(), telegramAPIUrl) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		sender.logger.Debug().
@@ -204,7 +204,7 @@ func (sender *Sender) sendAsAlbum(chat *telebot.Chat, plots [][]byte, caption st
 
 	_, err := sender.bot.SendAlbum(chat, album)
 	if err != nil {
-		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+		if strings.Contains(err.Error(), telegramAPIUrl) {
 			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
 		}
 		sender.logger.Debug().

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -2,7 +2,6 @@ package telegram
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -113,9 +112,7 @@ func (sender *Sender) getChat(username string) (*telebot.Chat, error) {
 	}
 	chat, err := sender.bot.ChatByID(uid)
 	if err != nil {
-		if strings.Contains(err.Error(), sender.bot.URL) {
-			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
-		}
+		err = removeTokenFromError(err, sender.bot)
 		return nil, fmt.Errorf("can't find recipient %s: %s", uid, err.Error())
 	}
 	return chat, nil
@@ -134,9 +131,7 @@ func (sender *Sender) talk(chat *telebot.Chat, message string, plots [][]byte, m
 func (sender *Sender) sendAsMessage(chat *telebot.Chat, message string) error {
 	_, err := sender.bot.Send(chat, message)
 	if err != nil {
-		if strings.Contains(err.Error(), sender.bot.URL) {
-			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
-		}
+		err = removeTokenFromError(err, sender.bot)
 		sender.logger.Debug().
 			String("message", message).
 			Int64("chat_id", chat.ID).
@@ -204,9 +199,7 @@ func (sender *Sender) sendAsAlbum(chat *telebot.Chat, plots [][]byte, caption st
 
 	_, err := sender.bot.SendAlbum(chat, album)
 	if err != nil {
-		if strings.Contains(err.Error(), sender.bot.URL) {
-			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
-		}
+		err = removeTokenFromError(err, sender.bot)
 		sender.logger.Debug().
 			Int64("chat_id", chat.ID).
 			Error(err).

--- a/senders/telegram/send.go
+++ b/senders/telegram/send.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -112,6 +113,10 @@ func (sender *Sender) getChat(username string) (*telebot.Chat, error) {
 	}
 	chat, err := sender.bot.ChatByID(uid)
 	if err != nil {
+		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+			hidden := "[DATA DELETED]"
+			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
+		}
 		return nil, fmt.Errorf("can't find recipient %s: %s", uid, err.Error())
 	}
 	return chat, nil
@@ -130,6 +135,10 @@ func (sender *Sender) talk(chat *telebot.Chat, message string, plots [][]byte, m
 func (sender *Sender) sendAsMessage(chat *telebot.Chat, message string) error {
 	_, err := sender.bot.Send(chat, message)
 	if err != nil {
+		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+			hidden := "[DATA DELETED]"
+			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
+		}
 		sender.logger.Debug().
 			String("message", message).
 			Int64("chat_id", chat.ID).
@@ -197,6 +206,10 @@ func (sender *Sender) sendAsAlbum(chat *telebot.Chat, plots [][]byte, caption st
 
 	_, err := sender.bot.SendAlbum(chat, album)
 	if err != nil {
+		if strings.Contains(err.Error(), "https://api.telegram.org/") {
+			hidden := "[DATA DELETED]"
+			err = errors.New(moira.ReplaceSubstring(err.Error(), "bot", "/", hidden)) // Cut the token from the url in error message
+		}
 		sender.logger.Debug().
 			Int64("chat_id", chat.ID).
 			Error(err).


### PR DESCRIPTION
# Remove telegram token from error message with function ReplaceSubstring

I decided it wasn't so terrible to rely on telegram's api, so I didn't remove the token link entirely, just replaced the token with `[DATA DELETED]`, knowing that the token is enclosed between `/bot` and the following `/` based on telegram's api documentation:
> All requests to the Telegram Bot API must be made via HTTPS in the following form: https://api.telegram.org/bot<token\>/METHOD
For example:
https://api.telegram.org/bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11/getMe
