### PR TITLE
fix(api): make triggers with seriesByTag function require at least one argument with a strict equality

### DIFF
--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -230,7 +230,15 @@ func checkFunction(funcName string, triggerSource moira.TriggerSource) *ProblemO
 	}
 
 	if strings.HasPrefix(funcName, "seriesByTag") {
-		if !validateSeriesByTag(funcName) {
+		valid, err := validateSeriesByTag(funcName)
+		if err != nil {
+			return &ProblemOfTarget{
+				Argument:    funcName,
+				Type:        isBad,
+				Description: "Incorrect seriesByTag syntax.",
+			}
+		}
+		if !valid {
 			return &ProblemOfTarget{
 				Argument:    funcName,
 				Type:        isBad,
@@ -293,20 +301,20 @@ func funcIsSupported(funcName string) bool {
 }
 
 // checks if a seriesByTag expression has at least one argument with a strict equality
-func validateSeriesByTag(target string) bool {
+func validateSeriesByTag(target string) (bool, error) {
 	tagArgs, err := filter.ParseSeriesByTag(target)
 
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	for _, arg := range tagArgs {
 		if arg.Operator == filter.EqualOperator && !hasWildcard(arg.Value) {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func hasWildcard(target string) bool {

--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -2,13 +2,14 @@ package dto
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-graphite/carbonapi/expr/functions"
 	"github.com/go-graphite/carbonapi/expr/metadata"
-	"github.com/moira-alert/moira"
-
 	"github.com/go-graphite/carbonapi/pkg/parser"
+	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/filter"
 )
 
 func init() {
@@ -181,7 +182,8 @@ func DoesAnyTreeHaveError(trees []TreeOfProblems) bool {
 
 // checkExpression validates expression.
 func checkExpression(expression parser.Expr, ttl time.Duration, triggerSource moira.TriggerSource) *ProblemOfTarget {
-	if !expression.IsFunc() {
+
+	if !expression.IsFunc() && !strings.HasPrefix(expression.Target(), "seriesByTag") {
 		return nil
 	}
 
@@ -204,7 +206,7 @@ func checkExpression(expression parser.Expr, ttl time.Duration, triggerSource mo
 	}
 
 	for position, argument := range expression.Args() {
-		if !argument.IsFunc() {
+		if !argument.IsFunc() && !strings.HasPrefix(argument.Target(), "seriesByTag") {
 			continue
 		}
 
@@ -225,6 +227,17 @@ func checkExpression(expression parser.Expr, ttl time.Duration, triggerSource mo
 func checkFunction(funcName string, triggerSource moira.TriggerSource) *ProblemOfTarget {
 	if triggerSource != moira.GraphiteLocal {
 		return nil
+	}
+
+	if strings.HasPrefix(funcName, "seriesByTag") {
+		if !validateSeriesByTag(funcName) {
+			return &ProblemOfTarget{
+				Argument:    funcName,
+				Type:        isBad,
+				Description: "seriesByTag function requires at least one argument with strict equality.",
+			}
+		}
+		funcName = "seriesByTag"
 	}
 
 	if _, isUnstable := unstableFunctions[funcName]; isUnstable {
@@ -277,6 +290,27 @@ func functionArgumentsInTheRangeTTL(expression parser.Expr, ttl time.Duration) (
 func funcIsSupported(funcName string) bool {
 	_, ok := metadata.FunctionMD.Functions[funcName]
 	return ok || funcName == ""
+}
+
+// checks if a seriesByTag expression has at least one argument with a strict equality
+func validateSeriesByTag(target string) bool {
+	tagArgs, err := filter.ParseSeriesByTag(target)
+
+	if err != nil {
+		return false
+	}
+
+	for _, arg := range tagArgs {
+		if arg.Operator == filter.EqualOperator && !hasWildcard(arg.Value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasWildcard(target string) bool {
+	return strings.ContainsAny(target, "[]{}*?")
 }
 
 // positiveDuration:

--- a/api/dto/target_test.go
+++ b/api/dto/target_test.go
@@ -118,6 +118,49 @@ func TestTargetVerification(t *testing.T) {
 			So(problems[0].SyntaxOk, ShouldBeFalse)
 			So(problems[0].TreeOfProblems, ShouldBeNil)
 		})
+
+		Convey("Check seriesByTag target without non-regex args, regex has anchors", func() {
+			targets := []string{"seriesByTag('name=~^tag\\..*$')"}
+			problems, err := TargetVerification(targets, 0, moira.GraphiteLocal)
+			So(err, ShouldBeNil)
+			So(problems[0].SyntaxOk, ShouldBeTrue)
+			So(problems[0].TreeOfProblems.Argument, ShouldEqual, "seriesByTag('name=~^tag\\..*$')")
+		})
+
+		Convey("Check seriesByTag target with a wildcard argument", func() {
+			targets := []string{"seriesByTag('name=ab.bc.*.cd.*.ef')"}
+			problems, err := TargetVerification(targets, 0, moira.GraphiteLocal)
+			So(err, ShouldBeNil)
+			So(problems[0].SyntaxOk, ShouldBeTrue)
+			So(problems[0].TreeOfProblems.Argument, ShouldEqual, "seriesByTag('name=ab.bc.*.cd.*.ef')")
+		})
+
+		Convey("Check nested seriesByTag target without non-regex args", func() {
+			targets := []string{"aliasByTags(seriesByTag('name=~*'),'tag')"}
+
+			problems, err := TargetVerification(targets, 0, moira.GraphiteLocal)
+			So(err, ShouldBeNil)
+			So(problems[0].SyntaxOk, ShouldBeTrue)
+			So(problems[0].TreeOfProblems.Problems[0].Argument, ShouldEqual, "seriesByTag('name=~*')")
+		})
+
+		Convey("Check nested seriesByTag target without arguments that have strict equality", func() {
+			targets := []string{"aliasByTags(seriesByTag('name=~*', 'tag1~=*val1*', 'tag2=*val2*'),'tag')"}
+
+			problems, err := TargetVerification(targets, 0, moira.GraphiteLocal)
+			So(err, ShouldBeNil)
+			So(problems[0].SyntaxOk, ShouldBeTrue)
+			So(problems[0].TreeOfProblems.Problems[0].Argument, ShouldEqual, "seriesByTag('name=~*', 'tag1~=*val1*', 'tag2=*val2*')")
+		})
+
+		Convey("Check nested seriesByTag target with an argument that has strict equality", func() {
+			targets := []string{"aliasByTags(seriesByTag('name=~*', 'tag1=val1', 'tag2=val2', 'tag3=val3*'),'tag')"}
+
+			problems, err := TargetVerification(targets, 0, moira.GraphiteLocal)
+			So(err, ShouldBeNil)
+			So(problems[0].SyntaxOk, ShouldBeTrue)
+			So(problems[0].TreeOfProblems, ShouldBeNil)
+		})
 	})
 }
 

--- a/api/dto/target_test.go
+++ b/api/dto/target_test.go
@@ -125,6 +125,7 @@ func TestTargetVerification(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(problems[0].SyntaxOk, ShouldBeTrue)
 			So(problems[0].TreeOfProblems.Argument, ShouldEqual, "seriesByTag('name=~^tag\\..*$')")
+			So(problems[0].TreeOfProblems.Type, ShouldEqual, isBad)
 		})
 
 		Convey("Check seriesByTag target with a wildcard argument", func() {
@@ -133,6 +134,7 @@ func TestTargetVerification(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(problems[0].SyntaxOk, ShouldBeTrue)
 			So(problems[0].TreeOfProblems.Argument, ShouldEqual, "seriesByTag('name=ab.bc.*.cd.*.ef')")
+			So(problems[0].TreeOfProblems.Type, ShouldEqual, isBad)
 		})
 
 		Convey("Check nested seriesByTag target without non-regex args", func() {
@@ -142,6 +144,7 @@ func TestTargetVerification(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(problems[0].SyntaxOk, ShouldBeTrue)
 			So(problems[0].TreeOfProblems.Problems[0].Argument, ShouldEqual, "seriesByTag('name=~*')")
+			So(problems[0].TreeOfProblems.Problems[0].Type, ShouldEqual, isBad)
 		})
 
 		Convey("Check nested seriesByTag target without arguments that have strict equality", func() {
@@ -151,6 +154,7 @@ func TestTargetVerification(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(problems[0].SyntaxOk, ShouldBeTrue)
 			So(problems[0].TreeOfProblems.Problems[0].Argument, ShouldEqual, "seriesByTag('name=~*', 'tag1~=*val1*', 'tag2=*val2*')")
+			So(problems[0].TreeOfProblems.Problems[0].Type, ShouldEqual, isBad)
 		})
 
 		Convey("Check nested seriesByTag target with an argument that has strict equality", func() {


### PR DESCRIPTION
# Make triggers with seriesByTag function require at least one argument with a strict equality

This PR is intended to prevent Moira from saving too many metrics locally when someone creates/edits a trigger with a target that can match a lot of them.
With these changes seriesByTag must have at least one argument with equality operator and no wildcards.
## Examples

### Valid targets after the change
- `movingAverage(groupByTags(seriesByTag('project=my-test-project'), 'max'), '10min')`
- `aliasByTags(seriesByTag('name=~*', 'tag1=val1', 'tag2=val2', 'tag3=val3*'),'tag')`
### Invalid targets after the change
- `seriesByTag('name=ab.bc.*.cd.*.ef')`
- `aliasByTags(seriesByTag('name=~*'),'tag')`
- `aliasByTags(seriesByTag('name=~*', 'tag1~=*val1*', 'tag2=*val2*'),'tag')`