### PR TITLE
feat(notifier): add ability to move contacts and subscriptions between users and teams

### DIFF
--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -117,12 +117,25 @@ func UpdateContact(
 	contactData.Type = contactDTO.Type
 	contactData.Value = contactDTO.Value
 	contactData.Name = contactDTO.Name
+
+	if contactDTO.User != "" && contactDTO.TeamID == "" {
+		contactData.User = contactDTO.User
+		contactData.Team = contactDTO.TeamID
+	}
+
+	if contactDTO.TeamID != "" && contactDTO.User == "" {
+		contactData.Team = contactDTO.TeamID
+		contactData.User = contactDTO.User
+	}
+
 	if err := dataBase.SaveContact(&contactData); err != nil {
 		return contactDTO, api.ErrorInternalServer(err)
 	}
+
 	contactDTO.User = contactData.User
 	contactDTO.TeamID = contactData.Team
 	contactDTO.ID = contactData.ID
+
 	return contactDTO, nil
 }
 
@@ -221,9 +234,11 @@ func CheckUserPermissionsForContact(
 		}
 		return moira.ContactData{}, api.ErrorInternalServer(err)
 	}
+
 	if auth.IsAdmin(userLogin) {
 		return contactData, nil
 	}
+
 	if contactData.Team != "" {
 		teamContainsUser, err := dataBase.IsTeamContainUser(contactData.Team, userLogin)
 		if err != nil {
@@ -233,9 +248,11 @@ func CheckUserPermissionsForContact(
 			return contactData, nil
 		}
 	}
+
 	if contactData.User == userLogin {
 		return contactData, nil
 	}
+
 	return moira.ContactData{}, api.ErrorForbidden("you are not permitted")
 }
 

