### PR TITLE
fix(api): remove panic in get trigger function

### DIFF
--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -105,9 +105,6 @@ func removeTrigger(writer http.ResponseWriter, request *http.Request) {
 
 func getTrigger(writer http.ResponseWriter, request *http.Request) {
 	triggerID := middleware.GetTriggerID(request)
-	if triggerID == "testlog" {
-		panic("Test for multi line logs")
-	}
 
 	trigger, err := controller.GetTrigger(database, triggerID)
 	if err != nil {


### PR DESCRIPTION
# Remove panic in `getTrigger` function

It seems like it was just done for one-time testing, but then just forgotten about
