### PR TITLE
feat(api): query params to event history

### DIFF
--- a/api/controller/contact_events_test.go
+++ b/api/controller/contact_events_test.go
@@ -81,7 +81,7 @@ func TestGetContactEventsByIdWithLimit(t *testing.T) {
 
 	Convey("Ensure that request with default parameters would return both event items (no url params specified)", t, func() {
 		dataBase.EXPECT().GetContact(contact.ID).Return(contactExpect, nil).AnyTimes()
-		dataBase.EXPECT().GetNotificationsHistoryByContactId(contact.ID, defaultFromParameter, defaultToParameter, defaultPage, defaultSize).Return(items, nil)
+		dataBase.EXPECT().GetNotificationsHistoryByContactID(contact.ID, defaultFromParameter, defaultToParameter, defaultPage, defaultSize).Return(items, nil)
 
 		actualEvents, err := GetContactEventsHistoryByID(dataBase, contact.ID, defaultFromParameter, defaultToParameter, defaultPage, defaultSize)
 
@@ -91,7 +91,7 @@ func TestGetContactEventsByIdWithLimit(t *testing.T) {
 
 	Convey("Ensure that request with only 'from' parameter given and 'to' default will return only one (newest) event", t, func() {
 		dataBase.EXPECT().GetContact(contact.ID).Return(contactExpect, nil).AnyTimes()
-		dataBase.EXPECT().GetNotificationsHistoryByContactId(contact.ID, defaultFromParameter-20, defaultToParameter, defaultPage, defaultSize).Return(items[:1], nil)
+		dataBase.EXPECT().GetNotificationsHistoryByContactID(contact.ID, defaultFromParameter-20, defaultToParameter, defaultPage, defaultSize).Return(items[:1], nil)
 
 		actualEvents, err := GetContactEventsHistoryByID(dataBase, contact.ID, defaultFromParameter-20, defaultToParameter, defaultPage, defaultSize)
 		So(err, ShouldBeNil)
@@ -104,7 +104,7 @@ func TestGetContactEventsByIdWithLimit(t *testing.T) {
 
 	Convey("Ensure that request with only 'to' parameter given and 'from' default will return only one (oldest) event", t, func() {
 		dataBase.EXPECT().GetContact(contact.ID).Return(contactExpect, nil).AnyTimes()
-		dataBase.EXPECT().GetNotificationsHistoryByContactId(contact.ID, defaultFromParameter, defaultToParameter-30, defaultPage, defaultSize).Return(items[1:], nil)
+		dataBase.EXPECT().GetNotificationsHistoryByContactID(contact.ID, defaultFromParameter, defaultToParameter-30, defaultPage, defaultSize).Return(items[1:], nil)
 
 		actualEvents, err := GetContactEventsHistoryByID(dataBase, contact.ID, defaultFromParameter, defaultToParameter-30, defaultPage, defaultSize)
 		So(err, ShouldBeNil)

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -9,11 +9,13 @@ import (
 )
 
 // GetTriggerEvents gets trigger event from current page and all trigger event count. Events list is filtered by time range
-// (`from` and `to` params), metric (regular expression) and states. If `states` map is empty or nil then all states are accepted.
+// with `from` and `to` params (`from` and `to` should be "+inf", "-inf" or int64 converted to string),
+// by metric (regular expression) and by states. If `states` map is empty or nil then all states are accepted.
 func GetTriggerEvents(
 	database moira.Database,
 	triggerID string,
-	page, size, from, to int64,
+	page, size int64,
+	from, to string,
 	metricRegexp *regexp.Regexp,
 	states map[string]struct{},
 ) (*dto.EventsList, *api.ErrorResponse) {
@@ -40,7 +42,8 @@ func GetTriggerEvents(
 func getFilteredNotificationEvents(
 	database moira.Database,
 	triggerID string,
-	page, size, from, to int64,
+	page, size int64,
+	from, to string,
 	metricRegexp *regexp.Regexp,
 	states map[string]struct{},
 ) ([]*moira.NotificationEvent, error) {

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/moira-alert/moira"
@@ -56,8 +55,6 @@ func getFilteredNotificationEvents(
 		if err != nil {
 			return nil, err
 		}
-
-		fmt.Printf("len(eventsData) = %v\n", len(eventsData))
 
 		if len(eventsData) == 0 {
 			break

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -9,8 +9,8 @@ import (
 
 // GetTriggerEvents gets trigger event from current page and all trigger event count. Events list is filtered by time range
 // (`from` and `to` params), metric (regular expression) and states. If `states` map is empty or nil then all states are accepted.
-func GetTriggerEvents(database moira.Database, triggerID string, page, size, from, to int64, metric *regexp.Regexp, states map[string]struct{}) (*dto.EventsList, *api.ErrorResponse) {
-	events, err := database.GetNotificationEvents(triggerID, page*size, size, from, to, metric, states)
+func GetTriggerEvents(database moira.Database, triggerID string, page, size, from, to int64, metricRegexp *regexp.Regexp, states map[string]struct{}) (*dto.EventsList, *api.ErrorResponse) {
+	events, err := database.GetNotificationEvents(triggerID, page*size, size, from, to, metricRegexp, states)
 	if err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -39,14 +39,17 @@ func getFilteredNotificationEvents(
 	metricRegexp *regexp.Regexp,
 	states map[string]struct{},
 ) ([]*moira.NotificationEvent, error) {
+	// fetch all events
 	if size < 0 {
 		events, err := database.GetNotificationEvents(triggerID, page, size, from, to)
 		if err != nil {
 			return nil, err
 		}
+
 		return filterNotificationEvents(events, metricRegexp, states), nil
 	}
 
+	// fetch at most `size` events
 	filtered := make([]*moira.NotificationEvent, 0, size)
 	var count int64
 

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -10,7 +10,12 @@ import (
 
 // GetTriggerEvents gets trigger event from current page and all trigger event count. Events list is filtered by time range
 // (`from` and `to` params), metric (regular expression) and states. If `states` map is empty or nil then all states are accepted.
-func GetTriggerEvents(database moira.Database, triggerID string, page, size, from, to int64, metricRegexp *regexp.Regexp, states map[string]struct{},
+func GetTriggerEvents(
+	database moira.Database,
+	triggerID string,
+	page, size, from, to int64,
+	metricRegexp *regexp.Regexp,
+	states map[string]struct{},
 ) (*dto.EventsList, *api.ErrorResponse) {
 	events, err := getFilteredNotificationEvents(database, triggerID, page, size, from, to, metricRegexp, states)
 	if err != nil {
@@ -74,7 +79,11 @@ func getFilteredNotificationEvents(
 	return filtered, nil
 }
 
-func filterNotificationEvents(notificationEvents []*moira.NotificationEvent, metricRegexp *regexp.Regexp, states map[string]struct{}) []*moira.NotificationEvent {
+func filterNotificationEvents(
+	notificationEvents []*moira.NotificationEvent,
+	metricRegexp *regexp.Regexp,
+	states map[string]struct{},
+) []*moira.NotificationEvent {
 	filteredNotificationEvents := make([]*moira.NotificationEvent, 0)
 
 	for _, event := range notificationEvents {
@@ -82,7 +91,6 @@ func filterNotificationEvents(notificationEvents []*moira.NotificationEvent, met
 			_, ok := states[string(event.State)]
 			if len(states) == 0 || ok {
 				filteredNotificationEvents = append(filteredNotificationEvents, event)
-				continue
 			}
 		}
 	}

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -1,16 +1,18 @@
 package controller
 
 import (
+	"regexp"
+
 	"github.com/moira-alert/moira"
 	"github.com/moira-alert/moira/api"
 	"github.com/moira-alert/moira/api/dto"
-	"regexp"
 )
 
 // GetTriggerEvents gets trigger event from current page and all trigger event count. Events list is filtered by time range
 // (`from` and `to` params), metric (regular expression) and states. If `states` map is empty or nil then all states are accepted.
-func GetTriggerEvents(database moira.Database, triggerID string, page, size, from, to int64, metricRegexp *regexp.Regexp, states map[string]struct{}) (*dto.EventsList, *api.ErrorResponse) {
-	events, err := database.GetNotificationEvents(triggerID, page*size, size, from, to, metricRegexp, states)
+func GetTriggerEvents(database moira.Database, triggerID string, page, size, from, to int64, metricRegexp *regexp.Regexp, states map[string]struct{},
+) (*dto.EventsList, *api.ErrorResponse) {
+	events, err := getFilteredNotificationEvents(database, triggerID, page, size, from, to, metricRegexp, states)
 	if err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}
@@ -28,6 +30,57 @@ func GetTriggerEvents(database moira.Database, triggerID string, page, size, fro
 		}
 	}
 	return eventsList, nil
+}
+
+func getFilteredNotificationEvents(
+	database moira.Database,
+	triggerID string,
+	page, size, from, to int64,
+	metricRegexp *regexp.Regexp,
+	states map[string]struct{},
+) ([]*moira.NotificationEvent, error) {
+	if size < 0 {
+		events, err := database.GetNotificationEvents(triggerID, page, size, from, to)
+		if err != nil {
+			return nil, err
+		}
+		return filterNotificationEvents(events, metricRegexp, states), nil
+	}
+
+	filtered := make([]*moira.NotificationEvent, 0, size)
+	var count int64
+
+	for int64(len(filtered)) < size {
+		eventsData, err := database.GetNotificationEvents(triggerID, page+count, size, from, to)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(eventsData) == 0 {
+			break
+		}
+
+		filtered = append(filtered, filterNotificationEvents(eventsData, metricRegexp, states)...)
+		count += 1
+	}
+
+	return filtered, nil
+}
+
+func filterNotificationEvents(notificationEvents []*moira.NotificationEvent, metricRegexp *regexp.Regexp, states map[string]struct{}) []*moira.NotificationEvent {
+	filteredNotificationEvents := make([]*moira.NotificationEvent, 0)
+
+	for _, event := range notificationEvents {
+		if metricRegexp.MatchString(event.Metric) {
+			_, ok := states[string(event.State)]
+			if len(states) == 0 || ok {
+				filteredNotificationEvents = append(filteredNotificationEvents, event)
+				continue
+			}
+		}
+	}
+
+	return filteredNotificationEvents
 }
 
 // DeleteAllEvents deletes all notification events.

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -7,8 +7,8 @@ import (
 )
 
 // GetTriggerEvents gets trigger event from current page and all trigger event count.
-func GetTriggerEvents(database moira.Database, triggerID string, page int64, size int64) (*dto.EventsList, *api.ErrorResponse) {
-	events, err := database.GetNotificationEvents(triggerID, page*size, size-1)
+func GetTriggerEvents(database moira.Database, triggerID string, page, size, from, to int64, metric string, state moira.State) (*dto.EventsList, *api.ErrorResponse) {
+	events, err := database.GetNotificationEvents(triggerID, page*size, size, from, to, metric, state)
 	if err != nil {
 		return nil, api.ErrorInternalServer(err)
 	}

--- a/api/controller/events.go
+++ b/api/controller/events.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/moira-alert/moira"
@@ -56,12 +57,18 @@ func getFilteredNotificationEvents(
 			return nil, err
 		}
 
+		fmt.Printf("len(eventsData) = %v\n", len(eventsData))
+
 		if len(eventsData) == 0 {
 			break
 		}
 
 		filtered = append(filtered, filterNotificationEvents(eventsData, metricRegexp, states)...)
 		count += 1
+
+		if int64(len(eventsData)) < size {
+			break
+		}
 	}
 
 	return filtered, nil

--- a/api/controller/events_test.go
+++ b/api/controller/events_test.go
@@ -28,11 +28,11 @@ func TestGetEvents(t *testing.T) {
 	var page int64 = 10
 	var size int64 = 100
 	var from int64 = 0
-	var to = time.Now().Unix()
+	to := time.Now().Unix()
 
 	Convey("Test has events", t, func() {
 		var total int64 = 6000000
-		dataBase.EXPECT().GetNotificationEvents(triggerID, page*size, size, from, to, allMetrics, allStates).
+		dataBase.EXPECT().GetNotificationEvents(triggerID, page, size, from, to).
 			Return([]*moira.NotificationEvent{
 				{
 					State:    moira.StateNODATA,
@@ -56,7 +56,7 @@ func TestGetEvents(t *testing.T) {
 
 	Convey("Test no events", t, func() {
 		var total int64
-		dataBase.EXPECT().GetNotificationEvents(triggerID, page*size, size, from, to, allMetrics, allStates).Return(make([]*moira.NotificationEvent, 0), nil)
+		dataBase.EXPECT().GetNotificationEvents(triggerID, page, size, from, to).Return(make([]*moira.NotificationEvent, 0), nil)
 		dataBase.EXPECT().GetNotificationEventCount(triggerID, int64(-1)).Return(total)
 		list, err := GetTriggerEvents(dataBase, triggerID, page, size, from, to, allMetrics, allStates)
 		So(err, ShouldBeNil)
@@ -70,10 +70,49 @@ func TestGetEvents(t *testing.T) {
 
 	Convey("Test error", t, func() {
 		expected := fmt.Errorf("oooops! Can not get all contacts")
-		dataBase.EXPECT().GetNotificationEvents(triggerID, page*size, size, from, to, allMetrics, allStates).Return(nil, expected)
+		dataBase.EXPECT().GetNotificationEvents(triggerID, page, size, from, to).Return(nil, expected)
 		list, err := GetTriggerEvents(dataBase, triggerID, page, size, from, to, allMetrics, allStates)
 		So(err, ShouldResemble, api.ErrorInternalServer(expected))
 		So(list, ShouldBeNil)
+	})
+
+	Convey("Test filtering", t, func() {
+		Convey("by metric regex", func() {
+			now := time.Now().Unix()
+			page = 0
+			size = 2
+			Convey("with same prefix", func() {
+				filtered := []*moira.NotificationEvent{
+					{
+						Timestamp: now,
+						Metric:    "metric.test.event1",
+					},
+					{
+						Timestamp: now,
+						Metric:    "metric.test.event2",
+					},
+				}
+				notFiltered := []*moira.NotificationEvent{
+					{
+						Timestamp: now,
+						Metric:    "another.metric.test.event",
+					},
+					{
+						Timestamp: now,
+						Metric:    "metric.test",
+					},
+				}
+				firstPortion := append(make([]*moira.NotificationEvent, 0), notFiltered[0], filtered[0])
+				dataBase.EXPECT().GetNotificationEvents(triggerID, page, size, from, to).Return(firstPortion, nil)
+
+				secondPortion := append(make([]*moira.NotificationEvent, 0), filtered[1], notFiltered[1])
+				dataBase.EXPECT().GetNotificationEvents(triggerID, page+1, size, from, to).Return(secondPortion, nil)
+
+				actual, err := GetTriggerEvents(dataBase, triggerID, page, size, from, to, regexp.MustCompile(`metric\.test\.event`), allStates)
+				So(err, ShouldBeNil)
+				So(actual, ShouldResemble, filtered)
+			})
+		})
 	})
 }
 

--- a/api/controller/events_test.go
+++ b/api/controller/events_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/moira-alert/moira"
@@ -25,10 +24,11 @@ func TestGetEvents(t *testing.T) {
 	dataBase := mock_moira_alert.NewMockDatabase(mockCtrl)
 	defer mockCtrl.Finish()
 	triggerID := uuid.Must(uuid.NewV4()).String()
+
 	var page int64 = 10
 	var size int64 = 100
-	var from int64 = 0
-	to := time.Now().Unix()
+	from := "-inf"
+	to := "+inf"
 
 	Convey("Test has events", t, func() {
 		var total int64 = 6000000

--- a/api/handler/constants.go
+++ b/api/handler/constants.go
@@ -8,6 +8,7 @@ const (
 	eventDefaultFrom   = "-3hour"
 	eventDefaultTo     = "now"
 	eventDefaultMetric = allMetricsPattern
+)
 
 const (
 	contactEventsDefaultFrom = "-3hour"

--- a/api/handler/constants.go
+++ b/api/handler/constants.go
@@ -2,16 +2,10 @@ package handler
 
 const allMetricsPattern = ".*"
 
-// default values for event router.
 const (
-	// default values for middleware.Paginate.
-	eventDefaultPage = 0
-	eventDefaultSize = -1
-
-	// default values for middleware.DateRange.
-	eventDefaultFrom = "-3hour"
-	eventDefaultTo   = "now"
-
-	// default value for middleware.MetricProvider.
+	eventDefaultPage   = 0
+	eventDefaultSize   = -1
+	eventDefaultFrom   = "-3hour"
+	eventDefaultTo     = "now"
 	eventDefaultMetric = allMetricsPattern
 )

--- a/api/handler/constants.go
+++ b/api/handler/constants.go
@@ -4,9 +4,9 @@ const allMetricsPattern = ".*"
 
 const (
 	eventDefaultPage   = 0
-	eventDefaultSize   = -1
-	eventDefaultFrom   = "-3hour"
-	eventDefaultTo     = "now"
+	eventDefaultSize   = 100
+	eventDefaultFrom   = "-inf"
+	eventDefaultTo     = "+inf"
 	eventDefaultMetric = allMetricsPattern
 )
 

--- a/api/handler/constants.go
+++ b/api/handler/constants.go
@@ -1,0 +1,17 @@
+package handler
+
+const allMetricsPattern = ".*"
+
+// default values for event router.
+const (
+	// default values for middleware.Paginate.
+	eventDefaultPage = 0
+	eventDefaultSize = -1
+
+	// default values for middleware.DateRange.
+	eventDefaultFrom = "-3hour"
+	eventDefaultTo   = "now"
+
+	// default value for middleware.MetricProvider.
+	eventDefaultMetric = allMetricsPattern
+)

--- a/api/handler/contact_events.go
+++ b/api/handler/contact_events.go
@@ -33,11 +33,11 @@ func contactEvents(router chi.Router) {
 //	@id			get-contact-events-by-id
 //	@tags		contact
 //	@produce	json
-//	@param		contactID		path		string							true	"Contact ID"					default(bcba82f5-48cf-44c0-b7d6-e1d32c64a88c)
-//	@param		from				query		string							false	"Start time of the time range"	default(-3hour)
-//	@param		to					query		string							false	"End time of the time range"	default(now)
-//	@param		size				query		int									false	"Number of items to return or all items if size == -1 (if size == -1 p should be zero for correct work)"									default(100)
-//	@param		p						query		int									false	"Defines the index of data portion (combined with size). E.g, p=2, size=100 will return records from 200 (including), to 300 (not including)"	default(0)
+//	@param		contactID	path		string							true	"Contact ID"																																	default(bcba82f5-48cf-44c0-b7d6-e1d32c64a88c)
+//	@param		from		query		string							false	"Start time of the time range"																													default(-3hour)
+//	@param		to			query		string							false	"End time of the time range"																													default(now)
+//	@param		size		query		int								false	"Number of items to return or all items if size == -1 (if size == -1 p should be zero for correct work)"										default(100)
+//	@param		p			query		int								false	"Defines the index of data portion (combined with size). E.g, p=2, size=100 will return records from 200 (including), to 300 (not including)"	default(0)
 //	@success	200			{object}	dto.ContactEventItemList		"Successfully received contact events"
 //	@failure	400			{object}	api.ErrorInvalidRequestExample	"Bad request from client"
 //	@failure	403			{object}	api.ErrorForbiddenExample		"Forbidden"

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -20,8 +20,8 @@ func event(router chi.Router) {
 		middleware.TriggerContext,
 		middleware.Paginate(eventDefaultPage, eventDefaultSize),
 		middleware.DateRange(eventDefaultFrom, eventDefaultTo),
-		middleware.MetricProvider(eventDefaultMetric),
-		middleware.StatesProvider(),
+		middleware.MetricContext(eventDefaultMetric),
+		middleware.StatesContext(),
 	).Get("/{triggerId}", getEventsList)
 	router.With(middleware.AdminOnlyMiddleware()).Delete("/all", deleteAllEvents)
 }

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -33,13 +33,13 @@ func event(router chi.Router) {
 //	@id			get-events-list
 //	@tags		event
 //	@produce	json
-//	@param		triggerID	path		string							true	"The ID of updated trigger"														default(bcba82f5-48cf-44c0-b7d6-e1d32c64a88c)
-//	@param		size			query		int									false	"Number of items to be displayed on one page. if size = -1 then all events returned"	default(100)
-//	@param		p					query		int									false	"Defines the number of the displayed page. E.g, p=2 would display the 2nd page"	default(0)
-//	@param		from			query		string							false	"Start time of the time range"	default(-inf)
-//	@param		to				query		string							false	"End time of the time range"	default(+inf)
-//	@param		metric		query		string							false	"Regular expression that will be used to filter events"	default(.*)
-//	@param		states		query		[]string						false "String of ',' separated state names. If empty then all states will be used." collectionFormat(csv)
+//	@param		triggerID	path		string							true	"The ID of updated trigger"																default(bcba82f5-48cf-44c0-b7d6-e1d32c64a88c)
+//	@param		size		query		int								false	"Number of items to be displayed on one page. if size = -1 then all events returned"	default(100)
+//	@param		p			query		int								false	"Defines the number of the displayed page. E.g, p=2 would display the 2nd page"			default(0)
+//	@param		from		query		string							false	"Start time of the time range"															default(-3hours)
+//	@param		to			query		string							false	"End time of the time range"															default(now)
+//	@param		metric		query		string							false	"Regular expression that will be used to filter events"									default(.*)
+//	@param		states		query		[]string						false	"String of ',' separated state names. If empty then all states will be used."			collectionFormat(csv)
 //	@success	200			{object}	dto.EventsList					"Events fetched successfully"
 //	@Failure	400			{object}	api.ErrorInvalidRequestExample	"Bad request from client"
 //	@Failure	404			{object}	api.ErrorNotFoundExample		"Resource not found"
@@ -53,7 +53,7 @@ func getEventsList(writer http.ResponseWriter, request *http.Request) {
 	fromStr := middleware.GetFromStr(request)
 	toStr := middleware.GetToStr(request)
 
-	if fromStr != "-inf" && fromStr != "+inf" {
+	if fromStr != "-inf" {
 		from := date.DateParamToEpoch(fromStr, "UTC", 0, time.UTC)
 		if from == 0 {
 			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("can not parse from: %s", fromStr))) //nolint
@@ -62,7 +62,7 @@ func getEventsList(writer http.ResponseWriter, request *http.Request) {
 		fromStr = strconv.FormatInt(from, 10)
 	}
 
-	if toStr != "-inf" && toStr != "+inf" {
+	if toStr != "+inf" {
 		to := date.DateParamToEpoch(toStr, "UTC", 0, time.UTC)
 		if to == 0 {
 			render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("can not parse to: %v", to))) //nolint

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -14,13 +14,15 @@ import (
 	"github.com/moira-alert/moira/api/middleware"
 )
 
+const allMetrics = ".*"
+
 func event(router chi.Router) {
 	router.With(
 		middleware.TriggerContext,
 		middleware.Paginate(0, 100),
 		middleware.DateRange("-3hour", "now"),
-		middleware.MetricProvider("*"),
-		middleware.StatesProvider(nil),
+		middleware.MetricProvider(allMetrics),
+		middleware.StatesProvider(),
 	).Get("/{triggerId}", getEventsList)
 	router.With(middleware.AdminOnlyMiddleware()).Delete("/all", deleteAllEvents)
 }
@@ -36,7 +38,7 @@ func event(router chi.Router) {
 //	@param		p					query		int									false	"Defines the number of the displayed page. E.g, p=2 would display the 2nd page"	default(0)
 //	@param		from			query		string							false	"Start time of the time range"	default(-3hour)
 //	@param		to				query		string							false	"End time of the time range"	default(now)
-//	@param		metric		query		string							false	"Regular expression that will be used to filter events"	default(*)
+//	@param		metric		query		string							false	"Regular expression that will be used to filter events"	default(.*)
 //	@param		states		query		string							false "String of ',' separated state names. If empty then all states will be used." default()
 //	@success	200			{object}	dto.EventsList					"Events fetched successfully"
 //	@Failure	400			{object}	api.ErrorInvalidRequestExample	"Bad request from client"

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -14,14 +14,12 @@ import (
 	"github.com/moira-alert/moira/api/middleware"
 )
 
-const allMetrics = ".*"
-
 func event(router chi.Router) {
 	router.With(
 		middleware.TriggerContext,
-		middleware.Paginate(0, 100),
-		middleware.DateRange("-3hour", "now"),
-		middleware.MetricProvider(allMetrics),
+		middleware.Paginate(eventDefaultPage, eventDefaultSize),
+		middleware.DateRange(eventDefaultFrom, eventDefaultTo),
+		middleware.MetricProvider(eventDefaultMetric),
 		middleware.StatesProvider(),
 	).Get("/{triggerId}", getEventsList)
 	router.With(middleware.AdminOnlyMiddleware()).Delete("/all", deleteAllEvents)
@@ -34,7 +32,7 @@ func event(router chi.Router) {
 //	@tags		event
 //	@produce	json
 //	@param		triggerID	path		string							true	"The ID of updated trigger"														default(bcba82f5-48cf-44c0-b7d6-e1d32c64a88c)
-//	@param		size			query		int									false	"Number of items to be displayed on one page"									default(100)
+//	@param		size			query		int									false	"Number of items to be displayed on one page. if size = -1 then all events returned"	default(-1)
 //	@param		p					query		int									false	"Defines the number of the displayed page. E.g, p=2 would display the 2nd page"	default(0)
 //	@param		from			query		string							false	"Start time of the time range"	default(-3hour)
 //	@param		to				query		string							false	"End time of the time range"	default(now)
@@ -66,15 +64,15 @@ func getEventsList(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	metricStr := middleware.GetMetric(request)
-	metricPattern, errParseRegex := regexp.Compile(metricStr)
-	if errParseRegex != nil {
-		_ = render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("can not parse metric \"%s\": %w", metricStr, errParseRegex)))
+	metricRegexp, errCompile := regexp.Compile(metricStr)
+	if errCompile != nil {
+		_ = render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("can not parse metric \"%s\": %w", metricStr, errCompile)))
 		return
 	}
 
 	states := middleware.GetStates(request)
 
-	eventsList, err := controller.GetTriggerEvents(database, triggerID, page, size, from, to, metricPattern, states)
+	eventsList, err := controller.GetTriggerEvents(database, triggerID, page, size, from, to, metricRegexp, states)
 	if err != nil {
 		render.Render(writer, request, err) //nolint
 		return

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -2,10 +2,11 @@ package handler
 
 import (
 	"fmt"
-	"github.com/go-graphite/carbonapi/date"
 	"net/http"
 	"regexp"
 	"time"
+
+	"github.com/go-graphite/carbonapi/date"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -38,7 +38,7 @@ func event(router chi.Router) {
 //	@param		from			query		string							false	"Start time of the time range"	default(-3hour)
 //	@param		to				query		string							false	"End time of the time range"	default(now)
 //	@param		metric		query		string							false	"Regular expression that will be used to filter events"	default(.*)
-//	@param		states		query		string							false "String of ',' separated state names. If empty then all states will be used." default()
+//	@param		states		query		[]string						false "String of ',' separated state names. If empty then all states will be used." collectionFormat(csv) default()
 //	@success	200			{object}	dto.EventsList					"Events fetched successfully"
 //	@Failure	400			{object}	api.ErrorInvalidRequestExample	"Bad request from client"
 //	@Failure	404			{object}	api.ErrorNotFoundExample		"Resource not found"

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -38,7 +38,7 @@ func event(router chi.Router) {
 //	@param		from			query		string							false	"Start time of the time range"	default(-3hour)
 //	@param		to				query		string							false	"End time of the time range"	default(now)
 //	@param		metric		query		string							false	"Regular expression that will be used to filter events"	default(.*)
-//	@param		states		query		[]string						false "String of ',' separated state names. If empty then all states will be used." collectionFormat(csv) default()
+//	@param		states		query		[]string						false "String of ',' separated state names. If empty then all states will be used." collectionFormat(csv)
 //	@success	200			{object}	dto.EventsList					"Events fetched successfully"
 //	@Failure	400			{object}	api.ErrorInvalidRequestExample	"Bad request from client"
 //	@Failure	404			{object}	api.ErrorNotFoundExample		"Resource not found"

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -185,11 +185,13 @@ func checkingTemplateFilling(request *http.Request, trigger dto.Trigger) *api.Er
 		size = 3
 		from = 0
 	)
+
 	var (
 		to              = time.Now().Unix()
 		allMetricRegexp = regexp.MustCompile(allMetricsPattern)
 		allStates       map[string]struct{}
 	)
+
 	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, page, size, from, to, allMetricRegexp, allStates)
 	if err != nil {
 		return err

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -183,16 +183,14 @@ func checkingTemplateFilling(request *http.Request, trigger dto.Trigger) *api.Er
 	const (
 		page = 0
 		size = 3
-		from = 0
 	)
 
 	var (
-		to              = time.Now().Unix()
 		allMetricRegexp = regexp.MustCompile(allMetricsPattern)
 		allStates       map[string]struct{}
 	)
 
-	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, page, size, from, to, allMetricRegexp, allStates)
+	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, page, size, eventDefaultFrom, eventDefaultTo, allMetricRegexp, allStates)
 	if err != nil {
 		return err
 	}

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -180,7 +180,6 @@ func checkingTemplateFilling(request *http.Request, trigger dto.Trigger) *api.Er
 		return nil
 	}
 
-	allMetrics := "*"
 	metricPattern := regexp.MustCompile(allMetrics)
 	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, 0, 3, 1, time.Now().Unix(), metricPattern, nil)
 	if err != nil {

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -180,8 +180,12 @@ func checkingTemplateFilling(request *http.Request, trigger dto.Trigger) *api.Er
 		return nil
 	}
 
-	metricPattern := regexp.MustCompile(allMetrics)
-	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, 0, 3, 1, time.Now().Unix(), metricPattern, nil)
+	var page int64 = 0
+	var size int64 = 3
+	var from int64 = 0
+	to := time.Now().Unix()
+	metricRegexp := regexp.MustCompile(allMetricsPattern)
+	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, page, size, from, to, metricRegexp, nil)
 	if err != nil {
 		return err
 	}

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -180,12 +180,17 @@ func checkingTemplateFilling(request *http.Request, trigger dto.Trigger) *api.Er
 		return nil
 	}
 
-	var page int64 = 0
-	var size int64 = 3
-	var from int64 = 0
-	to := time.Now().Unix()
-	metricRegexp := regexp.MustCompile(allMetricsPattern)
-	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, page, size, from, to, metricRegexp, nil)
+	const (
+		page = 0
+		size = 3
+		from = 0
+	)
+	var (
+		to              = time.Now().Unix()
+		allMetricRegexp = regexp.MustCompile(allMetricsPattern)
+		allStates       map[string]struct{}
+	)
+	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, page, size, from, to, allMetricRegexp, allStates)
 	if err != nil {
 		return err
 	}

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/go-chi/chi"
@@ -179,7 +180,9 @@ func checkingTemplateFilling(request *http.Request, trigger dto.Trigger) *api.Er
 		return nil
 	}
 
-	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, 0, 3)
+	allMetrics := "*"
+	metricPattern := regexp.MustCompile(allMetrics)
+	eventsList, err := controller.GetTriggerEvents(database, trigger.ID, 0, 3, 1, time.Now().Unix(), metricPattern, nil)
 	if err != nil {
 		return err
 	}

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -420,7 +420,7 @@ func TestGetTriggerWithTriggerSource(t *testing.T) {
 
 		db.EXPECT().GetTrigger(triggerId).Return(trigger, nil)
 		db.EXPECT().GetTriggerThrottling(triggerId)
-		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
+		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
 		db.EXPECT().GetNotificationEventCount(triggerId, gomock.Any()).Return(int64(0))
 
 		responseWriter := httptest.NewRecorder()
@@ -464,7 +464,7 @@ func TestGetTriggerWithTriggerSource(t *testing.T) {
 
 		db.EXPECT().GetTrigger(triggerId).Return(trigger, nil)
 		db.EXPECT().GetTriggerThrottling(triggerId)
-		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
+		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
 		db.EXPECT().GetNotificationEventCount(triggerId, gomock.Any()).Return(int64(0))
 
 		responseWriter := httptest.NewRecorder()
@@ -508,7 +508,7 @@ func TestGetTriggerWithTriggerSource(t *testing.T) {
 
 		db.EXPECT().GetTrigger(triggerId).Return(trigger, nil)
 		db.EXPECT().GetTriggerThrottling(triggerId)
-		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
+		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
 		db.EXPECT().GetNotificationEventCount(triggerId, gomock.Any()).Return(int64(0))
 
 		responseWriter := httptest.NewRecorder()

--- a/api/handler/trigger_test.go
+++ b/api/handler/trigger_test.go
@@ -420,7 +420,7 @@ func TestGetTriggerWithTriggerSource(t *testing.T) {
 
 		db.EXPECT().GetTrigger(triggerId).Return(trigger, nil)
 		db.EXPECT().GetTriggerThrottling(triggerId)
-		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
+		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
 		db.EXPECT().GetNotificationEventCount(triggerId, gomock.Any()).Return(int64(0))
 
 		responseWriter := httptest.NewRecorder()
@@ -464,7 +464,7 @@ func TestGetTriggerWithTriggerSource(t *testing.T) {
 
 		db.EXPECT().GetTrigger(triggerId).Return(trigger, nil)
 		db.EXPECT().GetTriggerThrottling(triggerId)
-		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
+		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
 		db.EXPECT().GetNotificationEventCount(triggerId, gomock.Any()).Return(int64(0))
 
 		responseWriter := httptest.NewRecorder()
@@ -508,7 +508,7 @@ func TestGetTriggerWithTriggerSource(t *testing.T) {
 
 		db.EXPECT().GetTrigger(triggerId).Return(trigger, nil)
 		db.EXPECT().GetTriggerThrottling(triggerId)
-		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
+		db.EXPECT().GetNotificationEvents(triggerId, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(make([]*moira.NotificationEvent, 0), nil)
 		db.EXPECT().GetNotificationEventCount(triggerId, gomock.Any()).Return(int64(0))
 
 		responseWriter := httptest.NewRecorder()

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -318,7 +318,7 @@ func StatesProvider() func(next http.Handler) http.Handler {
 			if statesStr != "" {
 				statesList := strings.Split(statesStr, statesArraySeparator)
 				for _, state := range statesList {
-					if !moira.IsValidState(state) {
+					if !moira.State(state).IsValid() {
 						_ = render.Render(writer, request, api.ErrorInvalidRequest(fmt.Errorf("bad state in query parameter: %s", state)))
 						return
 					}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -302,8 +302,8 @@ func MetricProvider(defaultMetric string) func(next http.Handler) http.Handler {
 
 const statesArraySeparator = ","
 
-// StatesProvider is a function that gets `states` value from query string and places it in context. If query does not have value sets given value.
-func StatesProvider(defaultStates map[string]struct{}) func(next http.Handler) http.Handler {
+// StatesProvider is a function that gets `states` value from query string and places it in context. If query does not have value empty map will be used.
+func StatesProvider() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			urlValues, err := url.ParseQuery(request.URL.RawQuery)
@@ -312,12 +312,10 @@ func StatesProvider(defaultStates map[string]struct{}) func(next http.Handler) h
 				return
 			}
 
-			var states map[string]struct{}
+			states := make(map[string]struct{}, 0)
 
 			statesStr := urlValues.Get("states")
-			if statesStr == "" {
-				states = defaultStates
-			} else {
+			if statesStr != "" {
 				statesList := strings.Split(statesStr, statesArraySeparator)
 				for _, state := range statesList {
 					if !moira.IsValidState(state) {

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -328,7 +328,7 @@ func StatesProvider(defaultStates map[string]struct{}) func(next http.Handler) h
 				}
 			}
 
-			ctx := context.WithValue(request.Context(), metricContextKey, states)
+			ctx := context.WithValue(request.Context(), stateContextKey, states)
 			next.ServeHTTP(writer, request.WithContext(ctx))
 		})
 	}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -277,3 +277,45 @@ func AuthorizationContext(auth *api.Authorization) func(next http.Handler) http.
 		})
 	}
 }
+
+// MetricProvider is a function that gets `metric` value from query string and places it in context. If query does not have value sets given value.
+func MetricProvider(defaultMetric string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			urlValues, err := url.ParseQuery(request.URL.RawQuery)
+			if err != nil {
+				render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+				return
+			}
+
+			metric := urlValues.Get("metric")
+			if metric == "" {
+				metric = defaultMetric
+			}
+
+			ctx := context.WithValue(request.Context(), metricContextKey, metric)
+			next.ServeHTTP(writer, request.WithContext(ctx))
+		})
+	}
+}
+
+// StateProvider is a function that gets `state` value from query string and places it in context. If query does not have value sets given value.
+func StateProvider(defaultState string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			urlValues, err := url.ParseQuery(request.URL.RawQuery)
+			if err != nil {
+				render.Render(writer, request, api.ErrorInvalidRequest(err)) //nolint
+				return
+			}
+
+			stateStr := urlValues.Get("state")
+			if stateStr == "" {
+				stateStr = defaultState
+			}
+
+			ctx := context.WithValue(request.Context(), metricContextKey, stateStr)
+			next.ServeHTTP(writer, request.WithContext(ctx))
+		})
+	}
+}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -326,7 +326,7 @@ func StatesProvider() func(next http.Handler) http.Handler {
 				}
 			}
 
-			ctx := context.WithValue(request.Context(), stateContextKey, states)
+			ctx := context.WithValue(request.Context(), statesContextKey, states)
 			next.ServeHTTP(writer, request.WithContext(ctx))
 		})
 	}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -279,8 +279,8 @@ func AuthorizationContext(auth *api.Authorization) func(next http.Handler) http.
 	}
 }
 
-// MetricProvider is a function that gets `metric` value from query string and places it in context. If query does not have value sets given value.
-func MetricProvider(defaultMetric string) func(next http.Handler) http.Handler {
+// MetricContext is a function that gets `metric` value from query string and places it in context. If query does not have value sets given value.
+func MetricContext(defaultMetric string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			urlValues, err := url.ParseQuery(request.URL.RawQuery)
@@ -302,8 +302,8 @@ func MetricProvider(defaultMetric string) func(next http.Handler) http.Handler {
 
 const statesArraySeparator = ","
 
-// StatesProvider is a function that gets `states` value from query string and places it in context. If query does not have value empty map will be used.
-func StatesProvider() func(next http.Handler) http.Handler {
+// StatesContext is a function that gets `states` value from query string and places it in context. If query does not have value empty map will be used.
+func StatesContext() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			urlValues, err := url.ParseQuery(request.URL.RawQuery)

--- a/api/middleware/context_test.go
+++ b/api/middleware/context_test.go
@@ -226,7 +226,7 @@ func TestMetricProviderMiddleware(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?metric=test%5C.metric.*", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
-			middlewareFunc := MetricProvider(defaultMetric)
+			middlewareFunc := MetricContext(defaultMetric)
 			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
 
 			wrappedHandler.ServeHTTP(responseWriter, testRequest)
@@ -240,7 +240,7 @@ func TestMetricProviderMiddleware(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?metric%=test", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
-			middlewareFunc := MetricProvider(defaultMetric)
+			middlewareFunc := MetricContext(defaultMetric)
 			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
 
 			wrappedHandler.ServeHTTP(responseWriter, testRequest)
@@ -263,7 +263,7 @@ func TestStatesProviderMiddleware(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?states=OK%2CERROR", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
-			middlewareFunc := StatesProvider()
+			middlewareFunc := StatesContext()
 			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
 
 			wrappedHandler.ServeHTTP(responseWriter, testRequest)
@@ -277,7 +277,7 @@ func TestStatesProviderMiddleware(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?states=OK%2CERROR%2Cwarn", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
-			middlewareFunc := StatesProvider()
+			middlewareFunc := StatesContext()
 			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
 
 			wrappedHandler.ServeHTTP(responseWriter, testRequest)
@@ -291,7 +291,7 @@ func TestStatesProviderMiddleware(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?states%=test", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
-			middlewareFunc := StatesProvider()
+			middlewareFunc := StatesContext()
 			wrappedHandler := middlewareFunc(http.HandlerFunc(handler))
 
 			wrappedHandler.ServeHTTP(responseWriter, testRequest)

--- a/api/middleware/context_test.go
+++ b/api/middleware/context_test.go
@@ -218,11 +218,11 @@ func TestTargetNameMiddleware(t *testing.T) {
 }
 
 func TestMetricProviderMiddleware(t *testing.T) {
-	Convey("checking correctness of parameter", t, func() {
+	Convey("Check metric provider", t, func() {
 		responseWriter := httptest.NewRecorder()
 		defaultMetric := ".*"
 
-		Convey("with correct parameter", func() {
+		Convey("status ok with correct query paramete", func() {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?metric=test%5C.metric.*", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
@@ -236,7 +236,7 @@ func TestMetricProviderMiddleware(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusOK)
 		})
 
-		Convey("with wrong url query parameter", func() {
+		Convey("status bad request with wrong url query parameter", func() {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?metric%=test", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
@@ -256,10 +256,10 @@ func TestMetricProviderMiddleware(t *testing.T) {
 }
 
 func TestStatesProviderMiddleware(t *testing.T) {
-	Convey("checking correctness of parameter", t, func() {
+	Convey("Checking states provide", t, func() {
 		responseWriter := httptest.NewRecorder()
 
-		Convey("with correct parameter", func() {
+		Convey("ok with correct states list", func() {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?states=OK%2CERROR", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
@@ -273,7 +273,7 @@ func TestStatesProviderMiddleware(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusOK)
 		})
 
-		Convey("with incorrect parameter", func() {
+		Convey("bad request with bad states list", func() {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?states=OK%2CERROR%2Cwarn", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 
@@ -287,7 +287,7 @@ func TestStatesProviderMiddleware(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 
-		Convey("with wrong url query parameter", func() {
+		Convey("bad request with wrong url query parameter", func() {
 			testRequest := httptest.NewRequest(http.MethodGet, "/test?states%=test", nil)
 			handler := func(w http.ResponseWriter, r *http.Request) {}
 

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -126,7 +126,7 @@ func SetTimeSeriesNames(request *http.Request, timeSeriesNames map[string]bool) 
 	*request = *request.WithContext(ctx)
 }
 
-// GetTimeSeriesNames gets from requests context timeSeriesNames from saved trigger.
+// GetTimeSeriesNames gets from request's context timeSeriesNames from saved trigger.
 func GetTimeSeriesNames(request *http.Request) map[string]bool {
 	return request.Context().Value(timeSeriesNamesKey).(map[string]bool)
 }

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -63,7 +63,7 @@ func GetTriggerID(request *http.Request) string {
 	return request.Context().Value(triggerIDKey).(string)
 }
 
-// GetLocalMetricTTL gets local metric ttl duration time from request context, which was sets in TriggerContext middleware.
+// GetMetricTTL gets local metric ttl duration time from request context, which was sets in TriggerContext middleware.
 func GetMetricTTL(request *http.Request) map[moira.ClusterKey]time.Duration {
 	return request.Context().Value(clustersMetricTTLKey).(map[moira.ClusterKey]time.Duration)
 }
@@ -118,7 +118,7 @@ func GetToStr(request *http.Request) string {
 	return request.Context().Value(toKey).(string)
 }
 
-// SetTimeSeriesNames sets to requests context timeSeriesNames from saved trigger.
+// SetTimeSeriesNames sets to request's context timeSeriesNames from saved trigger.
 func SetTimeSeriesNames(request *http.Request, timeSeriesNames map[string]bool) {
 	ctx := context.WithValue(request.Context(), timeSeriesNamesKey, timeSeriesNames)
 	*request = *request.WithContext(ctx)
@@ -161,4 +161,26 @@ func SetContextValueForTest(ctx context.Context, key string, value interface{}) 
 // GetAuth gets authorization configuration.
 func GetAuth(request *http.Request) *api.Authorization {
 	return request.Context().Value(authKey).(*api.Authorization)
+}
+
+type metricContextKeyType struct{}
+
+var metricContextKey metricContextKeyType
+
+// TODO: think about list of metrics or regular expression.
+
+// GetMetric is used to retrieve metric name.
+func GetMetric(request *http.Request) string {
+	return request.Context().Value(metricContextKey).(string)
+}
+
+type stateContextKeyType struct{}
+
+var stateContextKey stateContextKeyType
+
+// TODO: think about list of states or regular expression.
+
+// GetStateString is used to retrieve trigger state.
+func GetStateString(request *http.Request) string {
+	return request.Context().Value(stateContextKey).(string)
 }

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -39,6 +39,8 @@ var (
 	teamIDKey            ContextKey = "teamID"
 	teamUserIDKey        ContextKey = "teamUserIDKey"
 	authKey              ContextKey = "auth"
+	metricContextKey     ContextKey = "metric"
+	statesContextKey     ContextKey = "states"
 	anonymousUser                   = "anonymous"
 )
 
@@ -163,16 +165,6 @@ func GetAuth(request *http.Request) *api.Authorization {
 	return request.Context().Value(authKey).(*api.Authorization)
 }
 
-type (
-	metricContextKeyType struct{}
-	stateContextKeyType  struct{}
-)
-
-var (
-	metricContextKey metricContextKeyType
-	stateContextKey  stateContextKeyType
-)
-
 // GetMetric is used to retrieve metric name.
 func GetMetric(request *http.Request) string {
 	return request.Context().Value(metricContextKey).(string)
@@ -180,5 +172,5 @@ func GetMetric(request *http.Request) string {
 
 // GetStates is used to retrieve trigger state.
 func GetStates(request *http.Request) map[string]struct{} {
-	return request.Context().Value(stateContextKey).(map[string]struct{})
+	return request.Context().Value(statesContextKey).(map[string]struct{})
 }

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -163,24 +163,22 @@ func GetAuth(request *http.Request) *api.Authorization {
 	return request.Context().Value(authKey).(*api.Authorization)
 }
 
-type metricContextKeyType struct{}
+type (
+	metricContextKeyType struct{}
+	stateContextKeyType  struct{}
+)
 
-var metricContextKey metricContextKeyType
-
-// TODO: think about list of metrics or regular expression.
+var (
+	metricContextKey metricContextKeyType
+	stateContextKey  stateContextKeyType
+)
 
 // GetMetric is used to retrieve metric name.
 func GetMetric(request *http.Request) string {
 	return request.Context().Value(metricContextKey).(string)
 }
 
-type stateContextKeyType struct{}
-
-var stateContextKey stateContextKeyType
-
-// TODO: think about list of states or regular expression.
-
-// GetStateString is used to retrieve trigger state.
-func GetStateString(request *http.Request) string {
-	return request.Context().Value(stateContextKey).(string)
+// GetStates is used to retrieve trigger state.
+func GetStates(request *http.Request) map[string]struct{} {
+	return request.Context().Value(stateContextKey).(map[string]struct{})
 }

--- a/database/redis/notification_event.go
+++ b/database/redis/notification_event.go
@@ -15,14 +15,14 @@ import (
 var eventsTTL int64 = 3600 * 24 * 30
 
 // GetNotificationEvents gets NotificationEvents by given triggerID and interval. The events are also filtered by time range
-// (`from`, `to` params).
-func (connector *DbConnector) GetNotificationEvents(triggerID string, page, size, from, to int64) ([]*moira.NotificationEvent, error) {
+// with `from`, `to` params (`from` and `to` should be "+inf", "-inf" or int64 converted to string).
+func (connector *DbConnector) GetNotificationEvents(triggerID string, page, size int64, from, to string) ([]*moira.NotificationEvent, error) {
 	ctx := connector.Context()
 	client := connector.Client()
 
 	eventsData, err := reply.Events(client.ZRevRangeByScore(ctx, triggerEventsKey(triggerID), &redis.ZRangeBy{
-		Min:    strconv.FormatInt(from, 10),
-		Max:    strconv.FormatInt(to, 10),
+		Min:    from,
+		Max:    to,
 		Offset: page * size,
 		Count:  size,
 	}))

--- a/database/redis/notification_event.go
+++ b/database/redis/notification_event.go
@@ -73,24 +73,20 @@ func fetchNotificationEvents(ctx context.Context, client redis.UniversalClient, 
 	return eventsData, nil
 }
 
-func filterNotificationEvents(eventsData []*moira.NotificationEvent, metric *regexp.Regexp, states map[string]struct{}) []*moira.NotificationEvent {
-	notificationEvents := make([]*moira.NotificationEvent, 0)
+func filterNotificationEvents(notificationEvents []*moira.NotificationEvent, metric *regexp.Regexp, states map[string]struct{}) []*moira.NotificationEvent {
+	filteredNotificationEvents := make([]*moira.NotificationEvent, 0)
 
-	for _, event := range eventsData {
+	for _, event := range notificationEvents {
 		if metric.MatchString(event.Metric) {
-			if len(states) == 0 {
-				notificationEvents = append(notificationEvents, event)
-				continue
-			}
-
-			if _, ok := states[string(event.State)]; ok {
-				notificationEvents = append(notificationEvents, event)
+			_, ok := states[string(event.State)]
+			if len(states) == 0 || ok {
+				filteredNotificationEvents = append(filteredNotificationEvents, event)
 				continue
 			}
 		}
 	}
 
-	return notificationEvents
+	return filteredNotificationEvents
 }
 
 // PushNotificationEvent adds new NotificationEvent to events list and to given triggerID events list and deletes events who are older than 30 days.

--- a/database/redis/notification_event_test.go
+++ b/database/redis/notification_event_test.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
@@ -17,15 +16,11 @@ const (
 	triggerID1 = "7854DE02-0E4B-4430-A570-B0C0162755E4"
 	triggerID2 = "26D3C4E4-507E-4930-9B1E-FD5AD369445C"
 	triggerID3 = "F0F4A5B9-637C-4933-AA0D-88B9798A2630" //nolint
-	triggerID4 = "12345c33-eab3-4ad4-aa03-82a9560adad9"
-	triggerID5 = "STATE5B9-637C-4933-AA0D-88B9798A2630"
 )
 
 var (
-	now        = time.Now().Unix()
-	value      = float64(0)
-	allMetrics = regexp.MustCompile(".*")
-	allStates  map[string]struct{}
+	now   = time.Now().Unix()
+	value = float64(0)
 )
 
 // nolint
@@ -38,7 +33,7 @@ func TestNotificationEvents(t *testing.T) {
 	Convey("Notification events manipulation", t, func() {
 		Convey("Test push-get-get count-fetch", func() {
 			Convey("Should no events", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, make([]*moira.NotificationEvent, 0))
 
@@ -62,7 +57,7 @@ func TestNotificationEvents(t *testing.T) {
 				}, true)
 				So(err, ShouldBeNil)
 
-				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -91,7 +86,7 @@ func TestNotificationEvents(t *testing.T) {
 			})
 
 			Convey("Should has event by triggerID after fetch", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -137,7 +132,7 @@ func TestNotificationEvents(t *testing.T) {
 				}, true)
 				So(err, ShouldBeNil)
 
-				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, 0, now, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, 0, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -153,7 +148,7 @@ func TestNotificationEvents(t *testing.T) {
 				total := dataBase.GetNotificationEventCount(triggerID1, 0)
 				So(total, ShouldEqual, 1)
 
-				actual, err = dataBase.GetNotificationEvents(triggerID2, 0, 1, 0, now, allMetrics, allStates)
+				actual, err = dataBase.GetNotificationEvents(triggerID2, 0, 1, 0, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -182,7 +177,7 @@ func TestNotificationEvents(t *testing.T) {
 					Values:    map[string]float64{},
 				})
 
-				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, 0, now, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, 0, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -228,7 +223,7 @@ func TestNotificationEvents(t *testing.T) {
 			}, true)
 			So(err, ShouldBeNil)
 
-			actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, 0, now, allMetrics, allStates)
+			actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, 0, now)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.NotificationEvent{
 				{
@@ -253,7 +248,7 @@ func TestNotificationEvents(t *testing.T) {
 			total = dataBase.GetNotificationEventCount(triggerID3, now+1)
 			So(total, ShouldEqual, 0)
 
-			actual, err = dataBase.GetNotificationEvents(triggerID3, 1, 1, 0, now, allMetrics, allStates)
+			actual, err = dataBase.GetNotificationEvents(triggerID3, 1, 1, 0, now)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, make([]*moira.NotificationEvent, 0))
 		})
@@ -269,7 +264,7 @@ func TestNotificationEvents(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			Convey("returns event on exact time", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now, now, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now, now)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -284,13 +279,13 @@ func TestNotificationEvents(t *testing.T) {
 			})
 
 			Convey("not return event out of time range", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now-2, now-1, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now-2, now-1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{})
 			})
 
 			Convey("returns event in time range", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now-1, now+1, allMetrics, allStates)
+				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now-1, now+1)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -299,138 +294,6 @@ func TestNotificationEvents(t *testing.T) {
 						OldState:  moira.StateNODATA,
 						TriggerID: triggerID3,
 						Metric:    "my.metric",
-						Values:    map[string]float64{},
-					},
-				})
-			})
-		})
-
-		Convey("Test metric filtering", func() {
-			err := dataBase.PushNotificationEvent(&moira.NotificationEvent{
-				Timestamp: now,
-				State:     moira.StateEXCEPTION,
-				OldState:  moira.StateNODATA,
-				TriggerID: triggerID4,
-				Metric:    "my.metric.event1",
-			}, true)
-			So(err, ShouldBeNil)
-
-			err = dataBase.PushNotificationEvent(&moira.NotificationEvent{
-				Timestamp: now + 1,
-				State:     moira.StateOK,
-				OldState:  moira.StateWARN,
-				TriggerID: triggerID4,
-				Metric:    "my.metric.event2",
-			}, true)
-			So(err, ShouldBeNil)
-
-			Convey("with same prefix returns all", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID4, 0, -1, 0, now+1, regexp.MustCompile(`my\.metric\.event`), allStates)
-				So(err, ShouldBeNil)
-				So(actual, ShouldResemble, []*moira.NotificationEvent{
-					{
-						Timestamp: now + 1,
-						State:     moira.StateOK,
-						OldState:  moira.StateWARN,
-						TriggerID: triggerID4,
-						Metric:    "my.metric.event2",
-						Values:    map[string]float64{},
-					},
-					{
-						Timestamp: now,
-						State:     moira.StateEXCEPTION,
-						OldState:  moira.StateNODATA,
-						TriggerID: triggerID4,
-						Metric:    "my.metric.event1",
-						Values:    map[string]float64{},
-					},
-				})
-			})
-
-			Convey("with exact metric returns one", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID4, 0, -1, 0, now+1, regexp.MustCompile(`^my\.metric\.event2$`), allStates)
-				So(err, ShouldBeNil)
-				So(actual, ShouldResemble, []*moira.NotificationEvent{
-					{
-						Timestamp: now + 1,
-						State:     moira.StateOK,
-						OldState:  moira.StateWARN,
-						TriggerID: triggerID4,
-						Metric:    "my.metric.event2",
-						Values:    map[string]float64{},
-					},
-				})
-			})
-		})
-
-		Convey("Test states filtering", func() {
-			err := dataBase.PushNotificationEvent(&moira.NotificationEvent{
-				Timestamp: now,
-				State:     moira.StateEXCEPTION,
-				OldState:  moira.StateNODATA,
-				TriggerID: triggerID5,
-				Metric:    "my.metric.event1",
-			}, true)
-			So(err, ShouldBeNil)
-
-			err = dataBase.PushNotificationEvent(&moira.NotificationEvent{
-				Timestamp: now,
-				State:     moira.StateOK,
-				OldState:  moira.StateWARN,
-				TriggerID: triggerID5,
-				Metric:    "my.metric.event2",
-			}, true)
-			So(err, ShouldBeNil)
-
-			err = dataBase.PushNotificationEvent(&moira.NotificationEvent{
-				Timestamp: now + 1,
-				State:     moira.StateERROR,
-				OldState:  moira.StateOK,
-				TriggerID: triggerID5,
-				Metric:    "my.metric.event2",
-			}, true)
-			So(err, ShouldBeNil)
-
-			Convey("with 1 state 1 returned", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID5, 0, -1, 0, now+1, allMetrics,
-					map[string]struct{}{
-						"OK": {},
-					})
-				So(err, ShouldBeNil)
-				So(actual, ShouldResemble, []*moira.NotificationEvent{
-					{
-						Timestamp: now,
-						State:     moira.StateOK,
-						OldState:  moira.StateWARN,
-						TriggerID: triggerID5,
-						Metric:    "my.metric.event2",
-						Values:    map[string]float64{},
-					},
-				})
-			})
-
-			Convey("with 2 state 2 returned", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID5, 0, -1, 0, now+1, allMetrics,
-					map[string]struct{}{
-						"OK":    {},
-						"ERROR": {},
-					})
-				So(err, ShouldBeNil)
-				So(actual, ShouldResemble, []*moira.NotificationEvent{
-					{
-						Timestamp: now + 1,
-						State:     moira.StateERROR,
-						OldState:  moira.StateOK,
-						TriggerID: triggerID5,
-						Metric:    "my.metric.event2",
-						Values:    map[string]float64{},
-					},
-					{
-						Timestamp: now,
-						State:     moira.StateOK,
-						OldState:  moira.StateWARN,
-						TriggerID: triggerID5,
-						Metric:    "my.metric.event2",
 						Values:    map[string]float64{},
 					},
 				})
@@ -496,7 +359,7 @@ func TestNotificationEventErrorConnection(t *testing.T) {
 	}
 
 	Convey("Should throw error when no connection", t, func() {
-		actual1, err := dataBase.GetNotificationEvents("123", 0, 1, 0, time.Now().Unix(), allMetrics, nil)
+		actual1, err := dataBase.GetNotificationEvents("123", 0, 1, 0, time.Now().Unix())
 		So(actual1, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 

--- a/database/redis/notification_event_test.go
+++ b/database/redis/notification_event_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -19,8 +20,10 @@ const (
 )
 
 var (
-	now   = time.Now().Unix()
-	value = float64(0)
+	allTimeFrom = "-inf"
+	allTimeTo   = "+inf"
+	now         = time.Now().Unix()
+	value       = float64(0)
 )
 
 // nolint
@@ -33,7 +36,7 @@ func TestNotificationEvents(t *testing.T) {
 	Convey("Notification events manipulation", t, func() {
 		Convey("Test push-get-get count-fetch", func() {
 			Convey("Should no events", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now)
+				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, allTimeFrom, allTimeTo)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, make([]*moira.NotificationEvent, 0))
 
@@ -57,7 +60,7 @@ func TestNotificationEvents(t *testing.T) {
 				}, true)
 				So(err, ShouldBeNil)
 
-				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now)
+				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, allTimeFrom, allTimeTo)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -86,7 +89,7 @@ func TestNotificationEvents(t *testing.T) {
 			})
 
 			Convey("Should has event by triggerID after fetch", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, 0, now)
+				actual, err := dataBase.GetNotificationEvents(triggerID, 0, 1, allTimeFrom, allTimeTo)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -132,7 +135,7 @@ func TestNotificationEvents(t *testing.T) {
 				}, true)
 				So(err, ShouldBeNil)
 
-				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, 0, now)
+				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, allTimeFrom, allTimeTo)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -148,7 +151,7 @@ func TestNotificationEvents(t *testing.T) {
 				total := dataBase.GetNotificationEventCount(triggerID1, 0)
 				So(total, ShouldEqual, 1)
 
-				actual, err = dataBase.GetNotificationEvents(triggerID2, 0, 1, 0, now)
+				actual, err = dataBase.GetNotificationEvents(triggerID2, 0, 1, allTimeFrom, allTimeTo)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -177,7 +180,7 @@ func TestNotificationEvents(t *testing.T) {
 					Values:    map[string]float64{},
 				})
 
-				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, 0, now)
+				actual, err := dataBase.GetNotificationEvents(triggerID1, 0, 1, allTimeFrom, allTimeTo)
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -223,7 +226,7 @@ func TestNotificationEvents(t *testing.T) {
 			}, true)
 			So(err, ShouldBeNil)
 
-			actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, 0, now)
+			actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, allTimeFrom, allTimeTo)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, []*moira.NotificationEvent{
 				{
@@ -248,7 +251,7 @@ func TestNotificationEvents(t *testing.T) {
 			total = dataBase.GetNotificationEventCount(triggerID3, now+1)
 			So(total, ShouldEqual, 0)
 
-			actual, err = dataBase.GetNotificationEvents(triggerID3, 1, 1, 0, now)
+			actual, err = dataBase.GetNotificationEvents(triggerID3, 1, 1, allTimeFrom, allTimeTo)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, make([]*moira.NotificationEvent, 0))
 		})
@@ -264,7 +267,7 @@ func TestNotificationEvents(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			Convey("returns event on exact time", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now, now)
+				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, strconv.FormatInt(now, 10), strconv.FormatInt(now, 10))
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -279,13 +282,13 @@ func TestNotificationEvents(t *testing.T) {
 			})
 
 			Convey("not return event out of time range", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now-2, now-1)
+				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, strconv.FormatInt(now-2, 10), strconv.FormatInt(now-1, 10))
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{})
 			})
 
 			Convey("returns event in time range", func() {
-				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, now-1, now+1)
+				actual, err := dataBase.GetNotificationEvents(triggerID3, 0, 1, strconv.FormatInt(now-1, 10), strconv.FormatInt(now+1, 10))
 				So(err, ShouldBeNil)
 				So(actual, ShouldResemble, []*moira.NotificationEvent{
 					{
@@ -359,7 +362,7 @@ func TestNotificationEventErrorConnection(t *testing.T) {
 	}
 
 	Convey("Should throw error when no connection", t, func() {
-		actual1, err := dataBase.GetNotificationEvents("123", 0, 1, 0, time.Now().Unix())
+		actual1, err := dataBase.GetNotificationEvents("123", 0, 1, allTimeFrom, allTimeTo)
 		So(actual1, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,6 +1,7 @@
 package moira
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/moira-alert/go-chart"
@@ -60,7 +61,7 @@ type Database interface {
 	DeleteTriggerThrottling(triggerID string) error
 
 	// NotificationEvent storing
-	GetNotificationEvents(triggerID string, start, size, from, to int64, metric string, state State) ([]*NotificationEvent, error)
+	GetNotificationEvents(triggerID string, start, size, from, to int64, metric *regexp.Regexp, states map[string]struct{}) ([]*NotificationEvent, error)
 	PushNotificationEvent(event *NotificationEvent, ui bool) error
 	GetNotificationEventCount(triggerID string, from int64) int64
 	FetchNotificationEvent() (NotificationEvent, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -60,7 +60,7 @@ type Database interface {
 	DeleteTriggerThrottling(triggerID string) error
 
 	// NotificationEvent storing
-	GetNotificationEvents(triggerID string, start, size, from, to int64) ([]*NotificationEvent, error)
+	GetNotificationEvents(triggerID string, start, size int64, from, to string) ([]*NotificationEvent, error)
 	PushNotificationEvent(event *NotificationEvent, ui bool) error
 	GetNotificationEventCount(triggerID string, from int64) int64
 	FetchNotificationEvent() (NotificationEvent, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -60,7 +60,7 @@ type Database interface {
 	DeleteTriggerThrottling(triggerID string) error
 
 	// NotificationEvent storing
-	GetNotificationEvents(triggerID string, start, size int64) ([]*NotificationEvent, error)
+	GetNotificationEvents(triggerID string, start, size, from, to int64, metric string, state State) ([]*NotificationEvent, error)
 	PushNotificationEvent(event *NotificationEvent, ui bool) error
 	GetNotificationEventCount(triggerID string, from int64) int64
 	FetchNotificationEvent() (NotificationEvent, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,7 +1,6 @@
 package moira
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/moira-alert/go-chart"
@@ -61,7 +60,7 @@ type Database interface {
 	DeleteTriggerThrottling(triggerID string) error
 
 	// NotificationEvent storing
-	GetNotificationEvents(triggerID string, start, size, from, to int64, metric *regexp.Regexp, states map[string]struct{}) ([]*NotificationEvent, error)
+	GetNotificationEvents(triggerID string, start, size, from, to int64) ([]*NotificationEvent, error)
 	PushNotificationEvent(event *NotificationEvent, ui bool) error
 	GetNotificationEventCount(triggerID string, from int64) int64
 	FetchNotificationEvent() (NotificationEvent, error)

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -11,7 +11,6 @@ package mock_moira_alert
 
 import (
 	reflect "reflect"
-	regexp "regexp"
 	time "time"
 
 	moira "github.com/moira-alert/moira"
@@ -477,18 +476,18 @@ func (mr *MockDatabaseMockRecorder) GetNotificationEventCount(arg0, arg1 any) *g
 }
 
 // GetNotificationEvents mocks base method.
-func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2, arg3, arg4 int64, arg5 *regexp.Regexp, arg6 map[string]struct{}) ([]*moira.NotificationEvent, error) {
+func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2, arg3, arg4 int64) ([]*moira.NotificationEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]*moira.NotificationEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNotificationEvents indicates an expected call of GetNotificationEvents.
-func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetNotifications mocks base method.

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -191,7 +191,7 @@ func (m *MockDatabase) CleanUpOutdatedNotificationHistory(arg0 int64) error {
 }
 
 // CleanUpOutdatedNotificationHistory indicates an expected call of CleanUpOutdatedNotificationHistory.
-func (mr *MockDatabaseMockRecorder) CleanUpOutdatedNotificationHistory(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CleanUpOutdatedNotificationHistory(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpOutdatedNotificationHistory", reflect.TypeOf((*MockDatabase)(nil).CleanUpOutdatedNotificationHistory), arg0)
 }
@@ -490,7 +490,7 @@ func (mr *MockDatabaseMockRecorder) GetNotificationEventCount(arg0, arg1 any) *g
 }
 
 // GetNotificationEvents mocks base method.
-func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2, arg3, arg4 int64) ([]*moira.NotificationEvent, error) {
+func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2 int64, arg3, arg4 string) ([]*moira.NotificationEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]*moira.NotificationEvent)
@@ -520,7 +520,7 @@ func (mr *MockDatabaseMockRecorder) GetNotifications(arg0, arg1 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifications", reflect.TypeOf((*MockDatabase)(nil).GetNotifications), arg0, arg1)
 }
 
-// GetNotificationsHistoryByContactId mocks base method.
+// GetNotificationsHistoryByContactID mocks base method.
 func (m *MockDatabase) GetNotificationsHistoryByContactID(arg0 string, arg1, arg2, arg3, arg4 int64) ([]*moira.NotificationEventHistoryItem, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNotificationsHistoryByContactID", arg0, arg1, arg2, arg3, arg4)
@@ -529,8 +529,8 @@ func (m *MockDatabase) GetNotificationsHistoryByContactID(arg0 string, arg1, arg
 	return ret0, ret1
 }
 
-// GetNotificationsHistoryByContactId indicates an expected call of GetNotificationsHistoryByContactId.
-func (mr *MockDatabaseMockRecorder) GetNotificationsHistoryByContactId(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+// GetNotificationsHistoryByContactID indicates an expected call of GetNotificationsHistoryByContactID.
+func (mr *MockDatabaseMockRecorder) GetNotificationsHistoryByContactID(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationsHistoryByContactID", reflect.TypeOf((*MockDatabase)(nil).GetNotificationsHistoryByContactID), arg0, arg1, arg2, arg3, arg4)
 }

--- a/mock/moira-alert/database.go
+++ b/mock/moira-alert/database.go
@@ -11,6 +11,7 @@ package mock_moira_alert
 
 import (
 	reflect "reflect"
+	regexp "regexp"
 	time "time"
 
 	moira "github.com/moira-alert/moira"
@@ -476,18 +477,18 @@ func (mr *MockDatabaseMockRecorder) GetNotificationEventCount(arg0, arg1 any) *g
 }
 
 // GetNotificationEvents mocks base method.
-func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2 int64) ([]*moira.NotificationEvent, error) {
+func (m *MockDatabase) GetNotificationEvents(arg0 string, arg1, arg2, arg3, arg4 int64, arg5 *regexp.Regexp, arg6 map[string]struct{}) ([]*moira.NotificationEvent, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetNotificationEvents", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].([]*moira.NotificationEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNotificationEvents indicates an expected call of GetNotificationEvents.
-func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetNotificationEvents(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotificationEvents", reflect.TypeOf((*MockDatabase)(nil).GetNotificationEvents), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // GetNotifications mocks base method.

--- a/mock/scheduler/scheduler.go
+++ b/mock/scheduler/scheduler.go
@@ -48,7 +48,7 @@ func (m *MockScheduler) ScheduleNotification(arg0 moira.SchedulerParams, arg1 mo
 }
 
 // ScheduleNotification indicates an expected call of ScheduleNotification.
-func (mr *MockSchedulerMockRecorder) ScheduleNotification(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSchedulerMockRecorder) ScheduleNotification(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleNotification", reflect.TypeOf((*MockScheduler)(nil).ScheduleNotification), arg0, arg1)
 }

--- a/state.go
+++ b/state.go
@@ -22,6 +22,15 @@ var (
 	StateTEST      State = "TEST"      // Use this only for test notifications
 )
 
+var validStates = map[string]struct{}{
+	string(StateOK):        {},
+	string(StateWARN):      {},
+	string(StateERROR):     {},
+	string(StateNODATA):    {},
+	string(StateEXCEPTION): {},
+	string(StateTEST):      {},
+}
+
 // Moira ttl states.
 var (
 	TTLStateOK     TTLState = "OK"
@@ -59,6 +68,11 @@ func (state State) ToSelfState() string {
 		return SelfStateERROR
 	}
 	return SelfStateOK
+}
+
+func IsValidState(strState string) bool {
+	_, ok := validStates[strState]
+	return ok
 }
 
 // ToMetricState is an auxiliary function to handle metric state properly.

--- a/state.go
+++ b/state.go
@@ -22,15 +22,6 @@ var (
 	StateTEST      State = "TEST"      // Use this only for test notifications
 )
 
-var validStates = map[string]struct{}{
-	string(StateOK):        {},
-	string(StateWARN):      {},
-	string(StateERROR):     {},
-	string(StateNODATA):    {},
-	string(StateEXCEPTION): {},
-	string(StateTEST):      {},
-}
-
 // Moira ttl states.
 var (
 	TTLStateOK     TTLState = "OK"
@@ -70,9 +61,14 @@ func (state State) ToSelfState() string {
 	return SelfStateOK
 }
 
-func IsValidState(strState string) bool {
-	_, ok := validStates[strState]
-	return ok
+// IsValid checks if  valid State.
+func (state State) IsValid() bool {
+	switch state {
+	case StateOK, StateWARN, StateERROR, StateNODATA, StateEXCEPTION, StateTEST:
+		return true
+	default:
+		return false
+	}
 }
 
 // ToMetricState is an auxiliary function to handle metric state properly.

--- a/state.go
+++ b/state.go
@@ -63,12 +63,12 @@ func (state State) ToSelfState() string {
 
 // IsValid checks if  valid State.
 func (state State) IsValid() bool {
-	switch state {
-	case StateOK, StateWARN, StateERROR, StateNODATA, StateEXCEPTION, StateTEST:
-		return true
-	default:
-		return false
+	for _, allowedState := range eventStatesPriority {
+		if state == allowedState {
+			return true
+		}
 	}
+	return false
 }
 
 // ToMetricState is an auxiliary function to handle metric state properly.


### PR DESCRIPTION
# Add query parameters to `/api/event/{trigger_id}`

Offered query parameters are:
- `from` - start of time range (default value `-inf`)
- `to` - end of time range (default value `+inf`)
- `metric` - regular expression which will be used on `NotificationEvent.Metric` field (default value `.*`)
- `states` - separated string of states, separator is `','`, if empty means all states (empty by default)
