### PR TITLE
perf(checker): add fetching metrics values in pipe

### DIFF
--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -50,25 +50,47 @@ func (connector *DbConnector) GetPatterns() ([]string, error) {
 // GetMetricsValues gets metrics values for given interval.
 func (connector *DbConnector) GetMetricsValues(metrics []string, from int64, until int64) (map[string][]*moira.MetricValue, error) {
 	c := *connector.client
-	resultByMetrics := make([]*redis.ZSliceCmd, 0, len(metrics))
+	ctx := connector.context
+
+	pipe := c.TxPipeline()
 
 	for _, metric := range metrics {
-		rng := &redis.ZRangeBy{Min: strconv.FormatInt(from, 10), Max: strconv.FormatInt(until, 10)}
-		result := c.ZRangeByScoreWithScores(connector.context, metricDataKey(metric), rng)
-		resultByMetrics = append(resultByMetrics, result)
+		rng := &redis.ZRangeBy{
+			Min: strconv.FormatInt(from, 10),
+			Max: strconv.FormatInt(until, 10),
+		}
+		pipe.ZRangeByScoreWithScores(connector.context, metricDataKey(metric), rng)
 	}
 
-	res := make(map[string][]*moira.MetricValue, len(resultByMetrics))
+	cmds, err := pipe.Exec(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Exec in get metrics values: %w", err)
+	}
+
+	resultByMetrics := make([]*redis.ZSliceCmd, 0, len(metrics))
+
+	for _, cmd := range cmds {
+		res, ok := cmd.(*redis.ZSliceCmd)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert cmd response to *ZSliceCmd in get metrics values")
+		}
+
+		resultByMetrics = append(resultByMetrics, res)
+	}
+
+	result := make(map[string][]*moira.MetricValue, len(resultByMetrics))
 
 	for i, resultByMetric := range resultByMetrics {
 		metric := metrics[i]
 		metricsValues, err := reply.MetricValues(resultByMetric)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to convert ZSliceCmd to metric values in get metrics values: %w", err)
 		}
-		res[metric] = metricsValues
+
+		result[metric] = metricsValues
 	}
-	return res, nil
+
+	return result, nil
 }
 
 // GetMetricRetention gets given metric retention, if retention is empty then return default retention value(60).

--- a/database/redis/metric.go
+++ b/database/redis/metric.go
@@ -47,29 +47,6 @@ func (connector *DbConnector) GetPatterns() ([]string, error) {
 	return patterns, nil
 }
 
