### PR TITLE
perf(filter): improved handling of non-strict asterisk tags

### DIFF
--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -182,14 +182,7 @@ func createMatchingHandlerForOneTag(
 		matchingHandlerCondition = func(value string) bool {
 			return value != spec.Value
 		}
-	case MatchOperator:
-		allowMatchEmpty = compatibility.AllowRegexMatchEmpty
-
-		matchingHandlerCondition, err = handleRegexMatch(spec, compatibility)
-		if err != nil {
-			return nil, err
-		}
-	case NotMatchOperator:
+	case MatchOperator, NotMatchOperator:
 		allowMatchEmpty = compatibility.AllowRegexMatchEmpty
 
 		matchingHandlerCondition, err = handleRegexMatch(spec, compatibility)

--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -235,13 +235,10 @@ func handleRegexMatch(
 	}
 
 	return func(value string) bool {
-		match := matchRegex.MatchString(value)
+		matchRes := matchRegex.MatchString(value)
 
-		if isMatchOperator {
-			return match
-		}
-
-		return !match
+		// Invert the result depending on the match operator.
+		return isMatchOperator == matchRes
 	}, nil
 }
 

--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -184,24 +184,36 @@ func createMatchingHandlerForOneTag(
 	case MatchOperator:
 		allowMatchEmpty = compatibility.AllowRegexMatchEmpty
 
-		matchRegex, err := newMatchRegex(spec.Value, compatibility)
-		if err != nil {
-			return nil, err
-		}
+		if spec.Value == "*" {
+			matchingHandlerCondition = func(value string) bool {
+				return true
+			}
+		} else {
+			matchRegex, err := newMatchRegex(spec.Value, compatibility)
+			if err != nil {
+				return nil, err
+			}
 
-		matchingHandlerCondition = func(value string) bool {
-			return matchRegex.MatchString(value)
+			matchingHandlerCondition = func(value string) bool {
+				return matchRegex.MatchString(value)
+			}
 		}
 	case NotMatchOperator:
 		allowMatchEmpty = compatibility.AllowRegexMatchEmpty
 
-		matchRegex, err := newMatchRegex(spec.Value, compatibility)
-		if err != nil {
-			return nil, err
-		}
+		if spec.Value == "*" {
+			matchingHandlerCondition = func(value string) bool {
+				return true
+			}
+		} else {
+			matchRegex, err := newMatchRegex(spec.Value, compatibility)
+			if err != nil {
+				return nil, err
+			}
 
-		matchingHandlerCondition = func(value string) bool {
-			return !matchRegex.MatchString(value)
+			matchingHandlerCondition = func(value string) bool {
+				return !matchRegex.MatchString(value)
+			}
 		}
 	default:
 		matchingHandlerCondition = func(_ string) bool {
@@ -227,10 +239,6 @@ func newMatchRegex(
 	tagValue string,
 	compatibility *Compatibility,
 ) (*regexp.Regexp, error) {
-	if tagValue == "*" {
-		tagValue = ".*"
-	}
-
 	if !compatibility.AllowRegexLooseStartMatch {
 		tagValue = "^" + tagValue
 	}

--- a/filter/series_by_tag.go
+++ b/filter/series_by_tag.go
@@ -185,14 +185,14 @@ func createMatchingHandlerForOneTag(
 	case MatchOperator:
 		allowMatchEmpty = compatibility.AllowRegexMatchEmpty
 
-		matchingHandlerCondition, err = handleRegexMatch(true, spec, compatibility)
+		matchingHandlerCondition, err = handleRegexMatch(spec, compatibility)
 		if err != nil {
 			return nil, err
 		}
 	case NotMatchOperator:
 		allowMatchEmpty = compatibility.AllowRegexMatchEmpty
 
-		matchingHandlerCondition, err = handleRegexMatch(false, spec, compatibility)
+		matchingHandlerCondition, err = handleRegexMatch(spec, compatibility)
 		if err != nil {
 			return nil, err
 		}
@@ -217,10 +217,11 @@ func createMatchingHandlerForOneTag(
 }
 
 func handleRegexMatch(
-	isMatchOperator bool,
 	spec TagSpec,
 	compatibility *Compatibility,
 ) (func(string) bool, error) {
+	isMatchOperator := spec.Operator == MatchOperator
+
 	// We don't need to create a regular for the asterisk, because in such a tag
 	// it is the fact of the tag's presence that matters, not its value.
 	if spec.Value == "*" || spec.Value == ".*" {

--- a/filter/series_by_tag_pattern_index_test.go
+++ b/filter/series_by_tag_pattern_index_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -223,6 +224,15 @@ func TestSeriesByTagPatternIndex(t *testing.T) {
 			"tag2=~.*": {
 				{"tag2", MatchOperator, ".*"},
 			},
+			"tag2!=~*": {
+				{"tag2", NotMatchOperator, "*"},
+			},
+			"tag2!=~.*": {
+				{"tag2", NotMatchOperator, ".*"},
+			},
+			"tag2!=~al2": {
+				{"tag2", NotMatchOperator, "al2"},
+			},
 			"tag1=val1;tag2=val2": {
 				{"tag1", EqualOperator, "val1"},
 				{"tag2", EqualOperator, "val2"},
@@ -293,6 +303,7 @@ func TestSeriesByTagPatternIndex(t *testing.T) {
 					"name=~cpu;tag1=val1",
 					"name=~test1",
 					"tag1=~al1",
+					"tag2!=~al2",
 					"tag2=~*",
 					"tag2=~.*",
 				},
@@ -318,6 +329,18 @@ func TestSeriesByTagPatternIndex(t *testing.T) {
 					"name=cpu.*.*",
 					"name=cpu.*.test2",
 					"name=cpu.*.test2;tag2=val2",
+					"tag2=~*",
+					"tag2=~.*",
+				},
+			},
+			{
+				"cpu.test1.test3",
+				map[string]string{"tag2": "val3"},
+				[]string{
+					"name=cpu.*.*",
+					"name=cpu.test1.*",
+					"name=~test1",
+					"tag2!=~al2",
 					"tag2=~*",
 					"tag2=~.*",
 				},
@@ -355,6 +378,7 @@ func TestSeriesByTagPatternIndex(t *testing.T) {
 		for _, testCase := range testCases {
 			patterns := index.MatchPatterns(testCase.Name, testCase.Labels)
 			sort.Strings(patterns)
+			fmt.Println(testCase.Name)
 			c.So(patterns, ShouldResemble, testCase.MatchedPatterns)
 		}
 	})

--- a/filter/series_by_tag_pattern_index_test.go
+++ b/filter/series_by_tag_pattern_index_test.go
@@ -1,7 +1,6 @@
 package filter
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -378,7 +377,6 @@ func TestSeriesByTagPatternIndex(t *testing.T) {
 		for _, testCase := range testCases {
 			patterns := index.MatchPatterns(testCase.Name, testCase.Labels)
 			sort.Strings(patterns)
-			fmt.Println(testCase.Name)
 			c.So(patterns, ShouldResemble, testCase.MatchedPatterns)
 		}
 	})


### PR DESCRIPTION
# Improved handling of non-strict asterisk tags

It doesn't make sense to create a new regular expression for tags like `tag=~*`, `tag=~.*`, `tag!=~*` or `tag!=~.*`, because in such tags it is the fact of presence or absence of a tag that matters, not its value. This can reduce the total number of expensive `regexp.MatchString` operations in filters
