### PR TITLE
refactor(api): add some default vals to TriggerModel

### DIFF
--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -22,10 +22,6 @@ var targetNameRegex = regexp.MustCompile("t(\\d+)")
 // TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved.
 var asteriskPattern = "*"
 
-const (
-	DefaultTTL = 600
-)
-
 type TriggersList struct {
 	Page  *int64               `json:"page,omitempty" format:"int64" extensions:"x-nullable"`
 	Size  *int64               `json:"size,omitempty" format:"int64" extensions:"x-nullable"`
@@ -207,7 +203,7 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 	}
 
 	if trigger.TTL == 0 {
-		trigger.TTL = DefaultTTL
+		trigger.TTL = moira.DefaultTTL
 	}
 	if err := checkTTLSanity(trigger, metricsSource); err != nil {
 		return api.ErrInvalidRequestContent{ValidationError: err}
@@ -226,7 +222,7 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 	}
 
 	if trigger.Schedule == nil {
-		trigger.Schedule = getDefaultScheduleData()
+		trigger.Schedule = moira.GetDefaultScheduleData()
 	}
 
 	middleware.SetTimeSeriesNames(request, metricsDataNames)
@@ -298,23 +294,6 @@ func resolvePatterns(trigger *Trigger, expressionValues *expression.TriggerExpre
 		targetNum++
 	}
 	return metricsDataNames, nil
-}
-
-func getDefaultScheduleData() *moira.ScheduleData {
-	return &moira.ScheduleData{
-		Days: []moira.ScheduleDataDay{
-			{Name: "Mon", Enabled: true},
-			{Name: "Tue", Enabled: true},
-			{Name: "Wed", Enabled: true},
-			{Name: "Thu", Enabled: true},
-			{Name: "Fri", Enabled: true},
-			{Name: "Sat", Enabled: true},
-			{Name: "Sun", Enabled: true},
-		},
-		TimezoneOffset: 0,
-		StartOffset:    0,
-		EndOffset:      0,
-	}
 }
 
 func checkWarnErrorExpression(trigger *Trigger) error {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -226,7 +226,7 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 	}
 
 	if trigger.Schedule == nil {
-		trigger.Schedule = moira.GetDefaultScheduleData()
+		trigger.Schedule = moira.NewDefaultScheduleData()
 	}
 
 	middleware.SetTimeSeriesNames(request, metricsDataNames)

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -94,8 +94,8 @@ type TriggerModel struct {
 }
 
 // ClusterKey returns cluster key composed of trigger source and cluster id associated with the trigger.
-func (trigger *TriggerModel) ClusterKey() moira.ClusterKey {
-	return moira.MakeClusterKey(trigger.TriggerSource, trigger.ClusterId)
+func (model *TriggerModel) ClusterKey() moira.ClusterKey {
+	return moira.MakeClusterKey(model.TriggerSource, model.ClusterId)
 }
 
 // ToMoiraTrigger transforms TriggerModel to moira.Trigger.

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -184,6 +184,10 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 		}
 	}
 
