### PR TITLE
fix: remove benchmarks from ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Run tests
-        run: make test
+        run: make ci-test
+
       - name: Upload coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ validate-spec:
 test:
 	echo 'mode: atomic' > coverage.txt && go list ./... | xargs -n1 -I{} sh -c 'go test -race -v -bench=. -covermode=atomic -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt' && rm coverage.tmp
 
+.PHONY: ci-test
+ci-test:
+	echo 'mode: atomic' > coverage.txt && go list ./... | xargs -n1 -I{} sh -c 'go test -race -v -covermode=atomic -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt' && rm coverage.tmp
+
 .PHONY: build
 build:
 	for service in "filter" $(SERVICES) ; do \


### PR DESCRIPTION
# Remove benchmarks from ci

The speed of passing the tests increased by about 3 min