### PR TITLE
feat(cli): add remove subscriptions command

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -327,7 +327,7 @@ func main() { //nolint
 
 	if *removeSubscriptions != "" {
 		logger.Info().Msg("Start delition of subscriptions")
-		subscriptionIDs := strings.Split(*removeSubscriptions, " ")
+		subscriptionIDs := strings.Split(*removeSubscriptions, ";")
 
 		logger.Debug().
 			Interface("subscription_ids", subscriptionIDs).

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -46,7 +46,7 @@ var (
 )
 
 var (
-	removeSubscriptions = flag.String("remove-subscriptions", "", "Remove given space-separated subscriptions.")
+	removeSubscriptions = flag.String("remove-subscriptions", "", "Remove given subscriptions separated by semicolons.")
 )
 
 var (
@@ -329,12 +329,12 @@ func main() { //nolint
 		logger.Info().Msg("Start delition of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ";")
 
-		logger.Info().
+		logger.Debug().
 			Interface("subscription_ids", subscriptionIDs).
 			Msg("Remove subscription IDs")
 
 		for _, subscriptionID := range subscriptionIDs {
-			if err := database.RemoveSubscription(subscriptionID); err != nil {
+			if err := database.RemoveSubscription(strings.TrimSpace(subscriptionID)); err != nil {
 				logger.Error().
 					Error(err).
 					String("subscription_id", subscriptionID).

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -46,6 +46,10 @@ var (
 )
 
 var (
+	removeSubscriptions = flag.String("remove-subscriptions", "", "Remove given comma-separated subscriptions.")
+)
+
+var (
 	cleanupUsers      = flag.Bool("cleanup-users", false, "Disable/delete contacts and subscriptions of missing users")
 	cleanupLastChecks = flag.Bool("cleanup-last-checks", false, "Delete abandoned triggers last checks.")
 	cleanupTags       = flag.Bool("cleanup-tags", false, "Delete abandoned tags.")
@@ -320,6 +324,18 @@ func main() { //nolint
 		}
 		logger.Info().Msg("Dump was pushed")
 	}
+
+	if *removeSubscriptions != "" {
+		subscriptionIDs := strings.Split(*removeSubscriptions, ",")
+		for _, subscriptionID := range subscriptionIDs {
+			if err := database.RemoveSubscription(subscriptionID); err != nil {
+				logger.Error().
+					Error(err).
+					Msg("Failed to remove subscription")
+			}
+		}
+		logger.Info().Msg("Delition of subscriptions finished")
+	}
 }
 
 func GetDumpBriefInfo(dump *dto.TriggerDump) string {
@@ -334,7 +350,7 @@ func GetDumpBriefInfo(dump *dto.TriggerDump) string {
 func initApp() (cleanupConfig, moira.Logger, moira.Database) {
 	flag.Parse()
 	if *printVersion {
-		fmt.Println("Moira - alerting system based on graphite data")
+		fmt.Println("Moira - alerting system based on graphite or prometheus data")
 		fmt.Println("Version:", MoiraVersion)
 		fmt.Println("Git Commit:", GitCommit)
 		fmt.Println("Go Version:", GoVersion)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -326,6 +326,7 @@ func main() { //nolint
 	}
 
 	if *removeSubscriptions != "" {
+		logger.Info().Msg("Delition of subscriptions started")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ",")
 		for _, subscriptionID := range subscriptionIDs {
 			if err := database.RemoveSubscription(subscriptionID); err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -329,7 +329,7 @@ func main() { //nolint
 		logger.Info().Msg("Start delition of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ";")
 
-		logger.Debug().
+		logger.Info().
 			Interface("subscription_ids", subscriptionIDs).
 			Msg("Remove subscription IDs")
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -331,6 +331,7 @@ func main() { //nolint
 			if err := database.RemoveSubscription(subscriptionID); err != nil {
 				logger.Error().
 					Error(err).
+					String("subscription_id", subscriptionID).
 					Msg("Failed to remove subscription")
 			}
 		}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -326,7 +326,7 @@ func main() { //nolint
 	}
 
 	if *removeSubscriptions != "" {
-		logger.Info().Msg("Start delition of subscriptions")
+		logger.Info().Msg("Start deletion of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ";")
 
 		logger.Debug().
@@ -342,7 +342,7 @@ func main() { //nolint
 			}
 		}
 
-		logger.Info().Msg("Delition of subscriptions finished")
+		logger.Info().Msg("Deletion of subscriptions finished")
 	}
 }
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -328,6 +328,11 @@ func main() { //nolint
 	if *removeSubscriptions != "" {
 		logger.Info().Msg("Start delition of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ",")
+		logger.Info().
+			String("command", *removeSubscriptions).
+			Interface("subscription_ids", subscriptionIDs).
+			Msg("Debug remove subscriptions command")
+
 		for _, subscriptionID := range subscriptionIDs {
 			if err := database.RemoveSubscription(subscriptionID); err != nil {
 				logger.Error().

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -326,7 +326,7 @@ func main() { //nolint
 	}
 
 	if *removeSubscriptions != "" {
-		logger.Info().Msg("Delition of subscriptions started")
+		logger.Info().Msg("Start delition of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ",")
 		for _, subscriptionID := range subscriptionIDs {
 			if err := database.RemoveSubscription(subscriptionID); err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -328,10 +328,10 @@ func main() { //nolint
 	if *removeSubscriptions != "" {
 		logger.Info().Msg("Start delition of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, " ")
-		logger.Info().
-			String("command", *removeSubscriptions).
+
+		logger.Debug().
 			Interface("subscription_ids", subscriptionIDs).
-			Msg("Debug remove subscriptions command")
+			Msg("Remove subscription IDs")
 
 		for _, subscriptionID := range subscriptionIDs {
 			if err := database.RemoveSubscription(subscriptionID); err != nil {
@@ -341,6 +341,7 @@ func main() { //nolint
 					Msg("Failed to remove subscription")
 			}
 		}
+
 		logger.Info().Msg("Delition of subscriptions finished")
 	}
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -46,7 +46,7 @@ var (
 )
 
 var (
-	removeSubscriptions = flag.String("remove-subscriptions", "", "Remove given comma-separated subscriptions.")
+	removeSubscriptions = flag.String("remove-subscriptions", "", "Remove given space-separated subscriptions.")
 )
 
 var (

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -327,7 +327,7 @@ func main() { //nolint
 
 	if *removeSubscriptions != "" {
 		logger.Info().Msg("Start delition of subscriptions")
-		subscriptionIDs := strings.Split(*removeSubscriptions, ",")
+		subscriptionIDs := strings.Split(*removeSubscriptions, " ")
 		logger.Info().
 			String("command", *removeSubscriptions).
 			Interface("subscription_ids", subscriptionIDs).

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -328,6 +328,7 @@ func main() { //nolint
 	if *removeSubscriptions != "" {
 		logger.Info().Msg("Start deletion of subscriptions")
 		subscriptionIDs := strings.Split(*removeSubscriptions, ";")
+		deleted := 0
 
 		logger.Debug().
 			Interface("subscription_ids", subscriptionIDs).
@@ -339,10 +340,14 @@ func main() { //nolint
 					Error(err).
 					String("subscription_id", subscriptionID).
 					Msg("Failed to remove subscription")
+				continue
 			}
+			deleted++
 		}
 
-		logger.Info().Msg("Deletion of subscriptions finished")
+		logger.Info().
+			Int("deleted", deleted).
+			Msg("Deletion of subscriptions finished")
 	}
 }
 


### PR DESCRIPTION
# Add remove subscriptions command

Added a new command to delete given subscriptions separated by semicolons

Example: `cli --remove-subscriptions 'id1; id2; id3'`
