### PR TITLE
Add ability for admins to create contacts and subscriptions for other users and teams

### DIFF
--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -46,13 +46,19 @@ func GetContactById(database moira.Database, contactID string) (*dto.Contact, *a
 }
 
 // CreateContact creates new notification contact for current user.
-func CreateContact(dataBase moira.Database, contact *dto.Contact, userLogin, teamID string) *api.ErrorResponse {
+func CreateContact(dataBase moira.Database, auth *api.Authorization, contact *dto.Contact, userLogin, teamID string) *api.ErrorResponse {
 	if userLogin != "" && teamID != "" {
 		return api.ErrorInternalServer(fmt.Errorf("CreateContact: cannot create contact when both userLogin and teamID specified"))
 	}
+
+	// Only admins are allowed to create contacts for other users
+	if !auth.IsAdmin(userLogin) || contact.User == "" {
+		contact.User = userLogin
+	}
+
 	contactData := moira.ContactData{
 		ID:    contact.ID,
-		User:  userLogin,
+		User:  contact.User,
 		Team:  teamID,
 		Type:  contact.Type,
 		Value: contact.Value,
@@ -76,7 +82,7 @@ func CreateContact(dataBase moira.Database, contact *dto.Contact, userLogin, tea
 	if err := dataBase.SaveContact(&contactData); err != nil {
 		return api.ErrorInternalServer(err)
 	}
-	contact.User = userLogin
+	contact.User = contactData.User
 	contact.ID = contactData.ID
 	contact.TeamID = contactData.Team
 	return nil

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -111,6 +111,7 @@ func TestCreateContact(t *testing.T) {
 	defer mockCtrl.Finish()
 	const userLogin = "user"
 	const teamID = "team"
+	auth := &api.Authorization{Enabled: false}
 
 	Convey("Create for user", t, func() {
 		Convey("Success", func() {
@@ -119,7 +120,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  "mail",
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -138,7 +139,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, &contact, userLogin, "")
+			err := CreateContact(dataBase, auth, &contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 			So(contact.ID, ShouldResemble, contact.ID)
@@ -151,7 +152,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  "mail",
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-			err := CreateContact(dataBase, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contact, userLogin, "")
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
 		})
 
@@ -163,7 +164,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-			expected := CreateContact(dataBase, contact, userLogin, "")
+			expected := CreateContact(dataBase, auth, contact, userLogin, "")
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
@@ -174,7 +175,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-			expected := CreateContact(dataBase, contact, userLogin, "")
+			expected := CreateContact(dataBase, auth, contact, userLogin, "")
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
 				HTTPStatusCode: http.StatusInternalServerError,
@@ -191,7 +192,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  "mail",
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, contact, "", teamID)
+			err := CreateContact(dataBase, auth, contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 		})
@@ -210,7 +211,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, &contact, "", teamID)
+			err := CreateContact(dataBase, auth, &contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 			So(contact.ID, ShouldResemble, contact.ID)
@@ -223,7 +224,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  "mail",
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-			err := CreateContact(dataBase, contact, "", teamID)
+			err := CreateContact(dataBase, auth, contact, "", teamID)
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
 		})
 
@@ -235,7 +236,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-			expected := CreateContact(dataBase, contact, "", teamID)
+			expected := CreateContact(dataBase, auth, contact, "", teamID)
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
@@ -246,7 +247,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-			expected := CreateContact(dataBase, contact, "", teamID)
+			expected := CreateContact(dataBase, auth, contact, "", teamID)
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
 				HTTPStatusCode: http.StatusInternalServerError,
@@ -260,7 +261,7 @@ func TestCreateContact(t *testing.T) {
 			Value: "some@mail.com",
 			Type:  "mail",
 		}
-		err := CreateContact(dataBase, contact, userLogin, teamID)
+		err := CreateContact(dataBase, auth, contact, userLogin, teamID)
 		So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("CreateContact: cannot create contact when both userLogin and teamID specified")))
 	})
 }

--- a/api/controller/subscription.go
+++ b/api/controller/subscription.go
@@ -56,7 +56,7 @@ func CreateSubscription(dataBase moira.Database, auth *api.Authorization, userLo
 		}
 	}
 
-	// Only admins are allowed to create subscriptions for other users 
+	// Only admins are allowed to create subscriptions for other users
 	if !auth.IsAdmin(userLogin) || subscription.User == "" {
 		subscription.User = userLogin
 	}

