### PR TITLE
fix(build): add tag 'latest' to nightly images

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -33,8 +33,8 @@ jobs:
             MoiraVersion=${{env.DOCKER_TAG}}
             GIT_COMMIT=${{github.sha}}
           push: true
-          tags: moira/${{matrix.services}}-nightly:${{env.DOCKER_TAG}}
-
+          tags: moira/${{matrix.services}}-nightly:${{env.DOCKER_TAG}},moira/${{matrix.services}}-nightly:latest
+          
       - name: Comment PR with build tag
         uses: mshick/add-pr-comment@v2
         if: always()


### PR DESCRIPTION
# PR Summary
fix(build): add tag 'latest' to nightly images

Currently, "nightly" images are generated without the "latest" tag. Fix corrects this behavior so that you can always pull the latest image when building the service.