### PR TITLE
fix: switch to a maintained version of carbon-c-relay

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,14 +101,14 @@ services:
     restart: always
 
   relay:
-    image: openmetric/carbon-c-relay
+    image: openitcockpit/carbon-c-relay
     ports:
       - "2003:2003"
     depends_on:
       - graphite
     volumes:
-      - ./local/relay.conf:/openmetric/conf/relay.conf
-    command: /usr/bin/relay -E -s -f /openmetric/conf/relay.conf
+      - ./local/relay.conf:/opt/carbon-c-relay/relay.conf
+    command: /opt/carbon-c-relay/bin/relay -E -s -f /opt/carbon-c-relay/relay.conf
     restart: always
 networks:
   balancer:


### PR DESCRIPTION
Last time [openmetric/carbon-c-relay](https://registry.hub.docker.com/r/openmetric/carbon-c-relay/tags) was build almost 4 years ago. Obviously, it doesn't support arm, so it runs under emulation on m1/m2 macbooks.

