### PR TITLE
feat(api): Allow tag stats for non api triggers

### DIFF
--- a/api/handler/handler_test.go
+++ b/api/handler/handler_test.go
@@ -166,13 +166,13 @@ func TestAdminOnly(t *testing.T) {
 		})
 	})
 
-	Convey("Get tag stats", t, func() {
+	Convey("Get unused triggers", t, func() {
 		Convey("For non-admin", func() {
 			trigger := &dto.Trigger{}
 			triggerBytes, err := json.Marshal(trigger)
 			So(err, ShouldBeNil)
 
-			testRequest := httptest.NewRequest(http.MethodGet, "/api/tag/stats", bytes.NewReader(triggerBytes))
+			testRequest := httptest.NewRequest(http.MethodGet, "/api/trigger/unused", bytes.NewReader(triggerBytes))
 			testRequest.Header.Add("x-webauth-user", userLogin)
 
 			responseWriter := httptest.NewRecorder()
@@ -188,11 +188,10 @@ func TestAdminOnly(t *testing.T) {
 			triggerBytes, err := json.Marshal(trigger)
 			So(err, ShouldBeNil)
 
-			mockDb.EXPECT().GetTagNames().Return([]string{"tag_1"}, nil)
-			mockDb.EXPECT().GetTagsSubscriptions([]string{"tag_1"}).Return([]*moira.SubscriptionData{}, nil)
-			mockDb.EXPECT().GetTagTriggerIDs("tag_1").Return([]string{"tag_1_trigger_id"}, nil)
+			mockDb.EXPECT().GetUnusedTriggerIDs().Return([]string{"tag_1"}, nil)
+			mockDb.EXPECT().GetTriggerChecks([]string{"tag_1"}).Return([]*moira.TriggerCheck{}, nil)
 
-			testRequest := httptest.NewRequest(http.MethodGet, "/api/tag/stats", bytes.NewReader(triggerBytes))
+			testRequest := httptest.NewRequest(http.MethodGet, "/api/trigger/unused", bytes.NewReader(triggerBytes))
 			testRequest.Header.Add("x-webauth-user", adminLogin)
 
 			responseWriter := httptest.NewRecorder()

--- a/api/handler/tag.go
+++ b/api/handler/tag.go
@@ -14,7 +14,7 @@ import (
 func tag(router chi.Router) {
 	router.Post("/", createTags)
 	router.Get("/", getAllTags)
-	router.With(middleware.AdminOnlyMiddleware()).Get("/stats", getAllTagsAndSubscriptions)
+	router.Get("/stats", getAllTagsAndSubscriptions)
 	router.Route("/{tag}", func(router chi.Router) {
 		router.Use(middleware.TagContext)
 		router.Use(middleware.AdminOnlyMiddleware())


### PR DESCRIPTION
Allow usage of `/api/tag/stats` for non-admins