### PR TITLE
Revert panic logging in checker

### DIFF
--- a/checker/worker/handler.go
+++ b/checker/worker/handler.go
@@ -34,7 +34,8 @@ func (check *Checker) startTriggerHandler(triggerIDsToCheck <-chan string, metri
 	}
 }
 
-func (check *Checker) handleTrigger(triggerID string, metrics *metrics.CheckMetrics) (err error) {
+func (check *Checker) handleTrigger(triggerID string, metrics *metrics.CheckMetrics) error {
+	var err error
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: '%s' stack: %s", r, debug.Stack())


### PR DESCRIPTION
Partially reverts #933 due to multiple errors that appeared in logs after fixing panic handling in checker