+	if trigger.TTLState == nil {
+		trigger.TTLState = &moira.TTLStateNODATA
+	}
+
 	triggerExpression := expression.TriggerExpression{
 		AdditionalTargetsValues: make(map[string]float64),
 		WarnValue:               trigger.WarnValue,

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -46,6 +46,7 @@ func TestTriggerValidation(t *testing.T) {
 			Tags:           tags,
 			TTLState:       &moira.TTLStateNODATA,
 			TTL:            600,
+			Schedule:       getDefaultScheduleData(),
 			TriggerSource:  moira.GraphiteLocal,
 			ClusterId:      moira.DefaultCluster,
 			MuteNewMetrics: false,

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -46,7 +46,7 @@ func TestTriggerValidation(t *testing.T) {
 			Tags:           tags,
 			TTLState:       &moira.TTLStateNODATA,
 			TTL:            600,
-			Schedule:       getDefaultScheduleData(),
+			Schedule:       moira.GetDefaultScheduleData(),
 			TriggerSource:  moira.GraphiteLocal,
 			ClusterId:      moira.DefaultCluster,
 			MuteNewMetrics: false,

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -46,7 +46,7 @@ func TestTriggerValidation(t *testing.T) {
 			Tags:           tags,
 			TTLState:       &moira.TTLStateNODATA,
 			TTL:            600,
-			Schedule:       moira.GetDefaultScheduleData(),
+			Schedule:       moira.NewDefaultScheduleData(),
 			TriggerSource:  moira.GraphiteLocal,
 			ClusterId:      moira.DefaultCluster,
 			MuteNewMetrics: false,

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -97,7 +97,10 @@ func TestGetTriggerFromRequest(t *testing.T) {
 		request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
 
 		Convey("It should be parsed successfully", func() {
+			triggerDTO.TTL = dto.DefaultTTL
+
 			trigger, err := getTriggerFromRequest(request)
+
 			So(err, ShouldBeNil)
 			So(trigger, ShouldResemble, &triggerDTO)
 		})

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -97,7 +97,7 @@ func TestGetTriggerFromRequest(t *testing.T) {
 		request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
 
 		Convey("It should be parsed successfully", func() {
-			triggerDTO.TTL = dto.DefaultTTL
+			triggerDTO.TTL = moira.DefaultTTL
 
 			trigger, err := getTriggerFromRequest(request)
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -247,6 +247,7 @@ type ScheduleDataDay struct {
 	Name    string `json:"name,omitempty" example:"Mon"`
 }
 
+// GetDefaultScheduleData returns the default ScheduleData which can be used in Trigger
 func GetDefaultScheduleData() *ScheduleData {
 	return &ScheduleData{
 		Days: []ScheduleDataDay{
@@ -373,6 +374,7 @@ type Trigger struct {
 }
 
 const (
+	// DefaultTTL is a default value for Trigger.TTL.
 	DefaultTTL = 600
 )
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -247,6 +247,23 @@ type ScheduleDataDay struct {
 	Name    string `json:"name,omitempty" example:"Mon"`
 }
 
+func GetDefaultScheduleData() *ScheduleData {
+	return &ScheduleData{
+		Days: []ScheduleDataDay{
+			{Name: "Mon", Enabled: true},
+			{Name: "Tue", Enabled: true},
+			{Name: "Wed", Enabled: true},
+			{Name: "Thu", Enabled: true},
+			{Name: "Fri", Enabled: true},
+			{Name: "Sat", Enabled: true},
+			{Name: "Sun", Enabled: true},
+		},
+		TimezoneOffset: 0,
+		StartOffset:    0,
+		EndOffset:      0,
+	}
+}
+
 // ScheduledNotification represent notification object.
 type ScheduledNotification struct {
 	Event     NotificationEvent `json:"event"`
@@ -354,6 +371,10 @@ type Trigger struct {
 	CreatedBy        string          `json:"created_by"`
 	UpdatedBy        string          `json:"updated_by"`
 }
+
+const (
+	DefaultTTL = 600
+)
 
 // ClusterKey returns cluster key composed of trigger source and cluster id associated with the trigger.
 func (trigger *Trigger) ClusterKey() ClusterKey {

--- a/datatypes.go
+++ b/datatypes.go
@@ -247,7 +247,7 @@ type ScheduleDataDay struct {
 	Name    string `json:"name,omitempty" example:"Mon"`
 }
 
-// GetDefaultScheduleData returns the default ScheduleData which can be used in Trigger
+// GetDefaultScheduleData returns the default ScheduleData which can be used in Trigger.
 func GetDefaultScheduleData() *ScheduleData {
 	return &ScheduleData{
 		Days: []ScheduleDataDay{

--- a/datatypes.go
+++ b/datatypes.go
@@ -247,6 +247,15 @@ type ScheduleDataDay struct {
 	Name    string `json:"name,omitempty" example:"Mon"`
 }
 
+const (
+	// DefaultTimezoneOffset is a default value for timezone offset for (GMT+3) used in GetDefaultScheduleData.
+	DefaultTimezoneOffset = -180
+	// DefaultStartOffset is a default value for start offset for (GMT+3) used in GetDefaultScheduleData.
+	DefaultStartOffset = 0
+	// DefaultEndOffset is a default value for end offset for (GMT+3) used in GetDefaultScheduleData.
+	DefaultEndOffset = 1439
+)
+
 // GetDefaultScheduleData returns the default ScheduleData which can be used in Trigger.
 func GetDefaultScheduleData() *ScheduleData {
 	return &ScheduleData{
@@ -259,9 +268,9 @@ func GetDefaultScheduleData() *ScheduleData {
 			{Name: "Sat", Enabled: true},
 			{Name: "Sun", Enabled: true},
 		},
-		TimezoneOffset: 0,
-		StartOffset:    0,
-		EndOffset:      0,
+		TimezoneOffset: DefaultTimezoneOffset,
+		StartOffset:    DefaultStartOffset,
+		EndOffset:      DefaultEndOffset,
 	}
 }
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -248,16 +248,16 @@ type ScheduleDataDay struct {
 }
 
 const (
-	// DefaultTimezoneOffset is a default value for timezone offset for (GMT+3) used in GetDefaultScheduleData.
+	// DefaultTimezoneOffset is a default value for timezone offset for (GMT+3) used in NewDefaultScheduleData.
 	DefaultTimezoneOffset = -180
-	// DefaultStartOffset is a default value for start offset for (GMT+3) used in GetDefaultScheduleData.
+	// DefaultStartOffset is a default value for start offset for (GMT+3) used in NewDefaultScheduleData.
 	DefaultStartOffset = 0
-	// DefaultEndOffset is a default value for end offset for (GMT+3) used in GetDefaultScheduleData.
+	// DefaultEndOffset is a default value for end offset for (GMT+3) used in NewDefaultScheduleData.
 	DefaultEndOffset = 1439
 )
 
-// GetDefaultScheduleData returns the default ScheduleData which can be used in Trigger.
-func GetDefaultScheduleData() *ScheduleData {
+// NewDefaultScheduleData returns the default ScheduleData which can be used in Trigger.
+func NewDefaultScheduleData() *ScheduleData {
 	return &ScheduleData{
 		Days: []ScheduleDataDay{
 			{Name: "Mon", Enabled: true},


### PR DESCRIPTION
# Add default values to TTL and Schedule in TriggerModel

Lack of default values ​​may lead to incorrect behavior.
