### PR TITLE
refactor(api): validating of target name in alone metrics

### DIFF
--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -17,7 +17,7 @@ import (
 	metricSource "github.com/moira-alert/moira/metric_source"
 )
 
-var targetNameRegex = regexp.MustCompile("t(\\d+)")
+var targetNameRegex = regexp.MustCompile("^t\\d+$")
 
 // TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved.
 var asteriskPattern = "*"
@@ -170,10 +170,10 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 
 	for targetName := range trigger.AloneMetrics {
 		if !targetNameRegex.MatchString(targetName) {
-			return api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: t\\d+")}
+			return api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")}
 		}
 
-		targetIndexStr := targetNameRegex.FindStringSubmatch(targetName)[1]
+		targetIndexStr := targetName[1:]
 		targetIndex, err := strconv.Atoi(targetIndexStr)
 		if err != nil {
 			return api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target index should be valid number: %w", err)}

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -19,8 +19,8 @@ import (
 
 var targetNameRegex = regexp.MustCompile("^t\\d+$")
 
-// msgBadAloneMetricName is used for error constructing when any key in map TriggerModel.AloneMetric doesn't match targetNameRegex.
-var msgBadAloneMetricName = "alone metrics target name should be in pattern: ^t\\d+$"
+// ErrBadAloneMetricName is used when any key in map TriggerModel.AloneMetric doesn't match targetNameRegex.
+var ErrBadAloneMetricName = fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")
 
 // TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved.
 var asteriskPattern = "*"
@@ -173,7 +173,7 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 
 	for targetName := range trigger.AloneMetrics {
 		if !targetNameRegex.MatchString(targetName) {
-			return api.ErrInvalidRequestContent{ValidationError: fmt.Errorf(msgBadAloneMetricName)}
+			return api.ErrInvalidRequestContent{ValidationError: ErrBadAloneMetricName}
 		}
 
 		targetIndexStr := targetName[1:]

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -20,7 +20,7 @@ import (
 var targetNameRegex = regexp.MustCompile("^t\\d+$")
 
 // ErrBadAloneMetricName is used when any key in map TriggerModel.AloneMetric doesn't match targetNameRegex.
-var ErrBadAloneMetricName = fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")
+var ErrBadAloneMetricName = fmt.Errorf("alone metrics' target name must match the pattern: ^t\\d+$, for example: 't1'")
 
 // TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved.
 var asteriskPattern = "*"

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -19,6 +19,9 @@ import (
 
 var targetNameRegex = regexp.MustCompile("^t\\d+$")
 
+// msgBadAloneMetricName is used for error constructing when any key in map TriggerModel.AloneMetric doesn't match targetNameRegex.
+var msgBadAloneMetricName = "alone metrics target name should be in pattern: ^t\\d+$"
+
 // TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved.
 var asteriskPattern = "*"
 
@@ -170,7 +173,7 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 
 	for targetName := range trigger.AloneMetrics {
 		if !targetNameRegex.MatchString(targetName) {
-			return api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")}
+			return api.ErrInvalidRequestContent{ValidationError: fmt.Errorf(msgBadAloneMetricName)}
 		}
 
 		targetIndexStr := targetName[1:]

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -202,13 +202,13 @@ func TestTriggerValidation(t *testing.T) {
 				trigger.AloneMetrics = map[string]bool{"ttt": true}
 				tr := Trigger{trigger, throttling}
 				err := tr.Bind(request)
-				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")})
+				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf(msgBadAloneMetricName)})
 			})
-			Convey("have more then 1 metric name", func() {
+			Convey("have more than 1 metric name but only 1 need", func() {
 				trigger.AloneMetrics = map[string]bool{"t1 t2": true}
 				tr := Trigger{trigger, throttling}
 				err := tr.Bind(request)
-				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")})
+				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf(msgBadAloneMetricName)})
 			})
 			Convey("have target higher than total amount of targets", func() {
 				trigger.AloneMetrics = map[string]bool{"t3": true}

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -202,13 +202,13 @@ func TestTriggerValidation(t *testing.T) {
 				trigger.AloneMetrics = map[string]bool{"ttt": true}
 				tr := Trigger{trigger, throttling}
 				err := tr.Bind(request)
-				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf(msgBadAloneMetricName)})
+				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: ErrBadAloneMetricName})
 			})
 			Convey("have more than 1 metric name but only 1 need", func() {
 				trigger.AloneMetrics = map[string]bool{"t1 t2": true}
 				tr := Trigger{trigger, throttling}
 				err := tr.Bind(request)
-				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf(msgBadAloneMetricName)})
+				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: ErrBadAloneMetricName})
 			})
 			Convey("have target higher than total amount of targets", func() {
 				trigger.AloneMetrics = map[string]bool{"t3": true}

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -202,7 +202,13 @@ func TestTriggerValidation(t *testing.T) {
 				trigger.AloneMetrics = map[string]bool{"ttt": true}
 				tr := Trigger{trigger, throttling}
 				err := tr.Bind(request)
-				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: t\\d+")})
+				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")})
+			})
+			Convey("have more then 1 metric name", func() {
+				trigger.AloneMetrics = map[string]bool{"t1 t2": true}
+				tr := Trigger{trigger, throttling}
+				err := tr.Bind(request)
+				So(err, ShouldResemble, api.ErrInvalidRequestContent{ValidationError: fmt.Errorf("alone metrics target name should be in pattern: ^t\\d+$")})
 			})
 			Convey("have target higher than total amount of targets", func() {
 				trigger.AloneMetrics = map[string]bool{"t3": true}


### PR DESCRIPTION
# Change regular expession used for validating alone metrics names

Before this PR `"alone_metrics"` with format like `{"t1 t2": true}` was treated as valid (valid form is: `{"t1": true, "t2": true}`). After this PR it will be considered invalid.
