### PR TITLE
feature(metrics): add fetch notifications metric

### DIFF
--- a/cmd/notifier/main.go
+++ b/cmd/notifier/main.go
@@ -137,6 +137,7 @@ func main() {
 		Logger:   logger,
 		Database: database,
 		Notifier: sender,
+		Metrics:  notifierMetrics,
 	}
 	fetchNotificationsWorker.Start()
 	defer stopNotificationsFetcher(fetchNotificationsWorker)

--- a/integration_tests/notifier/notifier_test.go
+++ b/integration_tests/notifier/notifier_test.go
@@ -119,6 +119,7 @@ func TestNotifier(t *testing.T) {
 	fetchNotificationsWorker := notifications.FetchNotificationsWorker{
 		Database: database,
 		Logger:   logger,
+		Metrics:  notifierMetrics,
 		Notifier: notifierInstance,
 	}
 

--- a/metrics/notifier.go
+++ b/metrics/notifier.go
@@ -15,7 +15,7 @@ type NotifierMetrics struct {
 	SendersDroppedNotifications    MetersCollection
 	PlotsBuildDurationMs           Histogram
 	PlotsEvaluateTriggerDurationMs Histogram
-	FetchNotificationsDurationMs   Histogram
+	fetchNotificationsDurationMs   Histogram
 }
 
 // ConfigureNotifierMetrics is notifier metrics configurator.
@@ -32,13 +32,13 @@ func ConfigureNotifierMetrics(registry Registry, prefix string) *NotifierMetrics
 		SendersDroppedNotifications:    NewMetersCollection(registry),
 		PlotsBuildDurationMs:           registry.NewHistogram("plots", "build", "duration", "ms"),
 		PlotsEvaluateTriggerDurationMs: registry.NewHistogram("plots", "evaluate", "trigger", "duration", "ms"),
-		FetchNotificationsDurationMs:   registry.NewHistogram("fetch", "notifications", "duration", "ms"),
+		fetchNotificationsDurationMs:   registry.NewHistogram("fetch", "notifications", "duration", "ms"),
 	}
 }
 
 // UpdateFetchNotificationsDurationMs - counts how much time has passed since fetchNotificationsStartTime in ms and updates the metric
 func (metrics *NotifierMetrics) UpdateFetchNotificationsDurationMs(fetchNotificationsStartTime time.Time) {
-	metrics.FetchNotificationsDurationMs.Update(time.Since(fetchNotificationsStartTime).Milliseconds())
+	metrics.fetchNotificationsDurationMs.Update(time.Since(fetchNotificationsStartTime).Milliseconds())
 }
 
 // MarkSendersDroppedNotifications marks metrics as 1 by contactType for dropped notifications.

--- a/metrics/notifier.go
+++ b/metrics/notifier.go
@@ -12,6 +12,7 @@ type NotifierMetrics struct {
 	SendersFailedMetrics           MetersCollection
 	PlotsBuildDurationMs           Histogram
 	PlotsEvaluateTriggerDurationMs Histogram
+	FetchNotificationsDurationMs   Histogram
 }
 
 // ConfigureNotifierMetrics is notifier metrics configurator
@@ -27,5 +28,6 @@ func ConfigureNotifierMetrics(registry Registry, prefix string) *NotifierMetrics
 		SendersFailedMetrics:           NewMetersCollection(registry),
 		PlotsBuildDurationMs:           registry.NewHistogram("plots", "build", "duration", "ms"),
 		PlotsEvaluateTriggerDurationMs: registry.NewHistogram("plots", "evaluate", "trigger", "duration", "ms"),
+		FetchNotificationsDurationMs:   registry.NewHistogram("fetch", "notifications", "duration", "ms"),
 	}
 }

--- a/metrics/notifier.go
+++ b/metrics/notifier.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "time"
+
 // NotifierMetrics is a collection of metrics used in notifier
 type NotifierMetrics struct {
 	SubsMalformed                  Meter
@@ -30,4 +32,9 @@ func ConfigureNotifierMetrics(registry Registry, prefix string) *NotifierMetrics
 		PlotsEvaluateTriggerDurationMs: registry.NewHistogram("plots", "evaluate", "trigger", "duration", "ms"),
 		FetchNotificationsDurationMs:   registry.NewHistogram("fetch", "notifications", "duration", "ms"),
 	}
+}
+
+// UpdateFetchNotificationsDurationMs - counts how much time has passed since fetchNotificationsStartTime in ms and updates the metric
+func (metrics *NotifierMetrics) UpdateFetchNotificationsDurationMs(fetchNotificationsStartTime time.Time) {
+	metrics.FetchNotificationsDurationMs.Update(time.Since(fetchNotificationsStartTime).Milliseconds())
 }

--- a/notifier/notifications/notifications.go
+++ b/notifier/notifications/notifications.go
@@ -29,7 +29,7 @@ func (worker *FetchNotificationsWorker) updateFetchNotificationsMetric(fetchNoti
 		return
 	}
 
-	worker.Metrics.FetchNotificationsDurationMs.Update(time.Since(fetchNotificationsStartTime).Milliseconds())
+	worker.Metrics.UpdateFetchNotificationsDurationMs(fetchNotificationsStartTime)
 }
 
 // Start is a cycle that fetches scheduled notifications from database

--- a/notifier/notifications/notifications_test.go
+++ b/notifier/notifications/notifications_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	logging "github.com/moira-alert/moira/logging/zerolog_adapter"
+	"github.com/moira-alert/moira/metrics"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/moira-alert/moira"
@@ -13,6 +14,8 @@ import (
 	mock_notifier "github.com/moira-alert/moira/mock/notifier"
 	notifier2 "github.com/moira-alert/moira/notifier"
 )
+
+var notifierMetrics = metrics.ConfigureNotifierMetrics(metrics.NewDummyRegistry(), "notifier")
 
 func TestProcessScheduledEvent(t *testing.T) {
 	subID2 := "subscriptionID-00000000000002"
@@ -60,6 +63,7 @@ func TestProcessScheduledEvent(t *testing.T) {
 		Database: dataBase,
 		Logger:   logger,
 		Notifier: notifier,
+		Metrics:  notifierMetrics,
 	}
 
 	Convey("Two different notifications, should send two packages", t, func() {
@@ -159,6 +163,7 @@ func TestGoRoutine(t *testing.T) {
 		Database: dataBase,
 		Logger:   logger,
 		Notifier: notifier,
+		Metrics:  notifierMetrics,
 	}
 
 	shutdown := make(chan struct{})


### PR DESCRIPTION
# Add fetch notifications metric

A metric that determines the fetching time of notifications can help in determining `transaction_timeout`
