### PR TITLE
fix: hotfix swagger delete job

### DIFF
--- a/.github/workflows/swagger-delete.yml
+++ b/.github/workflows/swagger-delete.yml
@@ -3,14 +3,10 @@ defaults:
   run:
     working-directory: .
 on:
-  pull_request:
-    types: [closed]
-    branches:
-    - master
   push:
     branches:
-    - release/[0-9]+.[0-9]+.[0-9]+
     - master
+    - release/[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   removespec:


### PR DESCRIPTION
# Hotfix swagger delete job

Made the same call conditions as job with publishing