--- a/api/controller/subscription_test.go
+++ b/api/controller/subscription_test.go
@@ -176,12 +176,13 @@ func TestCreateSubscription(t *testing.T) {
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	const login = "user"
 	const teamID = "testTeam"
+	auth := &api.Authorization{Enabled: false}
 
 	Convey("Create for user", t, func() {
 		Convey("Success create", func() {
 			subscription := dto.Subscription{ID: ""}
 			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
-			err := CreateSubscription(dataBase, login, "", &subscription)
+			err := CreateSubscription(dataBase, auth, login, "", &subscription)
 			So(err, ShouldBeNil)
 		})
 
@@ -191,7 +192,7 @@ func TestCreateSubscription(t *testing.T) {
 			}
 			dataBase.EXPECT().GetSubscription(sub.ID).Return(moira.SubscriptionData{}, database.ErrNil)
 			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
-			err := CreateSubscription(dataBase, login, "", sub)
+			err := CreateSubscription(dataBase, auth, login, "", sub)
 			So(err, ShouldBeNil)
 			So(sub.User, ShouldResemble, login)
 			So(sub.ID, ShouldResemble, sub.ID)
@@ -202,7 +203,7 @@ func TestCreateSubscription(t *testing.T) {
 				ID: uuid.Must(uuid.NewV4()).String(),
 			}
 			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, nil)
-			err := CreateSubscription(dataBase, login, "", subscription)
+			err := CreateSubscription(dataBase, auth, login, "", subscription)
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("subscription with this ID already exists")))
 		})
 
@@ -212,7 +213,7 @@ func TestCreateSubscription(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, err)
-			expected := CreateSubscription(dataBase, login, "", subscription)
+			expected := CreateSubscription(dataBase, auth, login, "", subscription)
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
@@ -220,7 +221,7 @@ func TestCreateSubscription(t *testing.T) {
 			subscription := dto.Subscription{ID: ""}
 			expected := fmt.Errorf("oooops! Can not create subscription")
 			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(expected)
-			err := CreateSubscription(dataBase, login, "", &subscription)
+			err := CreateSubscription(dataBase, auth, login, "", &subscription)
 			So(err, ShouldResemble, api.ErrorInternalServer(expected))
 		})
 	})
@@ -228,7 +229,7 @@ func TestCreateSubscription(t *testing.T) {
 		Convey("Success create", func() {
 			subscription := dto.Subscription{ID: ""}
 			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
-			err := CreateSubscription(dataBase, "", teamID, &subscription)
+			err := CreateSubscription(dataBase, auth, "", teamID, &subscription)
 			So(err, ShouldBeNil)
 		})
 
@@ -238,7 +239,7 @@ func TestCreateSubscription(t *testing.T) {
 			}
 			dataBase.EXPECT().GetSubscription(sub.ID).Return(moira.SubscriptionData{}, database.ErrNil)
 			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
-			err := CreateSubscription(dataBase, "", teamID, sub)
+			err := CreateSubscription(dataBase, auth, "", teamID, sub)
 			So(err, ShouldBeNil)
 			So(sub.TeamID, ShouldResemble, teamID)
 			So(sub.ID, ShouldResemble, sub.ID)
@@ -249,7 +250,7 @@ func TestCreateSubscription(t *testing.T) {
 				ID: uuid.Must(uuid.NewV4()).String(),
 			}
 			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, nil)
-			err := CreateSubscription(dataBase, "", teamID, subscription)
+			err := CreateSubscription(dataBase, auth, "", teamID, subscription)
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("subscription with this ID already exists")))
 		})
 
@@ -259,7 +260,7 @@ func TestCreateSubscription(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetSubscription(subscription.ID).Return(moira.SubscriptionData{}, err)
-			expected := CreateSubscription(dataBase, "", teamID, subscription)
+			expected := CreateSubscription(dataBase, auth, "", teamID, subscription)
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
@@ -267,13 +268,13 @@ func TestCreateSubscription(t *testing.T) {
 			subscription := dto.Subscription{ID: ""}
 			expected := fmt.Errorf("oooops! Can not create subscription")
 			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(expected)
-			err := CreateSubscription(dataBase, "", teamID, &subscription)
+			err := CreateSubscription(dataBase, auth, "", teamID, &subscription)
 			So(err, ShouldResemble, api.ErrorInternalServer(expected))
 		})
 	})
 	Convey("Error on create with both: userLogin and teamID specified", t, func() {
 		subscription := &dto.Subscription{}
-		err := CreateSubscription(dataBase, login, teamID, subscription)
+		err := CreateSubscription(dataBase, auth, login, teamID, subscription)
 		So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("CreateSubscription: cannot create subscription when both userLogin and teamID specified")))
 	})
 }