--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -114,11 +114,8 @@ func UpdateContact(
 	contactData.Value = contactDTO.Value
 	contactData.Name = contactDTO.Name
 
-	if contactDTO.User != "" {
+	if contactDTO.User != "" || contactDTO.TeamID != "" {
 		contactData.User = contactDTO.User
-	}
-
-	if contactDTO.TeamID != "" {
 		contactData.Team = contactDTO.TeamID
 	}
 

--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -57,10 +57,6 @@ func CreateContact(
 	userLogin,
 	teamID string,
 ) *api.ErrorResponse {
-	if userLogin != "" && teamID != "" {
-		return api.ErrorInternalServer(fmt.Errorf("CreateContact: cannot create contact when both userLogin and teamID specified"))
-	}
-
 	if !isAllowedToUseContactType(auth, userLogin, contact.Type) {
 		return api.ErrorInvalidRequest(ErrNotAllowedContactType)
 	}
@@ -118,14 +114,12 @@ func UpdateContact(
 	contactData.Value = contactDTO.Value
 	contactData.Name = contactDTO.Name
 
-	if contactDTO.User != "" && contactDTO.TeamID == "" {
+	if contactDTO.User != "" {
 		contactData.User = contactDTO.User
-		contactData.Team = contactDTO.TeamID
 	}
 
-	if contactDTO.TeamID != "" && contactDTO.User == "" {
+	if contactDTO.TeamID != "" {
 		contactData.Team = contactDTO.TeamID
-		contactData.User = contactDTO.User
 	}
 
 	if err := dataBase.SaveContact(&contactData); err != nil {

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -366,15 +366,6 @@ func TestCreateContact(t *testing.T) {
 			})
 		})
 	})
-
-	Convey("Error on create with both: userLogin and teamID specified", t, func() {
-		contact := &dto.Contact{
-			Value: contactValue,
-			Type:  contactType,
-		}
-		err := CreateContact(dataBase, auth, contact, userLogin, teamID)
-		So(err, ShouldResemble, api.ErrorInternalServer(fmt.Errorf("CreateContact: cannot create contact when both userLogin and teamID specified")))
-	})
 }
 
 func TestAdminsCreatesContact(t *testing.T) {
@@ -528,27 +519,27 @@ func TestUpdateContact(t *testing.T) {
 			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
 		})
 
-		Convey("Failed to overwrite user with filled team id", func() {
-			newUser := "testUser"
-			contactDTO := dto.Contact{
-				Value:  contactValue,
-				Type:   contactType,
-				TeamID: teamID,
-				User:   newUser,
-			}
-			contactID := uuid.Must(uuid.NewV4()).String()
-			contact := moira.ContactData{
-				Value: contactDTO.Value,
-				Type:  contactDTO.Type,
-				ID:    contactID,
-				Team:  teamID,
-			}
-			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
-			So(err, ShouldBeNil)
-			So(expectedContact.User, ShouldBeEmpty)
-			So(expectedContact.ID, ShouldResemble, contactID)
-		})
+		// Convey("Failed to overwrite user with filled team id", func() {
+		// 	newUser := "testUser"
+		// 	contactDTO := dto.Contact{
+		// 		Value:  contactValue,
+		// 		Type:   contactType,
+		// 		TeamID: teamID,
+		// 		User:   newUser,
+		// 	}
+		// 	contactID := uuid.Must(uuid.NewV4()).String()
+		// 	contact := moira.ContactData{
+		// 		Value: contactDTO.Value,
+		// 		Type:  contactDTO.Type,
+		// 		ID:    contactID,
+		// 		Team:  teamID,
+		// 	}
+		// 	dataBase.EXPECT().SaveContact(&contact).Return(nil)
+		// 	expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+		// 	So(err, ShouldBeNil)
+		// 	So(expectedContact.User, ShouldBeEmpty)
+		// 	So(expectedContact.ID, ShouldResemble, contactID)
+		// })
 
 		Convey("Error update not allowed contact", func() {
 			contactDTO := dto.Contact{
@@ -654,27 +645,27 @@ func TestUpdateContact(t *testing.T) {
 			So(expectedContact.ID, ShouldResemble, contactID)
 		})
 
-		Convey("Failed to overwrite team with filled user", func() {
-			newTeam := "testTeam"
-			contactDTO := dto.Contact{
-				Value:  contactValue,
-				Type:   contactType,
-				TeamID: newTeam,
-				User:   userLogin,
-			}
-			contactID := uuid.Must(uuid.NewV4()).String()
-			contact := moira.ContactData{
-				Value: contactDTO.Value,
-				Type:  contactDTO.Type,
-				ID:    contactID,
-				User:  userLogin,
-			}
-			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
-			So(err, ShouldBeNil)
-			So(expectedContact.TeamID, ShouldBeEmpty)
-			So(expectedContact.ID, ShouldResemble, contactID)
-		})
+		// Convey("Failed to overwrite team with filled user", func() {
+		// 	newTeam := "testTeam"
+		// 	contactDTO := dto.Contact{
+		// 		Value:  contactValue,
+		// 		Type:   contactType,
+		// 		TeamID: newTeam,
+		// 		User:   userLogin,
+		// 	}
+		// 	contactID := uuid.Must(uuid.NewV4()).String()
+		// 	contact := moira.ContactData{
+		// 		Value: contactDTO.Value,
+		// 		Type:  contactDTO.Type,
+		// 		ID:    contactID,
+		// 		User:  userLogin,
+		// 	}
+		// 	dataBase.EXPECT().SaveContact(&contact).Return(nil)
+		// 	expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+		// 	So(err, ShouldBeNil)
+		// 	So(expectedContact.TeamID, ShouldBeEmpty)
+		// 	So(expectedContact.ID, ShouldResemble, contactID)
+		// })
 
 		Convey("Error save", func() {
 			contactDTO := dto.Contact{

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -519,28 +519,6 @@ func TestUpdateContact(t *testing.T) {
 			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
 		})
 
-		// Convey("Failed to overwrite user with filled team id", func() {
-		// 	newUser := "testUser"
-		// 	contactDTO := dto.Contact{
-		// 		Value:  contactValue,
-		// 		Type:   contactType,
-		// 		TeamID: teamID,
-		// 		User:   newUser,
-		// 	}
-		// 	contactID := uuid.Must(uuid.NewV4()).String()
-		// 	contact := moira.ContactData{
-		// 		Value: contactDTO.Value,
-		// 		Type:  contactDTO.Type,
-		// 		ID:    contactID,
-		// 		Team:  teamID,
-		// 	}
-		// 	dataBase.EXPECT().SaveContact(&contact).Return(nil)
-		// 	expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
-		// 	So(err, ShouldBeNil)
-		// 	So(expectedContact.User, ShouldBeEmpty)
-		// 	So(expectedContact.ID, ShouldResemble, contactID)
-		// })
-
 		Convey("Error update not allowed contact", func() {
 			contactDTO := dto.Contact{
 				Value: contactValue,
@@ -644,28 +622,6 @@ func TestUpdateContact(t *testing.T) {
 			So(expectedContact.TeamID, ShouldResemble, newTeam)
 			So(expectedContact.ID, ShouldResemble, contactID)
 		})
-
-		// Convey("Failed to overwrite team with filled user", func() {
-		// 	newTeam := "testTeam"
-		// 	contactDTO := dto.Contact{
-		// 		Value:  contactValue,
-		// 		Type:   contactType,
-		// 		TeamID: newTeam,
-		// 		User:   userLogin,
-		// 	}
-		// 	contactID := uuid.Must(uuid.NewV4()).String()
-		// 	contact := moira.ContactData{
-		// 		Value: contactDTO.Value,
-		// 		Type:  contactDTO.Type,
-		// 		ID:    contactID,
-		// 		User:  userLogin,
-		// 	}
-		// 	dataBase.EXPECT().SaveContact(&contact).Return(nil)
-		// 	expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
-		// 	So(err, ShouldBeNil)
-		// 	So(expectedContact.TeamID, ShouldBeEmpty)
-		// 	So(expectedContact.ID, ShouldResemble, contactID)
-		// })
 
 		Convey("Error save", func() {
 			contactDTO := dto.Contact{

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -504,6 +504,52 @@ func TestUpdateContact(t *testing.T) {
 			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
 		})
 
+		Convey("Success with rewrite user", func() {
+			newUser := "testUser"
+			contactDTO := dto.Contact{
+				Value: contactValue,
+				Name:  "some-name",
+				Type:  contactType,
+				User:  newUser,
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				Name:  contactDTO.Name,
+				ID:    contactID,
+				User:  newUser,
+			}
+			dataBase.EXPECT().SaveContact(&contact).Return(nil)
+			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			So(err, ShouldBeNil)
+			So(expectedContact.User, ShouldResemble, newUser)
+			So(expectedContact.ID, ShouldResemble, contactID)
+			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
+		})
+
+		Convey("Failed to overwrite user with filled team id", func() {
+			newUser := "testUser"
+			contactDTO := dto.Contact{
+				Value:  contactValue,
+				Type:   contactType,
+				TeamID: teamID,
+				User:   newUser,
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				Team:  teamID,
+			}
+			dataBase.EXPECT().SaveContact(&contact).Return(nil)
+			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			So(err, ShouldBeNil)
+			So(expectedContact.User, ShouldBeEmpty)
+			So(expectedContact.ID, ShouldResemble, contactID)
+		})
+
 		Convey("Error update not allowed contact", func() {
 			contactDTO := dto.Contact{
 				Value: contactValue,
@@ -584,6 +630,49 @@ func TestUpdateContact(t *testing.T) {
 			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
 			So(err, ShouldBeNil)
 			So(expectedContact.TeamID, ShouldResemble, teamID)
+			So(expectedContact.ID, ShouldResemble, contactID)
+		})
+
+		Convey("Success with rewrite team", func() {
+			newTeam := "testTeam"
+			contactDTO := dto.Contact{
+				Value:  contactValue,
+				Type:   contactType,
+				TeamID: newTeam,
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				Team:  newTeam,
+			}
+			dataBase.EXPECT().SaveContact(&contact).Return(nil)
+			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			So(err, ShouldBeNil)
+			So(expectedContact.TeamID, ShouldResemble, newTeam)
+			So(expectedContact.ID, ShouldResemble, contactID)
+		})
+
+		Convey("Failed to overwrite team with filled user", func() {
+			newTeam := "testTeam"
+			contactDTO := dto.Contact{
+				Value:  contactValue,
+				Type:   contactType,
+				TeamID: newTeam,
+				User:   userLogin,
+			}
+			contactID := uuid.Must(uuid.NewV4()).String()
+			contact := moira.ContactData{
+				Value: contactDTO.Value,
+				Type:  contactDTO.Type,
+				ID:    contactID,
+				User:  userLogin,
+			}
+			dataBase.EXPECT().SaveContact(&contact).Return(nil)
+			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			So(err, ShouldBeNil)
+			So(expectedContact.TeamID, ShouldBeEmpty)
 			So(expectedContact.ID, ShouldResemble, contactID)
 		})
 

--- a/api/controller/subscription.go
+++ b/api/controller/subscription.go
@@ -81,13 +81,16 @@ func GetSubscription(dataBase moira.Database, subscriptionID string) (*dto.Subsc
 // UpdateSubscription updates existing subscription.
 func UpdateSubscription(dataBase moira.Database, subscriptionID string, userLogin string, subscription *dto.Subscription) *api.ErrorResponse {
 	subscription.ID = subscriptionID
-	if subscription.TeamID == "" {
+	if subscription.TeamID == "" && subscription.User == "" {
 		subscription.User = userLogin
 	}
+
 	data := moira.SubscriptionData(*subscription)
+
 	if err := dataBase.SaveSubscription(&data); err != nil {
 		return api.ErrorInternalServer(err)
 	}
+
 	return nil
 }
 
@@ -131,21 +134,26 @@ func CheckUserPermissionsForSubscription(
 		}
 		return moira.SubscriptionData{}, api.ErrorInternalServer(err)
 	}
+
 	if auth.IsAdmin(userLogin) {
 		return subscription, nil
 	}
+
 	if subscription.TeamID != "" {
 		teamContainsUser, err := dataBase.IsTeamContainUser(subscription.TeamID, userLogin)
 		if err != nil {
 			return moira.SubscriptionData{}, api.ErrorInternalServer(err)
 		}
+
 		if teamContainsUser {
 			return subscription, nil
 		}
 	}
+
 	if subscription.User == userLogin {
 		return subscription, nil
 	}
+
 	return moira.SubscriptionData{}, api.ErrorForbidden("you are not permitted")
 }
 

--- a/api/dto/contact.go
+++ b/api/dto/contact.go
@@ -36,5 +36,8 @@ func (contact *Contact) Bind(r *http.Request) error {
 	if contact.Value == "" {
 		return fmt.Errorf("contact value of type %s can not be empty", contact.Type)
 	}
+	if contact.User != "" && contact.TeamID != "" {
+		return fmt.Errorf("contact cannot have both the user field and the team_id field filled in")
+	}
 	return nil
 }

--- a/api/dto/subscription.go
+++ b/api/dto/subscription.go
@@ -84,6 +84,7 @@ func (subscription *Subscription) checkContacts(request *http.Request) error {
 	if subscription.User != "" && teamID != "" {
 		return ErrSubscriptionContainsTeamAndUser{}
 	}
+
 	var contactIDs []string
 	var err error
 	if teamID != "" {
@@ -112,6 +113,7 @@ func (subscription *Subscription) checkContacts(request *http.Request) error {
 		if err != nil {
 			return ErrProvidedContactsForbidden{contactIds: subscriptionContactIDs}
 		}
+
 		anotherUserContactValues := make([]string, 0)
 		anotherUserContactIDs := make([]string, 0)
 		for i, contact := range contacts {
@@ -121,11 +123,13 @@ func (subscription *Subscription) checkContacts(request *http.Request) error {
 				anotherUserContactValues = append(anotherUserContactValues, contact.Value)
 			}
 		}
+
 		return ErrProvidedContactsForbidden{
 			contactNames: anotherUserContactValues,
 			contactIds:   subscriptionContactIDs,
 		}
 	}
+
 	return nil
 }
 

--- a/local/api.yml
+++ b/local/api.yml
@@ -37,10 +37,6 @@ prometheus_remote:
 api:
   listen: ":8081"
   enable_cors: false
-  authorization:
-    enabled: true
-    admin_list:
-      - anonymous
 web:
   contacts_template:
     - type: mail

--- a/local/api.yml
+++ b/local/api.yml
@@ -37,6 +37,10 @@ prometheus_remote:
 api:
   listen: ":8081"
   enable_cors: false
+  authorization:
+    enabled: true
+    admin_list:
+      - anonymous
 web:
   contacts_template:
     - type: mail


### PR DESCRIPTION
# Add ability to move contacts and subscriptions between users and teams

Users now have the ability to move their contacts to a team and vice versa. Subscriptions can also be moved from a user to a team, but only if you are a member and vice versa
