### PR TITLE
fix(api): add the parse query function instead of query

### DIFF
--- a/api/handler/notification.go
+++ b/api/handler/notification.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/go-chi/chi"
@@ -18,11 +19,18 @@ func notification(router chi.Router) {
 }
 
 func getNotification(writer http.ResponseWriter, request *http.Request) {
-	start, err := strconv.ParseInt(request.URL.Query().Get("start"), 10, 64)
+	urlValues, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+		return
+	}
+
+	start, err := strconv.ParseInt(urlValues.Get("start"), 10, 64)
 	if err != nil {
 		start = 0
 	}
-	end, err := strconv.ParseInt(request.URL.Query().Get("end"), 10, 64)
+
+	end, err := strconv.ParseInt(urlValues.Get("end"), 10, 64)
 	if err != nil {
 		end = -1
 	}
@@ -32,13 +40,20 @@ func getNotification(writer http.ResponseWriter, request *http.Request) {
 		render.Render(writer, request, errorResponse) //nolint
 		return
 	}
+
 	if err := render.Render(writer, request, notifications); err != nil {
 		render.Render(writer, request, api.ErrorRender(err)) //nolint
 	}
 }
 
 func deleteNotification(writer http.ResponseWriter, request *http.Request) {
-	notificationKey := request.URL.Query().Get("id")
+	urlValues, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+		return
+	}
+
+	notificationKey := urlValues.Get("id")
 	if notificationKey == "" {
 		render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("notification id can not be empty"))) //nolint
 		return
@@ -49,6 +64,7 @@ func deleteNotification(writer http.ResponseWriter, request *http.Request) {
 		render.Render(writer, request, errorResponse) //nolint
 		return
 	}
+
 	if err := render.Render(writer, request, notifications); err != nil {
 		render.Render(writer, request, api.ErrorRender(err)) //nolint
 	}