--- a/api/controller/subscription_test.go
+++ b/api/controller/subscription_test.go
@@ -279,6 +279,60 @@ func TestCreateSubscription(t *testing.T) {
 	})
 }
 
+func TestAdminsCreatesSubscription(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
+	const userLogin = "user"
+	const adminLogin = "admin"
+	auth := &api.Authorization{
+		Enabled:   true,
+		AdminList: map[string]struct{}{adminLogin: {}},
+	}
+
+	Convey("Create for user", t, func() {
+		Convey("For same user", func() {
+			subscription := dto.Subscription{
+				User: userLogin,
+			}
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, auth, userLogin, "", &subscription)
+			So(err, ShouldBeNil)
+			So(subscription.User, ShouldEqual, userLogin)
+		})
+
+		Convey("For same admin", func() {
+			subscription := dto.Subscription{
+				User: adminLogin,
+			}
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, auth, adminLogin, "", &subscription)
+			So(err, ShouldBeNil)
+			So(subscription.User, ShouldEqual, adminLogin)
+		})
+
+		Convey("User can not create subscription for other user", func() {
+			subscription := dto.Subscription{
+				User: adminLogin,
+			}
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, auth, userLogin, "", &subscription)
+			So(err, ShouldBeNil)
+			So(subscription.User, ShouldEqual, userLogin)
+		})
+
+		Convey("Admin can create subscription for other user", func() {
+			subscription := dto.Subscription{
+				User: userLogin,
+			}
+			dataBase.EXPECT().SaveSubscription(gomock.Any()).Return(nil)
+			err := CreateSubscription(dataBase, auth, adminLogin, "", &subscription)
+			So(err, ShouldBeNil)
+			So(subscription.User, ShouldEqual, userLogin)
+		})
+	})
+}
+
 func TestCheckUserPermissionsForSubscription(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/api/dto/subscription.go
+++ b/api/dto/subscription.go
@@ -70,9 +70,17 @@ func (subscription *Subscription) checkContacts(request *http.Request) error {
 	database := middleware.GetDatabase(request)
 	userLogin := middleware.GetLogin(request)
 	teamID := middleware.GetTeamID(request)
+	auth := middleware.GetAuth(request)
+
 	if teamID == "" && subscription.TeamID != "" {
 		teamID = subscription.TeamID
 	}
+
+	// Only admins are allowed to create subscriptions for other users
+	if auth.IsAdmin(userLogin) && subscription.User != "" {
+		userLogin = subscription.User
+	}
+
 	if subscription.User != "" && teamID != "" {
 		return ErrSubscriptionContainsTeamAndUser{}
 	}

--- a/api/dto/subscription_test.go
+++ b/api/dto/subscription_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/moira-alert/moira"
+	"github.com/moira-alert/moira/api"
 	"github.com/moira-alert/moira/api/middleware"
 	mock "github.com/moira-alert/moira/mock/moira-alert"
 	. "github.com/smartystreets/goconvey/convey"
@@ -21,6 +22,8 @@ func TestSubscription_checkContacts(t *testing.T) {
 		defer mockCtrl.Finish()
 		dataBase := mock.NewMockDatabase(mockCtrl)
 
+		auth := &api.Authorization{Enabled: false}
+
 		subscription := Subscription{}
 		const userID = "userID"
 		const teamID = "teamID"
@@ -30,6 +33,7 @@ func TestSubscription_checkContacts(t *testing.T) {
 
 		Convey("For user", func() {
 			request := httptest.NewRequest(http.MethodPost, "/api/subscriptions", strings.NewReader(""))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "auth", auth))
 			middleware.DatabaseContext(dataBase)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				request = req
 			})).ServeHTTP(responseWriter, request)
@@ -56,6 +60,7 @@ func TestSubscription_checkContacts(t *testing.T) {
 
 		Convey("For team", func() {
 			request := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/teams/%s/subscriptions", teamID), strings.NewReader(""))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "auth", auth))
 			middleware.DatabaseContext(dataBase)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				request = req
 			})).ServeHTTP(responseWriter, request)
@@ -82,6 +87,7 @@ func TestSubscription_checkContacts(t *testing.T) {
 
 		Convey("Error bot teamID and userID specified in JSON", func() {
 			request := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/teams/%s/subscriptions", teamID), strings.NewReader(""))
+			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "auth", auth))
 			middleware.DatabaseContext(dataBase)(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				request = req
 			})).ServeHTTP(responseWriter, request)

