### PR TITLE
fix(notifier): fixed sending of notifications with schedule between different days

### DIFF
--- a/notifier/scheduler.go
+++ b/notifier/scheduler.go
@@ -170,11 +170,12 @@ func calculateNextDelivery(schedule *moira.ScheduleData, nextTime time.Time) (ti
 	localNextTime := nextTime.Add(-tzOffset).Truncate(time.Minute)
 	localNextTimeDay := localNextTime.Truncate(24 * time.Hour) //nolint
 	localNextWeekday := int(localNextTimeDay.Weekday()+6) % 7  //nolint
+	timeOfDay := localNextTime.Sub(localNextTimeDay)
 
 	if schedule.EndOffset < schedule.StartOffset {
 		// The condition can only be fulfilled if the begin offset should be on the past day and not on the current day.
 		// In other variants end offset must be on the next day
-		if localNextTime.Sub(localNextTimeDay) < beginOffset && localNextTime.Sub(localNextTimeDay) < endOffset {
+		if timeOfDay < beginOffset && timeOfDay < endOffset {
 			beginOffset -= time.Hour * 24
 		} else {
 			endOffset += time.Hour * 24

--- a/notifier/scheduler_test.go
+++ b/notifier/scheduler_test.go
@@ -343,7 +343,7 @@ func TestSubscriptionSchedule(t *testing.T) {
 		})
 	})
 
-	Convey("Test advanced schedule between different days (e.g. 23:30 - 18:00)", t, func ()  {
+	Convey("Test advanced schedule between different days (e.g. 23:30 - 18:00)", t, func() {
 		// Schedule: 23:30 - 18:00 (GTM +3)
 		Convey("Time is out of range within the current day, nextTime should resemble now", func() {
 			// 2015-09-02, 23:45:00 GMT+03:00


### PR DESCRIPTION
# Fixed sending of notifications with schedule between different days

The problem occurred when sending notifications in a subscription with a schedule of 11:30 PM - 06:00 PM in which the end was earlier than the beginning, i.e. it was supposed to go to the next day

In the test cases there was a similar example with the schedule from 02:00 AM - 00:00 AM earlier, but in this case everything happens **within one day**, which did not allow to detect the bug

In this PR I have fixed this incorrect behaviour by adding additional handling for the case where the end of the schedule is earlier than the beginning. Let's look at an example:
- We have a subscription with a schedule from 11:30 PM - 06:00 PM
- A metric came to us that generated an alert at 02:00 PM
- Before this PR we would only increment the 06:00 PM to the next day, not taking into account that the 11:30 PM subscription start is actually supposed to refer to the previous day, not the current day, accordingly in my new PR we would be pushing the start back a day. The code checks that the number of hours that have passed since the start of the new day is less than the subscription start time and the subscription end time, in which case we need to move the start of the subscription back by a day
![diff_days](https://github.com/user-attachments/assets/a2b355a1-ef0a-4d44-a4ae-ad3597dc4fbc)

Let's consider another example that worked correctly:
- We have a subscription with a schedule from 11:30 PM - 06:00 PM
- A metric came to us and generated an alert at 11:45 PM
- In this case, the logic before this PR was correct, as the start of the subscription is within the **current day**, and the end is just **on another day**, so the end needs to be incremented one day forward
![one_day](https://github.com/user-attachments/assets/40815743-6b33-41b5-9c64-f5ae922bf43f)