--- a/api/handler/notification_test.go
+++ b/api/handler/notification_test.go
@@ -22,7 +22,7 @@ func TestGetNotifications(t *testing.T) {
 		Convey("with the correct parameters", func() {
 			parameters := []string{"start=0&end=100", "start=0", "end=100", "", "start=test&end=100", "start=0&end=test"}
 			for _, param := range parameters {
-				mockDb.EXPECT().GetNotifications(gomock.Any(), gomock.Any()).Return([]*moira.ScheduledNotification{}, int64(0), nil)
+				mockDb.EXPECT().GetNotifications(gomock.Any(), gomock.Any()).Return([]*moira.ScheduledNotification{}, int64(0), nil).Times(1)
 				database = mockDb
 
 				testRequest := httptest.NewRequest(http.MethodGet, "/notifications?"+param, nil)
@@ -78,7 +78,7 @@ func TestDeleteNotifications(t *testing.T) {
 		})
 
 		Convey("with the correct id", func() {
-			mockDb.EXPECT().RemoveNotification(gomock.Any()).Return(int64(0), nil)
+			mockDb.EXPECT().RemoveNotification(gomock.Any()).Return(int64(0), nil).Times(1)
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, `/notifications?id=test`, nil)

--- a/api/handler/notification_test.go
+++ b/api/handler/notification_test.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/moira-alert/moira"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetNotifications(t *testing.T) {
+	Convey("test get notifications url parameters", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		responseWriter := httptest.NewRecorder()
+		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		Convey("with the correct parameters", func() {
+			parameters := []string{"start=0&end=100", "start=0", "end=100", "", "start=test&end=100", "start=0&end=test"}
+			for _, param := range parameters {
+				mockDb.EXPECT().GetNotifications(gomock.Any(), gomock.Any()).Return([]*moira.ScheduledNotification{}, int64(0), nil)
+				database = mockDb
+
+				testRequest := httptest.NewRequest(http.MethodGet, "/notifications?"+param, nil)
+
+				getNotification(responseWriter, testRequest)
+
+				response := responseWriter.Result()
+				defer response.Body.Close()
+
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+			}
+		})
+
+		Convey("with the wrong url query string", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/notifications?start=test%&end=100", nil)
+
+			getNotification(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Invalid request","error":"invalid URL escape \"%\""}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}
+
+func TestDeleteNotifications(t *testing.T) {
+	Convey("test delete notifications url parameters", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		responseWriter := httptest.NewRecorder()
+		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		Convey("with the empty id parameter", func() {
+			testRequest := httptest.NewRequest(http.MethodDelete, `/notifications`, nil)
+
+			deleteNotification(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Invalid request","error":"notification id can not be empty"}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("with the correct id", func() {
+			mockDb.EXPECT().RemoveNotification(gomock.Any()).Return(int64(0), nil)
+			database = mockDb
+
+			testRequest := httptest.NewRequest(http.MethodDelete, `/notifications?id=test`, nil)
+
+			deleteNotification(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"result":0}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("with the wrong url query string", func() {
+			testRequest := httptest.NewRequest(http.MethodDelete, `/notifications?id=test%&`, nil)
+
+			deleteNotification(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Invalid request","error":"invalid URL escape \"%\""}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}

--- a/api/handler/trigger_metric_test.go
+++ b/api/handler/trigger_metric_test.go
@@ -21,12 +21,12 @@ func TestDeleteTriggerMetric(t *testing.T) {
 		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
 
 		Convey("with the correct name", func() {
-			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001"}, nil)
-			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
-			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any()).Return(moira.CheckData{}, nil)
-			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any()).Return(nil)
-			mockDb.EXPECT().RemovePatternsMetrics(gomock.Any()).Return(nil)
-			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001"}, nil).Times(1)
+			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any()).Return(moira.CheckData{}, nil).Times(1)
+			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any()).Return(nil).Times(1)
+			mockDb.EXPECT().RemovePatternsMetrics(gomock.Any()).Return(nil).Times(1)
+			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/trigger/triggerID-0000000000001/metrics?name=test", nil)

--- a/api/handler/trigger_metric_test.go
+++ b/api/handler/trigger_metric_test.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api/middleware"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDeleteTriggerMetric(t *testing.T) {
+	Convey("Delete metric by name", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		responseWriter := httptest.NewRecorder()
+		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		Convey("with the correct name", func() {
+			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001"}, nil)
+			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
+			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any()).Return(moira.CheckData{}, nil)
+			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any()).Return(nil)
+			mockDb.EXPECT().RemovePatternsMetrics(gomock.Any()).Return(nil)
+			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			database = mockDb
+
+			testRequest := httptest.NewRequest(http.MethodDelete, "/trigger/triggerID-0000000000001/metrics?name=test", nil)
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "triggerID", "triggerID-0000000000001"))
+
+			deleteTriggerMetric(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+
+			So(contents, ShouldEqual, "")
+			So(response.StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("with wrong name", func() {
+			testRequest := httptest.NewRequest(http.MethodDelete, "/trigger/triggerID-0000000000001/metrics?name=test%name", nil)
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "triggerID", "triggerID-0000000000001"))
+			testRequest.Header.Add("content-type", "application/json")
+
+			deleteTriggerMetric(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Invalid request","error":"invalid URL escape \"%na\""}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}

--- a/api/handler/trigger_metrics.go
+++ b/api/handler/trigger_metrics.go
@@ -43,7 +43,7 @@ func getTriggerMetrics(writer http.ResponseWriter, request *http.Request) {
 		render.Render(writer, request, err) //nolint
 		return
 	}
-	
+
 	if err := render.Render(writer, request, triggerMetrics); err != nil {
 		render.Render(writer, request, api.ErrorRender(err)) //nolint
 	}

--- a/api/handler/trigger_metrics.go
+++ b/api/handler/trigger_metrics.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/go-chi/chi"
@@ -47,7 +48,14 @@ func getTriggerMetrics(writer http.ResponseWriter, request *http.Request) {
 
 func deleteTriggerMetric(writer http.ResponseWriter, request *http.Request) {
 	triggerID := middleware.GetTriggerID(request)
-	metricName := request.URL.Query().Get("name")
+
+	urlValues, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+		return
+	}
+
+	metricName := urlValues.Get("name")
 	if err := controller.DeleteTriggerMetric(database, metricName, triggerID); err != nil {
 		render.Render(writer, request, err) //nolint
 	}

--- a/api/handler/trigger_metrics.go
+++ b/api/handler/trigger_metrics.go
@@ -31,16 +31,19 @@ func getTriggerMetrics(writer http.ResponseWriter, request *http.Request) {
 		render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("can not parse from: %s", fromStr))) //nolint
 		return
 	}
+
 	to := date.DateParamToEpoch(toStr, "UTC", 0, time.UTC)
 	if to == 0 {
 		render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("can not parse to: %v", to))) //nolint
 		return
 	}
+
 	triggerMetrics, err := controller.GetTriggerMetrics(database, metricSourceProvider, from, to, triggerID)
 	if err != nil {
 		render.Render(writer, request, err) //nolint
 		return
 	}
+	
 	if err := render.Render(writer, request, triggerMetrics); err != nil {
 		render.Render(writer, request, api.ErrorRender(err)) //nolint
 	}

--- a/api/handler/trigger_render.go
+++ b/api/handler/trigger_render.go
@@ -112,7 +112,7 @@ func buildRenderable(request *http.Request, trigger *moira.Trigger, metricsData 
 	if err != nil {
 		return nil, fmt.Errorf("can not initialize plot theme %s", err.Error())
 	}
-	
+
 	renderable, err := plotTemplate.GetRenderable(targetName, trigger, metricsData)
 	if err != nil {
 		return nil, err

--- a/api/handler/trigger_render.go
+++ b/api/handler/trigger_render.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -57,23 +58,31 @@ func getEvaluationParameters(request *http.Request) (sourceProvider *metricSourc
 	fromStr := middleware.GetFromStr(request)
 	toStr := middleware.GetToStr(request)
 	from = date.DateParamToEpoch(fromStr, "UTC", 0, time.UTC)
+	urlValues, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		return sourceProvider, "", 0, 0, "", false, fmt.Errorf("failed to parse query string: %w", err)
+	}
 
 	if from == 0 {
 		return sourceProvider, "", 0, 0, "", false, fmt.Errorf("can not parse from: %s", fromStr)
 	}
 	from -= from % 60 //nolint
+
 	to = date.DateParamToEpoch(toStr, "UTC", 0, time.UTC)
 	if to == 0 {
 		return sourceProvider, "", 0, 0, "", false, fmt.Errorf("can not parse to: %s", fromStr)
 	}
-	realtime := request.URL.Query().Get("realtime")
+
+	realtime := urlValues.Get("realtime")
 	if realtime == "" {
 		return
 	}
+
 	fetchRealtimeData, err = strconv.ParseBool(realtime)
 	if err != nil {
 		return sourceProvider, "", 0, 0, "", false, fmt.Errorf("invalid realtime param: %s", err.Error())
 	}
+
 	return
 }
 
@@ -87,19 +96,27 @@ func evaluateTargetMetrics(metricSourceProvider *metricSource.SourceProvider, fr
 }
 
 func buildRenderable(request *http.Request, trigger *moira.Trigger, metricsData []metricSource.MetricData, targetName string) (*chart.Chart, error) {
-	timezone := request.URL.Query().Get("timezone")
+	urlValues, err := url.ParseQuery(request.URL.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query string: %w", err)
+	}
+
+	timezone := urlValues.Get("timezone")
 	location, err := time.LoadLocation(timezone)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load %s timezone: %s", timezone, err.Error())
 	}
-	plotTheme := request.URL.Query().Get("theme")
+
+	plotTheme := urlValues.Get("theme")
 	plotTemplate, err := plotting.GetPlotTemplate(plotTheme, location)
 	if err != nil {
 		return nil, fmt.Errorf("can not initialize plot theme %s", err.Error())
 	}
+	
 	renderable, err := plotTemplate.GetRenderable(targetName, trigger, metricsData)
 	if err != nil {
 		return nil, err
 	}
+
 	return &renderable, err
 }

--- a/api/handler/trigger_render_test.go
+++ b/api/handler/trigger_render_test.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api/middleware"
+	metricSource "github.com/moira-alert/moira/metric_source"
+	mock_metric_source "github.com/moira-alert/moira/mock/metric_source"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRenderTrigger(t *testing.T) {
+	Convey("Checking the correctness of parameters", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		localSource := mock_metric_source.NewMockMetricSource(mockCtrl)
+		remoteSource := mock_metric_source.NewMockMetricSource(mockCtrl)
+		sourceProvider := metricSource.CreateMetricSourceProvider(localSource, remoteSource)
+
+		responseWriter := httptest.NewRecorder()
+		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
+
+		Convey("with the wrong realtime parameter", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/trigger/triggerID-0000000000001/render?realtime=test", nil)
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "triggerID", "triggerID-0000000000001"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "target", "t1"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "from", "-1hour"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "to", "now"))
+
+			renderTrigger(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Invalid request","error":"invalid realtime param: strconv.ParseBool: parsing \"test\": invalid syntax"}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("with the wrong timezone parameter", func() {
+			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001", Targets: []string{"t1"}}, nil)
+			localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes()
+			fetchResult := mock_metric_source.NewMockFetchResult(mockCtrl)
+			fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)})
+			localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil)
+
+			database = mockDb
+
+			testRequest := httptest.NewRequest(http.MethodGet, "/trigger/triggerID-0000000000001/render?timezone=test", nil)
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "triggerID", "triggerID-0000000000001"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "target", "t1"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "from", "-1hour"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "to", "now"))
+
+			renderTrigger(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Internal Server Error","error":"failed to load test timezone: unknown time zone test"}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("without points for render", func() {
+			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001", Targets: []string{"t1"}}, nil)
+			localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes()
+			fetchResult := mock_metric_source.NewMockFetchResult(mockCtrl)
+			fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)})
+			localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil)
+
+			database = mockDb
+
+			testRequest := httptest.NewRequest(http.MethodGet, "/trigger/triggerID-0000000000001/render", nil)
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "triggerID", "triggerID-0000000000001"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "target", "t1"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "from", "-1hour"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "to", "now"))
+
+			renderTrigger(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Internal Server Error","error":"no points found to render trigger: triggerID-0000000000001"}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("with the wrong query string", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/trigger/triggerID-0000000000001/render?realtime=test%rt", nil)
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "triggerID", "triggerID-0000000000001"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "target", "t1"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "from", "-1hour"))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "to", "now"))
+
+			renderTrigger(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+			expected := `{"status":"Invalid request","error":"failed to parse query string: invalid URL escape \"%rt\""}
+`
+
+			So(contents, ShouldEqual, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}

--- a/api/handler/trigger_render_test.go
+++ b/api/handler/trigger_render_test.go
@@ -49,11 +49,11 @@ func TestRenderTrigger(t *testing.T) {
 		})
 
 		Convey("with the wrong timezone parameter", func() {
-			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001", Targets: []string{"t1"}}, nil)
-			localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes()
+			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001", Targets: []string{"t1"}}, nil).Times(1)
+			localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes().Times(1)
 			fetchResult := mock_metric_source.NewMockFetchResult(mockCtrl)
-			fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)})
-			localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil)
+			fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)}).Times(1)
+			localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil).Times(1)
 
 			database = mockDb
 
