### PR TITLE
fix(cli): add cleanup pattern metrics cli key

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -456,7 +456,7 @@ func openFile(filePath string, mode int) (*os.File, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("file is not specified")
 	}
-	file, err := os.OpenFile(filePath, mode, 0o666) //nolint:gofumpt,gomnd
+	file, err := os.OpenFile(filePath, mode, 0666) //nolint:gofumpt,gomnd
 	if err != nil {
 		return nil, fmt.Errorf("cannot open file: %w", err)
 	}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -441,7 +441,7 @@ func openFile(filePath string, mode int) (*os.File, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("file is not specified")
 	}
-	file, err := os.OpenFile(filePath, mode, 0o666) //nolint:gofumpt,gomnd
+	file, err := os.OpenFile(filePath, mode, 0666) //nolint:gofumpt,gomnd
 	if err != nil {
 		return nil, fmt.Errorf("cannot open file: %w", err)
 	}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -46,14 +46,15 @@ var plotting = flag.Bool("plotting", false, "enable images in all notifications"
 var removeSubscriptions = flag.String("remove-subscriptions", "", "Remove given subscriptions separated by semicolons.")
 
 var (
-	cleanupUsers      = flag.Bool("cleanup-users", false, "Disable/delete contacts and subscriptions of missing users")
-	cleanupLastChecks = flag.Bool("cleanup-last-checks", false, "Delete abandoned triggers last checks.")
-	cleanupTags       = flag.Bool("cleanup-tags", false, "Delete abandoned tags.")
-	cleanupMetrics    = flag.Bool("cleanup-metrics", false, "Delete outdated metrics.")
-	cleanupRetentions = flag.Bool("cleanup-retentions", false, "Delete abandoned retentions.")
-	userDel           = flag.String("user-del", "", "Delete all contacts and subscriptions for a user")
-	fromUser          = flag.String("from-user", "", "Transfer subscriptions and contacts from user.")
-	toUser            = flag.String("to-user", "", "Transfer subscriptions and contacts to user.")
+	cleanupUsers          = flag.Bool("cleanup-users", false, "Disable/delete contacts and subscriptions of missing users")
+	cleanupLastChecks     = flag.Bool("cleanup-last-checks", false, "Delete abandoned triggers last checks.")
+	cleanupTags           = flag.Bool("cleanup-tags", false, "Delete abandoned tags.")
+	cleanupMetrics        = flag.Bool("cleanup-metrics", false, "Delete outdated metrics.")
+	cleanupPatternMetrics = flag.Bool("cleanup-pattern-metrics", false, "Delete outdated pattern metrics.")
+	cleanupRetentions     = flag.Bool("cleanup-retentions", false, "Delete abandoned retentions.")
+	userDel               = flag.String("user-del", "", "Delete all contacts and subscriptions for a user")
+	fromUser              = flag.String("from-user", "", "Transfer subscriptions and contacts from user.")
+	toUser                = flag.String("to-user", "", "Transfer subscriptions and contacts to user.")
 )
 
 var (
@@ -231,12 +232,20 @@ func main() { //nolint
 		log := logger.String(moira.LogFieldNameContext, "cleanup-metrics")
 
 		log.Info().Msg("Cleanup of outdated metrics started")
-		err := handleCleanUpOutdatedMetrics(confCleanup, database)
-		if err != nil {
+
+		if err := handleCleanUpOutdatedMetrics(confCleanup, database); err != nil {
 			log.Error().
 				Error(err).
 				Msg("Failed to cleanup outdated metrics")
 		}
+
+		log.Info().Msg("Cleanup of outdated metrics finished")
+	}
+
+	if *cleanupPatternMetrics {
+		log := logger.String(moira.LogFieldNameContext, "cleanup-pattern-metrics")
+
+		log.Info().Msg("Cleanup of outdated pattern metrics started")
 
 		count, err := handleCleanUpOutdatedPatternMetrics(database)
 		if err != nil {
@@ -249,7 +258,7 @@ func main() { //nolint
 			Int64("deleted_pattern_metrics", count).
 			Msg("Cleaned up outdated pattern metrics")
 
-		log.Info().Msg("Cleanup of outdated metrics finished")
+		log.Info().Msg("Cleanup of outdated pattern metrics finished")
 	}
 
 	if *cleanupLastChecks {
@@ -432,7 +441,7 @@ func openFile(filePath string, mode int) (*os.File, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("file is not specified")
 	}
-	file, err := os.OpenFile(filePath, mode, 0666) //nolint:gofumpt,gomnd
+	file, err := os.OpenFile(filePath, mode, 0o666) //nolint:gofumpt,gomnd
 	if err != nil {
 		return nil, fmt.Errorf("cannot open file: %w", err)
 	}


### PR DESCRIPTION
# Add cleanup pattern metrics cli key

Removed the `moira-pattern-metrics` key clearance from the `cleanup-metrics` cli key and added `cleanup-pattern-metrics` to the `cleanup-pattern-metrics` cli key