### PR TITLE
fix(checker,api): fix switch to maintenance at set del

### DIFF
--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/moira-alert/moira"
@@ -129,7 +128,6 @@ func GetTriggerLastCheck(dataBase moira.Database, triggerID string) (*dto.Trigge
 	// Need to not show the user metrics that should have been deleted due to ttlState = Del,
 	// but remained in the database because their Maintenance did not expire
 	if lastCheck != nil && len(lastCheck.Metrics) != 0 {
-		log.Println("Last check in controller", *lastCheck)
 		aliveMetrics := make(map[string]moira.MetricState, len(lastCheck.Metrics))
 		for metricName, metricState := range lastCheck.Metrics {
 			if !metricState.NeedToDeleteAfterMaintenance {

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/moira-alert/moira"
@@ -128,6 +129,7 @@ func GetTriggerLastCheck(dataBase moira.Database, triggerID string) (*dto.Trigge
 	// Need to not show the user metrics that should have been deleted due to ttlState = Del,
 	// but remained in the database because their Maintenance did not expire
 	if lastCheck != nil && len(lastCheck.Metrics) != 0 {
+		log.Println("Last check in controller", *lastCheck)
 		aliveMetrics := make(map[string]moira.MetricState, len(lastCheck.Metrics))
 		for metricName, metricState := range lastCheck.Metrics {
 			if !metricState.NeedToDeleteAfterMaintenance {

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -130,7 +130,7 @@ func GetTriggerLastCheck(dataBase moira.Database, triggerID string) (*dto.Trigge
 	if lastCheck != nil && len(lastCheck.Metrics) != 0 {
 		aliveMetrics := make(map[string]moira.MetricState, len(lastCheck.Metrics))
 		for metricName, metricState := range lastCheck.Metrics {
-			if !metricState.NeedToDeleteAfterMaintenance {
+			if !metricState.HiddenMetricDueMaintenance {
 				aliveMetrics[metricName] = metricState
 			}
 		}

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -112,6 +112,18 @@ func GetTriggerThrottling(database moira.Database, triggerID string) (*dto.Throt
 	return &dto.ThrottlingResponse{Throttling: throttlingUnix}, nil
 }
 
+// Need to not show the user metrics that should have been deleted due to ttlState = Del,
+// but remained in the database because their Maintenance did not expire
+func getAliveMetrics(metrics map[string]moira.MetricState) map[string]moira.MetricState {
+	aliveMetrics := make(map[string]moira.MetricState, len(metrics))
+	for metricName, metricState := range metrics {
+		if !metricState.HiddenMetricDueMaintenance {
+			aliveMetrics[metricName] = metricState
+		}
+	}
+	return aliveMetrics
+}
+
 // GetTriggerLastCheck gets trigger last check data
 func GetTriggerLastCheck(dataBase moira.Database, triggerID string) (*dto.TriggerCheck, *api.ErrorResponse) {
 	lastCheck := &moira.CheckData{}
@@ -125,16 +137,8 @@ func GetTriggerLastCheck(dataBase moira.Database, triggerID string) (*dto.Trigge
 		lastCheck = nil
 	}
 
-	// Need to not show the user metrics that should have been deleted due to ttlState = Del,
-	// but remained in the database because their Maintenance did not expire
 	if lastCheck != nil && len(lastCheck.Metrics) != 0 {
-		aliveMetrics := make(map[string]moira.MetricState, len(lastCheck.Metrics))
-		for metricName, metricState := range lastCheck.Metrics {
-			if !metricState.HiddenMetricDueMaintenance {
-				aliveMetrics[metricName] = metricState
-			}
-		}
-		lastCheck.Metrics = aliveMetrics
+		lastCheck.Metrics = getAliveMetrics(lastCheck.Metrics)
 	}
 
 	triggerCheck := dto.TriggerCheck{

--- a/api/controller/trigger.go
+++ b/api/controller/trigger.go
@@ -117,7 +117,7 @@ func GetTriggerThrottling(database moira.Database, triggerID string) (*dto.Throt
 func getAliveMetrics(metrics map[string]moira.MetricState) map[string]moira.MetricState {
 	aliveMetrics := make(map[string]moira.MetricState, len(metrics))
 	for metricName, metricState := range metrics {
-		if !metricState.HiddenMetricDueMaintenance {
+		if !metricState.DeletedButKept {
 			aliveMetrics[metricName] = metricState
 		}
 	}

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -372,7 +372,7 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		})
 	})
 
-	Convey("Returns all metrics, because their NeedToDeleteAfterMaintenance is false", t, func() {
+	Convey("Returns all metrics, because their HiddenMetricDueMaintenance is false", t, func() {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				"metric":  {},
@@ -388,11 +388,11 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		})
 	})
 
-	Convey("Does not return all metrics, as some NeedToDeleteAfterMaintenance is true", t, func() {
+	Convey("Does not return all metrics, as some HiddenMetricDueMaintenance is true", t, func() {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				"metric": {
-					NeedToDeleteAfterMaintenance: true,
+					HiddenMetricDueMaintenance: true,
 				},
 				"metric2": {},
 			},

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -372,7 +372,7 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		})
 	})
 
-	Convey("Returns all metrics, because their HiddenMetricDueMaintenance is false", t, func() {
+	Convey("Returns all metrics, because their DeletedButKept is false", t, func() {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				"metric":  {},
@@ -388,7 +388,7 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		})
 	})
 
-	Convey("Does not return all metrics, as some HiddenMetricDueMaintenance is true", t, func() {
+	Convey("Does not return all metrics, as some DeletedButKept is true", t, func() {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				"metric": {

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -372,10 +372,10 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		})
 	})
 
-	Convey("Returns all metrics, because their NeedToDeleteAfterMaintenance is false", t, func ()  {
+	Convey("Returns all metrics, because their NeedToDeleteAfterMaintenance is false", t, func() {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
-				"metric": {},
+				"metric":  {},
 				"metric2": {},
 			},
 		}
@@ -388,7 +388,7 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		})
 	})
 
-	Convey("Does not return all metrics, as some NeedToDeleteAfterMaintenance is true", t, func ()  {
+	Convey("Does not return all metrics, as some NeedToDeleteAfterMaintenance is true", t, func() {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				"metric": {

--- a/api/controller/trigger_test.go
+++ b/api/controller/trigger_test.go
@@ -392,7 +392,7 @@ func TestGetTriggerLastCheck(t *testing.T) {
 		lastCheck = moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				"metric": {
-					HiddenMetricDueMaintenance: true,
+					DeletedButKept: true,
 				},
 				"metric2": {},
 			},

--- a/checker/check.go
+++ b/checker/check.go
@@ -315,17 +315,13 @@ func (triggerChecker *TriggerChecker) check(
 		isNewMetric := prevMetricState.Timestamp != metricState.Timestamp
 
 		if needToDeleteMetric {
-			if metricState.Maintenance != 0 {
-				if metricState.NeedToDeleteAfterMaintenance && time.Now().Unix() >= metricState.Maintenance {
-					checkData.RemoveMetricState(metricName)
-					err = triggerChecker.database.RemovePatternsMetrics(triggerChecker.trigger.Patterns)
-				} else if !metricState.NeedToDeleteAfterMaintenance {
-					metricState.NeedToDeleteAfterMaintenance = true
-					checkData.Metrics[metricName] = metricState
-				}
-			} else {
+			if metricState.Maintenance == 0 || (metricState.Maintenance != 0 && time.Now().Unix() >= metricState.Maintenance) {
+				log.Info().Msg("Remove metric")
 				checkData.RemoveMetricState(metricName)
 				err = triggerChecker.database.RemovePatternsMetrics(triggerChecker.trigger.Patterns)
+			} else if metricState.Maintenance != 0 && !metricState.NeedToDeleteAfterMaintenance {
+				metricState.NeedToDeleteAfterMaintenance = true
+				checkData.Metrics[metricName] = metricState
 			}
 		} else {
 			if prevMetricState.NeedToDeleteAfterMaintenance && isNewMetric {

--- a/checker/check.go
+++ b/checker/check.go
@@ -321,8 +321,8 @@ func (triggerChecker *TriggerChecker) check(
 			err = triggerChecker.database.RemovePatternsMetrics(triggerChecker.trigger.Patterns)
 		} else {
 			// Starting to show user the updated metric, which has been hidden as its Maintenance time is not over
-			if metricState.HiddenMetricDueMaintenance && isMetricChanged(checkData.Metrics, metricName, metricState) {
-				metricState.HiddenMetricDueMaintenance = false
+			if metricState.DeletedButKept && isMetricChanged(checkData.Metrics, metricName, metricState) {
+				metricState.DeletedButKept = false
 			}
 			checkData.Metrics[metricName] = metricState
 		}
@@ -391,7 +391,7 @@ func (triggerChecker *TriggerChecker) checkForNoData(
 
 	if triggerChecker.ttlState == moira.TTLStateDEL && metricLastState.EventTimestamp != 0 {
 		if metricLastState.Maintenance != 0 && lastCheckTimeStamp <= metricLastState.Maintenance {
-			metricLastState.HiddenMetricDueMaintenance = true
+			metricLastState.DeletedButKept = true
 			return false, &metricLastState
 		}
 		return true, nil

--- a/checker/check.go
+++ b/checker/check.go
@@ -28,6 +28,7 @@ func (triggerChecker *TriggerChecker) Check() error {
 	if err != nil {
 		return triggerChecker.handleFetchError(checkData, err)
 	}
+	triggerChecker.logger.Debug().Msg(fmt.Sprintf("Fetched metrics: %v", triggerMetricsData))
 
 	preparedMetrics, aloneMetrics, err := triggerChecker.prepareMetrics(triggerMetricsData)
 	if err != nil {
@@ -36,6 +37,7 @@ func (triggerChecker *TriggerChecker) Check() error {
 			return err
 		}
 	}
+	triggerChecker.logger.Debug().Msg(fmt.Sprintf("Prepared metrics: %v, alone metrics: %v", preparedMetrics, aloneMetrics))
 
 	checkData.MetricsToTargetRelation = conversion.GetRelations(aloneMetrics, triggerChecker.trigger.AloneMetrics)
 
@@ -43,6 +45,7 @@ func (triggerChecker *TriggerChecker) Check() error {
 	if err != nil {
 		return triggerChecker.handleUndefinedError(checkData, err)
 	}
+	triggerChecker.logger.Debug().Msg(fmt.Sprintf("New checkdata: %v", checkData))
 
 	if errorSeverity == NoCheckError {
 		checkData.State = moira.StateOK
@@ -313,18 +316,22 @@ func (triggerChecker *TriggerChecker) check(
 		metricState, needToDeleteMetric, err := triggerChecker.checkTargets(metricName, targets, log)
 		prevMetricState := checkData.Metrics[metricName]
 		isNewMetric := prevMetricState.Timestamp != metricState.Timestamp
+		logger.Debug().Msg(fmt.Sprintf("Prev metric state: %v, new metric state: %v, isNewMetric: %v", prevMetricState, metricState, isNewMetric))
 
 		if needToDeleteMetric {
+			logger.Debug().Msg("Need to delete metric!")
 			if metricState.Maintenance == 0 || (metricState.Maintenance != 0 && time.Now().Unix() >= metricState.Maintenance) {
 				log.Info().Msg("Remove metric")
 				checkData.RemoveMetricState(metricName)
 				err = triggerChecker.database.RemovePatternsMetrics(triggerChecker.trigger.Patterns)
 			} else if metricState.Maintenance != 0 && !metricState.NeedToDeleteAfterMaintenance {
+				logger.Debug().Msg("Set true to NeedToDeleteAfterMaintenance")
 				metricState.NeedToDeleteAfterMaintenance = true
 				checkData.Metrics[metricName] = metricState
 			}
 		} else {
 			if prevMetricState.NeedToDeleteAfterMaintenance && isNewMetric {
+				logger.Debug().Msg("Set false to NeedToDeleteAfterMaintenance")
 				metricState.NeedToDeleteAfterMaintenance = false
 			}
 			checkData.Metrics[metricName] = metricState
@@ -351,6 +358,7 @@ func (triggerChecker *TriggerChecker) checkTargets(
 	if err != nil {
 		return lastState, needToDeleteMetric, err
 	}
+	logger.Debug().Msg(fmt.Sprintf("Last state: %v", lastState))
 
 	for _, currentState := range metricStates {
 		lastState, err = triggerChecker.compareMetricStates(metricName, currentState, lastState)
@@ -367,6 +375,8 @@ func (triggerChecker *TriggerChecker) checkTargets(
 	if noDataState != nil {
 		lastState, err = triggerChecker.compareMetricStates(metricName, *noDataState, lastState)
 	}
+
+	logger.Debug().Msg(fmt.Sprintf("New last state: %v", lastState))
 
 	return lastState, needToDeleteMetric, err
 }

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -1182,6 +1182,115 @@ func TestHandleTrigger(t *testing.T) {
 			MetricsToTargetRelation:      map[string]string{},
 		})
 	})
+
+	metricState := lastCheck.Metrics[metric]
+	metricState.Maintenance = 4000
+	lastCheck.Metrics[metric] = metricState
+
+	Convey("No data too long and ttlState is delete, but the metric is on maintenance and NeedToDeleteAfterMaintenance is false, so it won't be deleted", t, func() {
+		triggerChecker.from = 4217
+		triggerChecker.until = 4267
+		triggerChecker.ttlState = moira.TTLStateDEL
+		lastCheck.Timestamp = 4267
+
+		aloneMetrics := map[string]metricSource.MetricData{"t1": *metricSource.MakeMetricData(metric, []float64{}, retention, triggerChecker.from)}
+		lastCheck.MetricsToTargetRelation = conversion.GetRelations(aloneMetrics, triggerChecker.trigger.AloneMetrics)
+		checkData := newCheckData(&lastCheck, triggerChecker.until)
+		metricsToCheck := map[string]map[string]metricSource.MetricData{}
+		oldMetricState := lastCheck.Metrics[metric]
+
+		checkData, err := triggerChecker.check(metricsToCheck, aloneMetrics, checkData, logger)
+
+		So(err, ShouldBeNil)
+		So(checkData, ShouldResemble, moira.CheckData{
+			Metrics: map[string]moira.MetricState{
+				metric: {
+					Timestamp:                    oldMetricState.Timestamp,
+					EventTimestamp:               oldMetricState.EventTimestamp,
+					State:                        oldMetricState.State,
+					Values:                       oldMetricState.Values,
+					Maintenance:                  oldMetricState.Maintenance,
+					NeedToDeleteAfterMaintenance: true,
+				},
+			},
+			MetricsToTargetRelation: map[string]string{},
+			Timestamp:               triggerChecker.until,
+			State:                   moira.StateOK,
+			Score:                   0,
+		})
+	})
+
+	metricState = lastCheck.Metrics[metric]
+	metricState.NeedToDeleteAfterMaintenance = true
+	lastCheck.Metrics[metric] = metricState
+
+	// Convey("Metric on maintenance, NeedToDeleteAfterMaintenance is true, ttlState is delete, but a new metric comes in and NeedToDeleteAfterMaintenance becomes false", t, func() {
+	// 	triggerChecker.from = 4217
+	// 	triggerChecker.until = 4267
+	// 	triggerChecker.ttlState = moira.TTLStateDEL
+	// 	lastCheck.Timestamp = 4227
+
+	// 	aloneMetrics := map[string]metricSource.MetricData{"t1": *metricSource.MakeMetricData(metric, []float64{}, retention, triggerChecker.from)}
+	// 	lastCheck.MetricsToTargetRelation = conversion.GetRelations(aloneMetrics, triggerChecker.trigger.AloneMetrics)
+	// 	checkData := newCheckData(&lastCheck, triggerChecker.until)
+	// 	metricsToCheck := map[string]map[string]metricSource.MetricData{
+	// 		metric : {
+	// 			"t1": {
+	// 				Name: metric,
+	// 				StartTime: 4225,
+	// 				StopTime: 4226,
+	// 				Values: []float64{25},
+	// 			},
+	// 		},
+	// 	}
+	// 	oldMetricState := lastCheck.Metrics[metric]
+
+	// 	checkData, err := triggerChecker.check(metricsToCheck, aloneMetrics, checkData, logger)
+
+	// 	So(err, ShouldBeNil)
+	// 	So(checkData, ShouldResemble, moira.CheckData{
+	// 		Metrics: map[string]moira.MetricState{
+	// 			metric: {
+	// 				Timestamp:                    oldMetricState.Timestamp,
+	// 				EventTimestamp:               oldMetricState.EventTimestamp,
+	// 				State:                        oldMetricState.State,
+	// 				Values:                       oldMetricState.Values,
+	// 				Maintenance:                  oldMetricState.Maintenance,
+	// 				NeedToDeleteAfterMaintenance: false,
+	// 			},
+	// 		},
+	// 		MetricsToTargetRelation: map[string]string{},
+	// 		Timestamp:               triggerChecker.until,
+	// 		State:                   moira.StateOK,
+	// 		Score:                   0,
+	// 	})
+	// })
+
+	Convey("No data too long and ttlState is delete, but the metric is on maintenance and NeedToDeleteAfterMaintenance is true, so it will be deleted", t, func() {
+		triggerChecker.from = 4217
+		triggerChecker.until = 4267
+		triggerChecker.ttlState = moira.TTLStateDEL
+		lastCheck.Timestamp = 4267
+
+		dataBase.EXPECT().RemovePatternsMetrics(triggerChecker.trigger.Patterns).Return(nil)
+
+		aloneMetrics := map[string]metricSource.MetricData{"t1": *metricSource.MakeMetricData(metric, []float64{}, retention, triggerChecker.from)}
+		lastCheck.MetricsToTargetRelation = conversion.GetRelations(aloneMetrics, triggerChecker.trigger.AloneMetrics)
+		checkData := newCheckData(&lastCheck, triggerChecker.until)
+		metricsToCheck := map[string]map[string]metricSource.MetricData{}
+
+		checkData, err := triggerChecker.check(metricsToCheck, aloneMetrics, checkData, logger)
+
+		So(err, ShouldBeNil)
+		So(checkData, ShouldResemble, moira.CheckData{
+			Metrics:                      make(map[string]moira.MetricState),
+			Timestamp:                    triggerChecker.until,
+			State:                        moira.StateOK,
+			Score:                        0,
+			LastSuccessfulCheckTimestamp: 0,
+			MetricsToTargetRelation:      map[string]string{},
+		})
+	})
 }
 
 func TestTriggerChecker_Check(t *testing.T) {

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -1157,7 +1157,7 @@ func TestHandleTrigger(t *testing.T) {
 		})
 	})
 
-	Convey("No data too long and ttlState is delete", t, func() {
+	Convey("No data too long and ttlState is delete, the metric is not on Maintenance, so it will be removed", t, func() {
 		triggerChecker.from = 4217
 		triggerChecker.until = 4267
 		triggerChecker.ttlState = moira.TTLStateDEL
@@ -1224,47 +1224,38 @@ func TestHandleTrigger(t *testing.T) {
 	metricState.NeedToDeleteAfterMaintenance = true
 	lastCheck.Metrics[metric] = metricState
 
-	// Convey("Metric on maintenance, NeedToDeleteAfterMaintenance is true, ttlState is delete, but a new metric comes in and NeedToDeleteAfterMaintenance becomes false", t, func() {
-	// 	triggerChecker.from = 4217
-	// 	triggerChecker.until = 4267
-	// 	triggerChecker.ttlState = moira.TTLStateDEL
-	// 	lastCheck.Timestamp = 4227
+	Convey("Metric on maintenance, NeedToDeleteAfterMaintenance is true, ttlState is delete, but a new metric comes in and NeedToDeleteAfterMaintenance becomes false", t, func() {
+		triggerChecker.from = 4217
+		triggerChecker.until = 4267
+		triggerChecker.ttlState = moira.TTLStateDEL
+		lastCheck.Timestamp = 4227
 
-	// 	aloneMetrics := map[string]metricSource.MetricData{"t1": *metricSource.MakeMetricData(metric, []float64{}, retention, triggerChecker.from)}
-	// 	lastCheck.MetricsToTargetRelation = conversion.GetRelations(aloneMetrics, triggerChecker.trigger.AloneMetrics)
-	// 	checkData := newCheckData(&lastCheck, triggerChecker.until)
-	// 	metricsToCheck := map[string]map[string]metricSource.MetricData{
-	// 		metric : {
-	// 			"t1": {
-	// 				Name: metric,
-	// 				StartTime: 4225,
-	// 				StopTime: 4226,
-	// 				Values: []float64{25},
-	// 			},
-	// 		},
-	// 	}
-	// 	oldMetricState := lastCheck.Metrics[metric]
+		aloneMetrics := map[string]metricSource.MetricData{"t1": *metricSource.MakeMetricData(metric, []float64{5}, retention, triggerChecker.from)}
+		lastCheck.MetricsToTargetRelation = conversion.GetRelations(aloneMetrics, triggerChecker.trigger.AloneMetrics)
+		checkData := newCheckData(&lastCheck, triggerChecker.until)
+		metricsToCheck := map[string]map[string]metricSource.MetricData{}
+		oldMetricState := lastCheck.Metrics[metric]
 
-	// 	checkData, err := triggerChecker.check(metricsToCheck, aloneMetrics, checkData, logger)
+		checkData, err := triggerChecker.check(metricsToCheck, aloneMetrics, checkData, logger)
 
-	// 	So(err, ShouldBeNil)
-	// 	So(checkData, ShouldResemble, moira.CheckData{
-	// 		Metrics: map[string]moira.MetricState{
-	// 			metric: {
-	// 				Timestamp:                    oldMetricState.Timestamp,
-	// 				EventTimestamp:               oldMetricState.EventTimestamp,
-	// 				State:                        oldMetricState.State,
-	// 				Values:                       oldMetricState.Values,
-	// 				Maintenance:                  oldMetricState.Maintenance,
-	// 				NeedToDeleteAfterMaintenance: false,
-	// 			},
-	// 		},
-	// 		MetricsToTargetRelation: map[string]string{},
-	// 		Timestamp:               triggerChecker.until,
-	// 		State:                   moira.StateOK,
-	// 		Score:                   0,
-	// 	})
-	// })
+		So(err, ShouldBeNil)
+		So(checkData, ShouldResemble, moira.CheckData{
+			Metrics: map[string]moira.MetricState{
+				metric: {
+					Timestamp:                    triggerChecker.from,
+					EventTimestamp:               oldMetricState.EventTimestamp,
+					State:                        oldMetricState.State,
+					Values:                       map[string]float64{"t1": 5},
+					Maintenance:                  oldMetricState.Maintenance,
+					NeedToDeleteAfterMaintenance: false,
+				},
+			},
+			MetricsToTargetRelation: map[string]string{},
+			Timestamp:               triggerChecker.until,
+			State:                   moira.StateOK,
+			Score:                   0,
+		})
+	})
 
 	metricState = lastCheck.Metrics[metric]
 	metricState.Maintenance = 4000

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -583,11 +583,11 @@ func TestCheckForNODATA(t *testing.T) {
 		So(needToDeleteMetric, ShouldBeFalse)
 		So(currentState, ShouldNotBeNil)
 		So(*currentState, ShouldResemble, moira.MetricState{
-			Timestamp:                  metricLastState.Timestamp,
-			EventTimestamp:             metricLastState.EventTimestamp,
-			Maintenance:                metricLastState.Maintenance,
-			Suppressed:                 metricLastState.Suppressed,
-			HiddenMetricDueMaintenance: true,
+			Timestamp:      metricLastState.Timestamp,
+			EventTimestamp: metricLastState.EventTimestamp,
+			Maintenance:    metricLastState.Maintenance,
+			Suppressed:     metricLastState.Suppressed,
+			DeletedButKept: true,
 		})
 	})
 
@@ -1227,12 +1227,12 @@ func TestHandleTrigger(t *testing.T) {
 		So(checkData, ShouldResemble, moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				metric: {
-					Timestamp:                  oldMetricState.Timestamp,
-					EventTimestamp:             oldMetricState.EventTimestamp,
-					State:                      oldMetricState.State,
-					Values:                     oldMetricState.Values,
-					Maintenance:                oldMetricState.Maintenance,
-					HiddenMetricDueMaintenance: true,
+					Timestamp:      oldMetricState.Timestamp,
+					EventTimestamp: oldMetricState.EventTimestamp,
+					State:          oldMetricState.State,
+					Values:         oldMetricState.Values,
+					Maintenance:    oldMetricState.Maintenance,
+					DeletedButKept: true,
 				},
 			},
 			MetricsToTargetRelation: map[string]string{},
@@ -1243,7 +1243,7 @@ func TestHandleTrigger(t *testing.T) {
 	})
 
 	metricState = lastCheck.Metrics[metric]
-	metricState.HiddenMetricDueMaintenance = true
+	metricState.DeletedButKept = true
 	lastCheck.Metrics[metric] = metricState
 
 	Convey("Metric on maintenance, HiddenMetricDueMaintenance is true, ttlState is delete, but a new metric comes in and HiddenMetricDueMaintenance becomes false", t, func() {
@@ -1264,12 +1264,12 @@ func TestHandleTrigger(t *testing.T) {
 		So(checkData, ShouldResemble, moira.CheckData{
 			Metrics: map[string]moira.MetricState{
 				metric: {
-					Timestamp:                  triggerChecker.from,
-					EventTimestamp:             oldMetricState.EventTimestamp,
-					State:                      oldMetricState.State,
-					Values:                     map[string]float64{"t1": 5},
-					Maintenance:                oldMetricState.Maintenance,
-					HiddenMetricDueMaintenance: false,
+					Timestamp:      triggerChecker.from,
+					EventTimestamp: oldMetricState.EventTimestamp,
+					State:          oldMetricState.State,
+					Values:         map[string]float64{"t1": 5},
+					Maintenance:    oldMetricState.Maintenance,
+					DeletedButKept: false,
 				},
 			},
 			MetricsToTargetRelation: map[string]string{},

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -577,7 +577,7 @@ func TestCheckForNODATA(t *testing.T) {
 		So(currentState, ShouldBeNil)
 	})
 
-	Convey("TTLState is DEL, has EventTimeStamp, but the metric is on Maintenance, so it's not deleted and HiddenMetricDueMaintenance = true", t, func() {
+	Convey("TTLState is DEL, has EventTimeStamp, but the metric is on Maintenance, so it's not deleted and DeletedButKept = true", t, func() {
 		metricLastState.Maintenance = 11111
 		needToDeleteMetric, currentState := triggerChecker.checkForNoData(metricLastState, logger)
 		So(needToDeleteMetric, ShouldBeFalse)
@@ -1209,7 +1209,7 @@ func TestHandleTrigger(t *testing.T) {
 	metricState.Maintenance = 5000
 	lastCheck.Metrics[metric] = metricState
 
-	Convey("No data too long and ttlState is delete, but the metric is on maintenance and HiddenMetricDueMaintenance is false, so it won't be deleted", t, func() {
+	Convey("No data too long and ttlState is delete, but the metric is on maintenance and DeletedButKept is false, so it won't be deleted", t, func() {
 		triggerChecker.from = 4217
 		triggerChecker.until = 4267
 		triggerChecker.ttlState = moira.TTLStateDEL
@@ -1246,7 +1246,7 @@ func TestHandleTrigger(t *testing.T) {
 	metricState.DeletedButKept = true
 	lastCheck.Metrics[metric] = metricState
 
-	Convey("Metric on maintenance, HiddenMetricDueMaintenance is true, ttlState is delete, but a new metric comes in and HiddenMetricDueMaintenance becomes false", t, func() {
+	Convey("Metric on maintenance, DeletedButKept is true, ttlState is delete, but a new metric comes in and DeletedButKept becomes false", t, func() {
 		triggerChecker.from = 4217
 		triggerChecker.until = 4267
 		triggerChecker.ttlState = moira.TTLStateDEL

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -1184,7 +1184,7 @@ func TestHandleTrigger(t *testing.T) {
 	})
 
 	metricState := lastCheck.Metrics[metric]
-	metricState.Maintenance = 4000
+	metricState.Maintenance = time.Now().Add(time.Minute).Unix()
 	lastCheck.Metrics[metric] = metricState
 
 	Convey("No data too long and ttlState is delete, but the metric is on maintenance and NeedToDeleteAfterMaintenance is false, so it won't be deleted", t, func() {
@@ -1266,7 +1266,11 @@ func TestHandleTrigger(t *testing.T) {
 	// 	})
 	// })
 
-	Convey("No data too long and ttlState is delete, but the metric is on maintenance and NeedToDeleteAfterMaintenance is true, so it will be deleted", t, func() {
+	metricState = lastCheck.Metrics[metric]
+	metricState.Maintenance = 4000
+	lastCheck.Metrics[metric] = metricState
+
+	Convey("No data too long and ttlState is delete, the time for Maintenance of metric is over, so it will be deleted", t, func() {
 		triggerChecker.from = 4217
 		triggerChecker.until = 4267
 		triggerChecker.ttlState = moira.TTLStateDEL

--- a/cmd/cli/cluster.go
+++ b/cmd/cli/cluster.go
@@ -7,7 +7,6 @@ import (
 	"github.com/moira-alert/moira/database/redis"
 )
 
-var noSuchKeyError = "ERR no such key"
 var anyTagsSubscriptionsKeyOld = "moira-any-tags-subscriptions"
 var anyTagsSubscriptionsKeyNew = "{moira-tag-subscriptions}:moira-any-tags-subscriptions"
 var triggersListKeyOld = "moira-triggers-list"

--- a/datatypes.go
+++ b/datatypes.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"sort"
 	"strconv"
@@ -589,7 +588,6 @@ func (event NotificationEvent) FormatTimestamp(location *time.Location, timeForm
 
 // GetOrCreateMetricState gets metric state from check data or create new if CheckData has no state for given metric
 func (checkData *CheckData) GetOrCreateMetricState(metric string, emptyTimestampValue int64, muteNewMetric bool) MetricState {
-	log.Printf("GetOrCreateMetricState: metricName: %v, metrics: %v", metric, checkData.Metrics)
 	_, ok := checkData.Metrics[metric]
 	if !ok {
 		checkData.Metrics[metric] = createEmptyMetricState(emptyTimestampValue, !muteNewMetric)

--- a/datatypes.go
+++ b/datatypes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"strconv"
@@ -377,15 +378,17 @@ func (checkData *CheckData) RemoveMetricsToTargetRelation() {
 
 // MetricState represents metric state data for given timestamp
 type MetricState struct {
-	EventTimestamp  int64              `json:"event_timestamp" example:"1590741878" format:"int64"`
-	State           State              `json:"state" example:"OK"`
-	Suppressed      bool               `json:"suppressed" example:"false"`
-	SuppressedState State              `json:"suppressed_state,omitempty"`
-	Timestamp       int64              `json:"timestamp" example:"1590741878" format:"int64"`
-	Value           *float64           `json:"value,omitempty" example:"70"`
-	Values          map[string]float64 `json:"values,omitempty"`
-	Maintenance     int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
-	MaintenanceInfo MaintenanceInfo    `json:"maintenance_info"`
+	EventTimestamp               int64              `json:"event_timestamp" example:"1590741878" format:"int64"`
+	State                        State              `json:"state" example:"OK"`
+	Suppressed                   bool               `json:"suppressed" example:"false"`
+	SuppressedState              State              `json:"suppressed_state,omitempty"`
+	Timestamp                    int64              `json:"timestamp" example:"1590741878" format:"int64"`
+	Value                        *float64           `json:"value,omitempty" example:"70"`
+	Values                       map[string]float64 `json:"values,omitempty"`
+	Maintenance                  int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
+	MaintenanceInfo              MaintenanceInfo    `json:"maintenance_info"`
+	// NeedToDeleteAfterMaintenance controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
+	NeedToDeleteAfterMaintenance bool               `json:"need_to_delete_after_maintenance,omitempty" example:"false"`
 	// AloneMetrics    map[string]string  `json:"alone_metrics"` // represents a relation between name of alone metrics and their targets
 }
 
@@ -586,6 +589,7 @@ func (event NotificationEvent) FormatTimestamp(location *time.Location, timeForm
 
 // GetOrCreateMetricState gets metric state from check data or create new if CheckData has no state for given metric
 func (checkData *CheckData) GetOrCreateMetricState(metric string, emptyTimestampValue int64, muteNewMetric bool) MetricState {
+	log.Printf("GetOrCreateMetricState: metricName: %v, metrics: %v", metric, checkData.Metrics)
 	_, ok := checkData.Metrics[metric]
 	if !ok {
 		checkData.Metrics[metric] = createEmptyMetricState(emptyTimestampValue, !muteNewMetric)

--- a/datatypes.go
+++ b/datatypes.go
@@ -378,17 +378,17 @@ func (checkData *CheckData) RemoveMetricsToTargetRelation() {
 
 // MetricState represents metric state data for given timestamp
 type MetricState struct {
-	EventTimestamp               int64              `json:"event_timestamp" example:"1590741878" format:"int64"`
-	State                        State              `json:"state" example:"OK"`
-	Suppressed                   bool               `json:"suppressed" example:"false"`
-	SuppressedState              State              `json:"suppressed_state,omitempty"`
-	Timestamp                    int64              `json:"timestamp" example:"1590741878" format:"int64"`
-	Value                        *float64           `json:"value,omitempty" example:"70"`
-	Values                       map[string]float64 `json:"values,omitempty"`
-	Maintenance                  int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
-	MaintenanceInfo              MaintenanceInfo    `json:"maintenance_info"`
+	EventTimestamp  int64              `json:"event_timestamp" example:"1590741878" format:"int64"`
+	State           State              `json:"state" example:"OK"`
+	Suppressed      bool               `json:"suppressed" example:"false"`
+	SuppressedState State              `json:"suppressed_state,omitempty"`
+	Timestamp       int64              `json:"timestamp" example:"1590741878" format:"int64"`
+	Value           *float64           `json:"value,omitempty" example:"70"`
+	Values          map[string]float64 `json:"values,omitempty"`
+	Maintenance     int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
+	MaintenanceInfo MaintenanceInfo    `json:"maintenance_info"`
 	// NeedToDeleteAfterMaintenance controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
-	NeedToDeleteAfterMaintenance bool               `json:"need_to_delete_after_maintenance,omitempty" example:"false"`
+	NeedToDeleteAfterMaintenance bool `json:"need_to_delete_after_maintenance,omitempty" example:"false"`
 	// AloneMetrics    map[string]string  `json:"alone_metrics"` // represents a relation between name of alone metrics and their targets
 }
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -386,8 +386,8 @@ type MetricState struct {
 	Values          map[string]float64 `json:"values,omitempty"`
 	Maintenance     int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
 	MaintenanceInfo MaintenanceInfo    `json:"maintenance_info"`
-	// HiddenMetricDueMaintenance controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
-	HiddenMetricDueMaintenance bool `json:"hidden_metric_due_maintenance,omitempty" example:"false"`
+	// DeletedButKept controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
+	DeletedButKept bool `json:"deleted_but_kept,omitempty" example:"false"`
 	// AloneMetrics    map[string]string  `json:"alone_metrics"` // represents a relation between name of alone metrics and their targets
 }
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -386,8 +386,8 @@ type MetricState struct {
 	Values          map[string]float64 `json:"values,omitempty"`
 	Maintenance     int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
 	MaintenanceInfo MaintenanceInfo    `json:"maintenance_info"`
-	// NeedToDeleteAfterMaintenance controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
-	NeedToDeleteAfterMaintenance bool `json:"need_to_delete_after_maintenance,omitempty" example:"false"`
+	// HiddenMetricDueMaintenance controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
+	HiddenMetricDueMaintenance bool `json:"hidden_metric_due_maintenance,omitempty" example:"false"`
 	// AloneMetrics    map[string]string  `json:"alone_metrics"` // represents a relation between name of alone metrics and their targets
 }
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -386,7 +386,8 @@ type MetricState struct {
 	Values          map[string]float64 `json:"values,omitempty"`
 	Maintenance     int64              `json:"maintenance,omitempty" example:"0" format:"int64"`
 	MaintenanceInfo MaintenanceInfo    `json:"maintenance_info"`
-	// DeletedButKept controls whether the metric will be shown to the user if the trigger has ttlState = Del and the metric is in Maintenance
+	// DeletedButKept controls whether the metric is shown to the user if the trigger has ttlState = Del
+	// and the metric is in Maintenance. The metric remains in the database
 	DeletedButKept bool `json:"deleted_but_kept,omitempty" example:"false"`
 	// AloneMetrics    map[string]string  `json:"alone_metrics"` // represents a relation between name of alone metrics and their targets
 }

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -27,7 +27,7 @@ prometheus:
 checker:
   nodata_check_interval: 60s
   check_interval: 10s
-  stop_checking_interval: 3000s
+  stop_checking_interval: 30s
 log:
   log_file: stdout
   log_level: debug

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -27,7 +27,7 @@ prometheus:
 checker:
   nodata_check_interval: 60s
   check_interval: 10s
-  stop_checking_interval: 30s
+  stop_checking_interval: 3000s
 log:
   log_file: stdout
   log_level: debug


### PR DESCRIPTION
# Fix switch to maintenance at set del

Added a flag `DeletedButKept` which means whether the metric will be shown to the user if it should be deleted by TTL trigger but is on Maintenance, there are several possible events:
1) The TTL of the trigger that has TTLState = Del has expired:
- if the metric is not on Maintenance or its Maintenance time has expired, it is immediately deleted
- if the metric is on Maintenance and `DeletedButKept` is false, then we set `DeletedButKept` = true, the metric remains in the database, but will not be shown to the user
2) The TTL of the trigger has not expired:
- if the metric is on Maintenance, its `DeletedButKept` is true and a new metric arrives, then `DeletedButKept` becomes false and the metric starts to be shown to the user
The state of the metric is updated

Close/relates: #530 