--- a/api/handler/contact.go
+++ b/api/handler/contact.go
@@ -99,8 +99,9 @@ func createNewContact(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	userLogin := middleware.GetLogin(request)
+	auth := middleware.GetAuth(request)
 
-	if err := controller.CreateContact(database, contact, userLogin, contact.TeamID); err != nil {
+	if err := controller.CreateContact(database, auth, contact, userLogin, contact.TeamID); err != nil {
 		render.Render(writer, request, err) //nolint
 		return
 	}

--- a/api/handler/contact_test.go
+++ b/api/handler/contact_test.go
@@ -195,6 +195,8 @@ func TestCreateNewContact(t *testing.T) {
 		login := defaultLogin
 		testErr := errors.New("test error")
 
+		auth := &api.Authorization{Enabled: false}
+
 		newContactDto := &dto.Contact{
 			ID:     defaultContact,
 			Type:   "mail",
@@ -219,6 +221,7 @@ func TestCreateNewContact(t *testing.T) {
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -250,6 +253,7 @@ func TestCreateNewContact(t *testing.T) {
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -289,6 +293,7 @@ func TestCreateNewContact(t *testing.T) {
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -319,6 +324,7 @@ func TestCreateNewContact(t *testing.T) {
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -351,6 +357,7 @@ func TestCreateNewContact(t *testing.T) {
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)

--- a/api/handler/subscription.go
+++ b/api/handler/subscription.go
@@ -71,6 +71,7 @@ func createSubscription(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	userLogin := middleware.GetLogin(request)
+	auth := middleware.GetAuth(request)
 
 	if subscription.AnyTags && len(subscription.Tags) > 0 {
 		writer.WriteHeader(http.StatusBadRequest)
@@ -78,7 +79,7 @@ func createSubscription(writer http.ResponseWriter, request *http.Request) {
 			errors.New("if any_tags is true, then the tags must be empty")))
 		return
 	}
-	if err := controller.CreateSubscription(database, userLogin, "", subscription); err != nil {
+	if err := controller.CreateSubscription(database, auth, userLogin, "", subscription); err != nil {
 		render.Render(writer, request, err) //nolint
 		return
 	}

--- a/api/handler/team_contact.go
+++ b/api/handler/team_contact.go
@@ -38,8 +38,9 @@ func createNewTeamContact(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	teamID := middleware.GetTeamID(request)
+	auth := middleware.GetAuth(request)
 
-	if err := controller.CreateContact(database, contact, "", teamID); err != nil {
+	if err := controller.CreateContact(database, auth, contact, "", teamID); err != nil {
 		render.Render(writer, request, err) //nolint:errcheck
 		return
 	}

--- a/api/handler/team_subscription.go
+++ b/api/handler/team_subscription.go
@@ -39,6 +39,7 @@ func createTeamSubscription(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	teamID := middleware.GetTeamID(request)
+	auth := middleware.GetAuth(request)
 
 	if subscription.AnyTags && len(subscription.Tags) > 0 {
 		writer.WriteHeader(http.StatusBadRequest)
@@ -46,7 +47,7 @@ func createTeamSubscription(writer http.ResponseWriter, request *http.Request) {
 			errors.New("if any_tags is true, then the tags must be empty")))
 		return
 	}
-	if err := controller.CreateSubscription(database, "", teamID, subscription); err != nil {
+	if err := controller.CreateSubscription(database, auth, "", teamID, subscription); err != nil {
 		render.Render(writer, request, err) //nolint:errcheck
 		return
 	}


### PR DESCRIPTION
Now admins can create contacts and subscriptions for other users and teams

If some non-admin user `A` tries to create subscription for other user `B` it is created for `A` instead for backwards compatibility