### PR TITLE
fix: RemoteAllowed calculation

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -137,7 +137,7 @@ func main() {
 		prometheusSource,
 	)
 
-	webConfigContent, err := applicationConfig.Web.getSettings(remoteConfig.Enabled)
+	webConfigContent, err := applicationConfig.Web.getSettings(remoteConfig.Enabled || prometheusConfig.Enabled)
 	if err != nil {
 		logger.Fatal().
 			Error(err).


### PR DESCRIPTION
Currently, RemoteAllowed controls if triggers of both "remote" types (remote graphite and prometheus) could be created, but it is calculated only based on remote graphite config.

In our case we only use prometheus triggers, so it is a little odd to fill in remote graphite config section (to set `Enabled: true`) to be able to create prometheus triggers.