### PR TITLE
feat(filter): improve perfomance or restoreMetricStringByNameAndLabels

### DIFF
--- a/filter/metrics_parser.go
+++ b/filter/metrics_parser.go
@@ -89,7 +89,7 @@ func restoreMetricStringByNameAndLabels(name string, labels map[string]string) s
 	builder.WriteString(name)
 
 	for _, key := range keys {
-		builder.WriteString(fmt.Sprintf(";%s=%s", key, labels[key]))
+		builder.WriteString(";" + key + "=" + labels[key])
 	}
 
 	return builder.String()


### PR DESCRIPTION
# Improve perfomance of `restoreMetricStringByNameAndLabels`

`restoreMetricStringByNameAndLabels` is called when parsing metrics, accordingly with a large volume of metrics the number of allocations and perfomance start to be greatly affected

```go
func BenchmarkWriteStringFmt(b *testing.B) {
  var testStr string
  for i := 0; i < b.N; i++ {
    testStr = fmt.Sprintf(";%s=%s", abcde, abcdeabcde)
  }
  _ = testStr
}

func BenchmarkWriteStringPlus(b *testing.B) {
  var testStr string
  for i := 0; i < b.N; i++ {
    testStr = ";" + abcde + "=" + abcdeabcde
  }
  _ = testStr
}

func BenchmarkWriteStringBuilder(b *testing.B) {
  var testStr string
  for i := 0; i < b.N; i++ {
    builder := strings.Builder{}
    builder.WriteString(";")
    builder.WriteString(abcde)
    builder.WriteString("=")
    builder.WriteString(abcdeabcde)
    testStr = builder.String()
  }
  _ = testStr
}
```

And the result:
```
BenchmarkWriteStringFmt
BenchmarkWriteStringFmt-12               6402115               182.8 ns/op            56 B/op          3 allocs/op
BenchmarkWriteStringPlus
BenchmarkWriteStringPlus-12             22961696                49.74 ns/op           24 B/op          1 allocs/op
BenchmarkWriteStringBuilder
BenchmarkWriteStringBuilder-12          17070512                66.30 ns/op           32 B/op          2 allocs/op
```