@@ -78,11 +78,11 @@ func TestRenderTrigger(t *testing.T) {
 		})
 
 		Convey("without points for render", func() {
-			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001", Targets: []string{"t1"}}, nil)
-			localSource.EXPECT().IsConfigured().Return(true, nil).AnyTimes()
+			mockDb.EXPECT().GetTrigger("triggerID-0000000000001").Return(moira.Trigger{ID: "triggerID-0000000000001", Targets: []string{"t1"}}, nil).Times(1)
+			localSource.EXPECT().IsConfigured().Return(true, nil).Times(1)
 			fetchResult := mock_metric_source.NewMockFetchResult(mockCtrl)
-			fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)})
-			localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil)
+			fetchResult.EXPECT().GetMetricsData().Return([]metricSource.MetricData{*metricSource.MakeMetricData("", []float64{}, 0, 0)}).Times(1)
+			localSource.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fetchResult, nil).Times(1)
 
 			database = mockDb
 

--- a/api/middleware/context_test.go
+++ b/api/middleware/context_test.go
@@ -1,0 +1,219 @@
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moira-alert/moira/api/middleware"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const expectedBadRequest = `{"status":"Invalid request","error":"invalid URL escape \"%\""}
+`
+
+func TestPaginateMiddleware(t *testing.T) {
+	Convey("checking correctness of parameters", t, func() {
+		responseWriter := httptest.NewRecorder()
+		defaultPage := int64(1)
+		defaultSize := int64(10)
+
+		Convey("with correct parameters", func() {
+			parameters := []string{"p=0&size=100", "p=0", "size=100", "", "p=test&size=100", "p=0&size=test"}
+
+			for _, param := range parameters {
+				testRequest := httptest.NewRequest(http.MethodGet, "/test?"+param, nil)
+				handler := func(w http.ResponseWriter, r *http.Request) {}
+
+				middlewareFunc := middleware.Paginate(defaultPage, defaultSize)
+				wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+				wrappedHandler.ServeHTTP(responseWriter, testRequest)
+				response := responseWriter.Result()
+				defer response.Body.Close()
+
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+			}
+		})
+
+		Convey("with wrong url query parameters", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?p=0%&size=100", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.Paginate(defaultPage, defaultSize)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+
+			So(contents, ShouldEqual, expectedBadRequest)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}
+
+func TestPagerMiddleware(t *testing.T) {
+	Convey("checking correctness of parameters", t, func() {
+		responseWriter := httptest.NewRecorder()
+		defaultCreatePager := false
+		defaultPagerID := "test"
+
+		Convey("with correct parameters", func() {
+			parameters := []string{"pagerID=test&createPager=true", "pagerID=test", "createPager=true", "", "pagerID=-1&createPager=true", "pagerID=test&createPager=-1"}
+
+			for _, param := range parameters {
+				testRequest := httptest.NewRequest(http.MethodGet, "/test?"+param, nil)
+				handler := func(w http.ResponseWriter, r *http.Request) {}
+
+				middlewareFunc := middleware.Pager(defaultCreatePager, defaultPagerID)
+				wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+				wrappedHandler.ServeHTTP(responseWriter, testRequest)
+				response := responseWriter.Result()
+				defer response.Body.Close()
+
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+			}
+		})
+
+		Convey("with wrong url query parameters", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?pagerID=test%&createPager=true", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.Pager(defaultCreatePager, defaultPagerID)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+
+			So(contents, ShouldEqual, expectedBadRequest)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}
+
+func TestPopulateMiddleware(t *testing.T) {
+	Convey("checking correctness of parameter", t, func() {
+		responseWriter := httptest.NewRecorder()
+		defaultPopulated := false
+
+		Convey("with correct parameter", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?populated=true", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.Populate(defaultPopulated)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+
+			So(response.StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("with wrong url query parameter", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?populated%=true", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.Populate(defaultPopulated)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+
+			So(contents, ShouldEqual, expectedBadRequest)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}
+
+func TestDateRangeMiddleware(t *testing.T) {
+	Convey("checking correctness of parameters", t, func() {
+		responseWriter := httptest.NewRecorder()
+		defaultFrom := "-1hour"
+		defaultTo := "now"
+
+		Convey("with correct parameters", func() {
+			parameters := []string{"from=-2hours&to=now", "from=-2hours", "to=now", "", "from=-2&to=now", "from=-2hours&to=-1"}
+
+			for _, param := range parameters {
+				testRequest := httptest.NewRequest(http.MethodGet, "/test?"+param, nil)
+				handler := func(w http.ResponseWriter, r *http.Request) {}
+
+				middlewareFunc := middleware.DateRange(defaultFrom, defaultTo)
+				wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+				wrappedHandler.ServeHTTP(responseWriter, testRequest)
+				response := responseWriter.Result()
+				defer response.Body.Close()
+
+				So(response.StatusCode, ShouldEqual, http.StatusOK)
+			}
+		})
+
+		Convey("with wrong url query parameters", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?from=-2hours%&to=now", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.DateRange(defaultFrom, defaultTo)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+
+			So(contents, ShouldEqual, expectedBadRequest)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}
+
+func TestTargetNameMiddleware(t *testing.T) {
+	Convey("checking correctness of parameter", t, func() {
+		responseWriter := httptest.NewRecorder()
+		defaultTargetName := "test"
+
+		Convey("with correct parameter", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?target=test", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.TargetName(defaultTargetName)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+
+			So(response.StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("with wrong url query parameter", func() {
+			testRequest := httptest.NewRequest(http.MethodGet, "/test?target%=test", nil)
+			handler := func(w http.ResponseWriter, r *http.Request) {}
+
+			middlewareFunc := middleware.TargetName(defaultTargetName)
+			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
+
+			wrappedHandler.ServeHTTP(responseWriter, testRequest)
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, _ := io.ReadAll(response.Body)
+			contents := string(contentBytes)
+
+			So(contents, ShouldEqual, expectedBadRequest)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+	})
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       - relay
     ports:
       - "8094:8094"
-      - "2004:2003"
     restart: always
 
   checker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - relay
     ports:
       - "8094:8094"
+      - "2004:2003"
     restart: always
 
   checker:

--- a/go.sum
+++ b/go.sum
@@ -444,7 +444,6 @@ github.com/aws/aws-sdk-go v1.44.219/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
-github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -689,7 +688,6 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -1111,7 +1109,6 @@ go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 go.uber.org/automaxprocs v1.5.1 h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
 go.uber.org/automaxprocs v1.5.1/go.mod h1:BF4eumQw0P9GtnuxxovUd06vwm1o18oMzFtK66vU6XU=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
-go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=


### PR DESCRIPTION
# Add the parse query function instead of query

This is done in order to get rid of error silence in case query string could not be unparsed
