### PR TITLE
chore: increase local stop checking interval

### DIFF
--- a/local/checker.yml
+++ b/local/checker.yml
@@ -39,7 +39,7 @@ prometheus_remote:
 checker:
   nodata_check_interval: 60s
   check_interval: 10s
-  stop_checking_interval: 30s
+  stop_checking_interval: 3600s
   lazy_triggers_check_interval: 60s
 log:
   log_file: stdout


### PR DESCRIPTION
# Increase local stop checking interval

Increased `stop_checking_interval` in the checker config so that users don't encounter the problem of quickly stopping checking local triggers