-func (connector *DbConnector) OldGetMetricsValues(metrics []string, from int64, until int64) (map[string][]*moira.MetricValue, error) {
-	c := *connector.client
-	resultByMetrics := make([]*redis.ZSliceCmd, 0, len(metrics))
-
-	for _, metric := range metrics {
-		rng := &redis.ZRangeBy{Min: strconv.FormatInt(from, 10), Max: strconv.FormatInt(until, 10)}
-		result := c.ZRangeByScoreWithScores(connector.context, metricDataKey(metric), rng)
-		resultByMetrics = append(resultByMetrics, result)
-	}
-
-	res := make(map[string][]*moira.MetricValue, len(resultByMetrics))
-
-	for i, resultByMetric := range resultByMetrics {
-		metric := metrics[i]
-		metricsValues, err := reply.MetricValues(resultByMetric)
-		if err != nil {
-			return nil, err
-		}
-		res[metric] = metricsValues
-	}
-	return res, nil
-}
-
 // GetMetricsValues gets metrics values for given interval.
 func (connector *DbConnector) GetMetricsValues(metrics []string, from int64, until int64) (map[string][]*moira.MetricValue, error) {
 	c := *connector.client

--- a/database/redis/metric_test.go
+++ b/database/redis/metric_test.go
@@ -72,7 +72,7 @@ func randStringBytesMaskImpr(n, letterIdxBits, letterIdxMax int, letterIdxMask i
 	return string(b)
 }
 
-func BenchmarkGetMetricValues(b *testing.B) {
+func BenchmarkGetMetricsValues(b *testing.B) {
 	const (
 		metricNameLen = 20
 		metricPattern = "random-pattern"

--- a/database/redis/metric_test.go
+++ b/database/redis/metric_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -21,6 +22,111 @@ const (
 	toInf   = "+inf"
 	fromInf = "-inf"
 )
+
+func saveMetricsWithRandomValues(
+	connector *DbConnector,
+	metricNames []string,
+	metricPattern string,
+	pointNum int,
+) error {
+	for i := 0; i < pointNum; i++ {
+		matchedMetrics := make(map[string]*moira.MatchedMetric, len(metricNames))
+
+		for _, metricName := range metricNames {
+			matchedMetric := &moira.MatchedMetric{
+				Metric:             metricName,
+				Patterns:           []string{metricPattern},
+				Value:              rand.Float64(),
+				Timestamp:          int64(i),
+				RetentionTimestamp: int64(i),
+				Retention:          rand.Int(),
+			}
+
+			matchedMetrics[metricName] = matchedMetric
+		}
+
+		if err := connector.SaveMetrics(matchedMetrics); err != nil {
+			return fmt.Errorf("failed to save matched metrics: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// randStringBytesMaskImpr function, which is needed for fast generation of random strings.
+func randStringBytesMaskImpr(n, letterIdxBits, letterIdxMax int, letterIdxMask int64, letterBytes []byte) string {
+	b := make([]byte, n)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}
+
+func BenchmarkGetMetricValues(b *testing.B) {
+	const (
+		metricNameLen = 20
+		metricPattern = "random-pattern"
+		letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		letterIdxBits = 6                    // 6 bits to represent a letter index
+		letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+		letterIdxMax  = 63 / letterIdxBits   // number of letter indices fitting in 63 bits
+		pointsNum     = 10
+	)
+
+	testcases := map[string]struct {
+		pointsNum  int
+		metricsNum int
+	}{
+		"100-metrics": {
+			pointsNum:  pointsNum,
+			metricsNum: 100,
+		},
+		"1000-metrics": {
+			pointsNum:  pointsNum,
+			metricsNum: 1000,
+		},
+		"1500-metrics": {
+			pointsNum:  pointsNum,
+			metricsNum: 1500,
+		},
+	}
+
+	logger, _ := logging.GetLogger("database")
+	database := NewTestDatabase(logger)
+	database.Flush()
+
+	for testname, testcase := range testcases {
+		b.Run(testname, func(b *testing.B) {
+			randomMetrics := make([]string, 0, testcase.metricsNum)
+			for i := 0; i < testcase.metricsNum; i++ {
+				randomMetrics = append(randomMetrics, randStringBytesMaskImpr(metricNameLen, letterIdxBits, letterIdxMax, letterIdxMask, []byte(letterBytes)))
+			}
+
+			database.Flush()
+			if err := saveMetricsWithRandomValues(database, randomMetrics, metricPattern, testcase.pointsNum); err != nil {
+				b.Fatalf("failed to save metrics with random values: %s", err.Error())
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := database.GetMetricsValues(randomMetrics, 0, int64(testcase.pointsNum)); err != nil {
+					b.Fatalf("failed to get metrics values: %s", err.Error())
+				}
+			}
+		})
+	}
+}
 
 func TestMetricsStoring(t *testing.T) {
 	logger, _ := logging.GetLogger("dataBase")

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -39,7 +39,7 @@ prometheus_remote:
 checker:
   nodata_check_interval: 60s
   check_interval: 10s
-  stop_checking_interval: 3000s
+  stop_checking_interval: 30s
   lazy_triggers_check_interval: 60s
 log:
   log_file: stdout

--- a/local/checker.yml
+++ b/local/checker.yml
@@ -39,7 +39,7 @@ prometheus_remote:
 checker:
   nodata_check_interval: 60s
   check_interval: 10s
-  stop_checking_interval: 30s
+  stop_checking_interval: 3000s
   lazy_triggers_check_interval: 60s
 log:
   log_file: stdout


### PR DESCRIPTION
# Add fetching metrics values in pipe

Added fetching metrics to the redis pipeline

In addition, conducted benchmarks testing the performance of the solution on N number of unique metrics with 10 points each, the solution with pipeline greatly reduced the time to get values by metrics, but required more allocations

`old` - old solution without pipeline
`new` - new solution with pipeline

```
benchmark                                     old ns/op      new ns/op     delta
BenchmarkGetMetricValues/100-metrics-12       67507442       3536363       -94.76%
BenchmarkGetMetricValues/1000-metrics-12      512515118      26622719      -94.81%
BenchmarkGetMetricValues/5000-metrics-12      2600663168     94167600      -96.38%
BenchmarkGetMetricValues/10000-metrics-12     4881419523     179366564     -96.33%

benchmark                                     old allocs     new allocs     delta
BenchmarkGetMetricValues/100-metrics-12       5212           5126           -1.65%
BenchmarkGetMetricValues/1000-metrics-12      21133          51036          +141.50%
BenchmarkGetMetricValues/5000-metrics-12      158636         155034         -2.27%
BenchmarkGetMetricValues/10000-metrics-12     104532         147356         +40.97%

benchmark                                     old bytes     new bytes     delta
BenchmarkGetMetricValues/100-metrics-12       184949        182788        -1.17%
BenchmarkGetMetricValues/1000-metrics-12      833624        1845147       +121.34%
BenchmarkGetMetricValues/5000-metrics-12      5856144       5865810       +0.17%
BenchmarkGetMetricValues/10000-metrics-12     4961472       6296489       +26.91%
```