### PR TITLE
feat(api): contact template validation

### DIFF
--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -54,7 +54,7 @@ func GetContactById(database moira.Database, contactID string) (*dto.Contact, *a
 func CreateContact(
 	dataBase moira.Database,
 	auth *api.Authorization,
-	webConfig *api.WebConfig,
+	contactsTemplate []api.WebContact,
 	contact *dto.Contact,
 	userLogin,
 	teamID string,
@@ -93,7 +93,7 @@ func CreateContact(
 		}
 	}
 
-	if err := validateContact(webConfig, contactData); err != nil {
+	if err := validateContact(contactsTemplate, contactData); err != nil {
 		return api.ErrorInvalidRequest(err)
 	}
 
@@ -112,7 +112,7 @@ func CreateContact(
 func UpdateContact(
 	dataBase moira.Database,
 	auth *api.Authorization,
-	webConfig *api.WebConfig,
+	contactsTemplate []api.WebContact,
 	contactDTO dto.Contact,
 	contactData moira.ContactData,
 ) (dto.Contact, *api.ErrorResponse) {
@@ -129,7 +129,7 @@ func UpdateContact(
 		contactData.Team = contactDTO.TeamID
 	}
 
-	if err := validateContact(webConfig, contactData); err != nil {
+	if err := validateContact(contactsTemplate, contactData); err != nil {
 		return contactDTO, api.ErrorInvalidRequest(err)
 	}
 
@@ -280,9 +280,9 @@ func isAllowedToUseContactType(auth *api.Authorization, userLogin string, contac
 	return isAllowedContactType || isAdmin || !isAuthEnabled
 }
 
-func validateContact(webConfig *api.WebConfig, contact moira.ContactData) error {
+func validateContact(contactsTemplate []api.WebContact, contact moira.ContactData) error {
 	var validationPattern string
-	for _, contactTemplate := range webConfig.Contacts {
+	for _, contactTemplate := range contactsTemplate {
 		if contactTemplate.ContactType == contact.Type {
 			validationPattern = contactTemplate.ValidationRegex
 			break

--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/go-graphite/carbonapi/date"
@@ -53,6 +54,7 @@ func GetContactById(database moira.Database, contactID string) (*dto.Contact, *a
 func CreateContact(
 	dataBase moira.Database,
 	auth *api.Authorization,
+	webConfig *api.WebConfig,
 	contact *dto.Contact,
 	userLogin,
 	teamID string,
@@ -74,6 +76,7 @@ func CreateContact(
 		Type:  contact.Type,
 		Value: contact.Value,
 	}
+
 	if contactData.ID == "" {
 		uuid4, err := uuid.NewV4()
 		if err != nil {
@@ -90,12 +93,18 @@ func CreateContact(
 		}
 	}
 
+	if err := validateContact(webConfig, contactData); err != nil {
+		return api.ErrorInvalidRequest(err)
+	}
+
 	if err := dataBase.SaveContact(&contactData); err != nil {
 		return api.ErrorInternalServer(err)
 	}
+
 	contact.User = contactData.User
 	contact.ID = contactData.ID
 	contact.TeamID = contactData.Team
+
 	return nil
 }
 
@@ -103,6 +112,7 @@ func CreateContact(
 func UpdateContact(
 	dataBase moira.Database,
 	auth *api.Authorization,
+	webConfig *api.WebConfig,
 	contactDTO dto.Contact,
 	contactData moira.ContactData,
 ) (dto.Contact, *api.ErrorResponse) {
@@ -117,6 +127,10 @@ func UpdateContact(
 	if contactDTO.User != "" || contactDTO.TeamID != "" {
 		contactData.User = contactDTO.User
 		contactData.Team = contactDTO.TeamID
+	}
+
+	if err := validateContact(webConfig, contactData); err != nil {
+		return contactDTO, api.ErrorInvalidRequest(err)
 	}
 
 	if err := dataBase.SaveContact(&contactData); err != nil {
@@ -264,4 +278,20 @@ func isAllowedToUseContactType(auth *api.Authorization, userLogin string, contac
 	_, isAllowedContactType := auth.AllowedContactTypes[contactType]
 
 	return isAllowedContactType || isAdmin || !isAuthEnabled
+}
+
+func validateContact(webConfig *api.WebConfig, contact moira.ContactData) error {
+	var validationPattern string
+	for _, contactTemplate := range webConfig.Contacts {
+		if contactTemplate.ContactType == contact.Type {
+			validationPattern = contactTemplate.ValidationRegex
+			break
+		}
+	}
+
+	if matched, err := regexp.MatchString(validationPattern, contact.Value); !matched || err != nil {
+		return fmt.Errorf("contact value doesn't match regex: '%s'", validationPattern)
+	}
+
+	return nil
 }

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -127,12 +127,10 @@ func TestCreateContact(t *testing.T) {
 		},
 	}
 
-	webConfig := &api.WebConfig{
-		Contacts: []api.WebContact{
-			{
-				ContactType:     contactType,
-				ValidationRegex: "@mail.com",
-			},
+	contactsTemplate := []api.WebContact{
+		{
+			ContactType:     contactType,
+			ValidationRegex: "@mail.com",
 		},
 	}
 
@@ -143,7 +141,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -162,7 +160,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, &contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, &contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 			So(contact.ID, ShouldResemble, contact.ID)
@@ -175,7 +173,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
 		})
 
@@ -187,11 +185,11 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-			expected := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			expected := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
-		webConfig.Contacts = []api.WebContact{
+		contactsTemplate = []api.WebContact{
 			{
 				ContactType:     contactType,
 				ValidationRegex: "@yandex.ru",
@@ -204,11 +202,11 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			expectedErr := api.ErrorInvalidRequest(fmt.Errorf("contact value doesn't match regex: '%s'", "@yandex.ru"))
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldResemble, expectedErr)
 		})
 
-		webConfig.Contacts = []api.WebContact{
+		contactsTemplate = []api.WebContact{
 			{
 				ContactType:     contactType,
 				ValidationRegex: "@mail.com",
@@ -222,7 +220,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  notAllowedContactType,
 			}
 			expectedErr := api.ErrorInvalidRequest(ErrNotAllowedContactType)
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldResemble, expectedErr)
 		})
 
@@ -248,7 +246,7 @@ func TestCreateContact(t *testing.T) {
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
 
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldBeNil)
 		})
 
@@ -259,7 +257,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-			expected := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			expected := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
 				HTTPStatusCode: http.StatusInternalServerError,
@@ -276,7 +274,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 		})
@@ -295,7 +293,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, &contact, "", teamID)
+			err := CreateContact(dataBase, auth, contactsTemplate, &contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 			So(contact.ID, ShouldResemble, contact.ID)
@@ -317,7 +315,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, &contact, "", teamID)
+			err := CreateContact(dataBase, auth, contactsTemplate, &contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 			So(contact.Name, ShouldResemble, expectedContact.Name)
@@ -330,7 +328,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, "", teamID)
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
 		})
 
@@ -342,7 +340,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-			expected := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
+			expected := CreateContact(dataBase, auth, contactsTemplate, contact, "", teamID)
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
@@ -353,7 +351,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  notAllowedContactType,
 			}
 			expectedErr := api.ErrorInvalidRequest(ErrNotAllowedContactType)
-			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, "", teamID)
 			So(err, ShouldResemble, expectedErr)
 		})
 
@@ -379,7 +377,7 @@ func TestCreateContact(t *testing.T) {
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
 
-			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, "", teamID)
 			So(err, ShouldBeNil)
 		})
 
@@ -390,7 +388,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-			expected := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
+			expected := CreateContact(dataBase, auth, contactsTemplate, contact, "", teamID)
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
 				HTTPStatusCode: http.StatusInternalServerError,
@@ -422,7 +420,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 		},
 	}
 
-	webConfig := &api.WebConfig{}
+	contactsTemplate := []api.WebContact{}
 
 	Convey("Create for user", t, func() {
 		Convey("The same user", func() {
@@ -432,7 +430,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -444,7 +442,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  adminLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, adminLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, adminLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, adminLogin)
 		})
@@ -456,7 +454,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  adminLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -468,7 +466,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, adminLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, adminLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -480,7 +478,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, webConfig, contact, adminLogin, "")
+			err := CreateContact(dataBase, auth, contactsTemplate, contact, adminLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -507,12 +505,10 @@ func TestUpdateContact(t *testing.T) {
 		},
 	}
 
-	webConfig := &api.WebConfig{
-		Contacts: []api.WebContact{
-			{
-				ContactType:     contactType,
-				ValidationRegex: "@mail.com",
-			},
+	contactsTemplate := []api.WebContact{
+		{
+			ContactType:     contactType,
+			ValidationRegex: "@mail.com",
 		},
 	}
 
@@ -532,7 +528,7 @@ func TestUpdateContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldBeNil)
 			So(expectedContact.User, ShouldResemble, userLogin)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -556,7 +552,7 @@ func TestUpdateContact(t *testing.T) {
 				User:  newUser,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldBeNil)
 			So(expectedContact.User, ShouldResemble, newUser)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -570,14 +566,14 @@ func TestUpdateContact(t *testing.T) {
 			}
 			expectedErr := api.ErrorInvalidRequest(ErrNotAllowedContactType)
 			contactID := uuid.Must(uuid.NewV4()).String()
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldResemble, expectedErr)
 			So(expectedContact.User, ShouldResemble, contactDTO.User)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
 			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
 		})
 
-		webConfig.Contacts = []api.WebContact{
+		contactsTemplate = []api.WebContact{
 			{
 				ContactType:     contactType,
 				ValidationRegex: "@yandex.ru",
@@ -591,14 +587,14 @@ func TestUpdateContact(t *testing.T) {
 			}
 			expectedErr := api.ErrorInvalidRequest(fmt.Errorf("contact value doesn't match regex: '%s'", "@yandex.ru"))
 			contactID := uuid.Must(uuid.NewV4()).String()
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldResemble, expectedErr)
 			So(expectedContact.User, ShouldResemble, contactDTO.User)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
 			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
 		})
 
-		webConfig.Contacts = []api.WebContact{
+		contactsTemplate = []api.WebContact{
 			{
 				ContactType:     contactType,
 				ValidationRegex: "@mail.com",
@@ -626,7 +622,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldBeNil)
 			So(expectedContact.User, ShouldResemble, userLogin)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -647,7 +643,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops")
 			dataBase.EXPECT().SaveContact(&contact).Return(err)
-			expectedContact, actual := UpdateContact(dataBase, auth, webConfig, contactDTO, contact)
+			expectedContact, actual := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, contact)
 			So(actual, ShouldResemble, api.ErrorInternalServer(err))
 			So(expectedContact.User, ShouldResemble, contactDTO.User)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
@@ -668,7 +664,7 @@ func TestUpdateContact(t *testing.T) {
 				Team:  teamID,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
 			So(err, ShouldBeNil)
 			So(expectedContact.TeamID, ShouldResemble, teamID)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -689,7 +685,7 @@ func TestUpdateContact(t *testing.T) {
 				Team:  newTeam,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			expectedContact, err := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
 			So(err, ShouldBeNil)
 			So(expectedContact.TeamID, ShouldResemble, newTeam)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -709,7 +705,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops")
 			dataBase.EXPECT().SaveContact(&contact).Return(err)
-			expectedContact, actual := UpdateContact(dataBase, auth, webConfig, contactDTO, contact)
+			expectedContact, actual := UpdateContact(dataBase, auth, contactsTemplate, contactDTO, contact)
 			So(actual, ShouldResemble, api.ErrorInternalServer(err))
 			So(expectedContact.TeamID, ShouldResemble, contactDTO.TeamID)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
@@ -1050,40 +1046,36 @@ func TestValidateContact(t *testing.T) {
 			Value: contactValue,
 		}
 
-		Convey("With empty webConfig", func() {
-			webConfig := &api.WebConfig{}
+		Convey("With empty contactsTemplate", func() {
+			contactsTemplate := []api.WebContact{}
 
-			err := validateContact(webConfig, contact)
+			err := validateContact(contactsTemplate, contact)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("With not matched regex pattern", func() {
-			webConfig := &api.WebConfig{
-				Contacts: []api.WebContact{
-					{
-						ContactType:     contactType,
-						ValidationRegex: "^9\\d{9}$",
-					},
+			contactsTemplate := []api.WebContact{
+				{
+					ContactType:     contactType,
+					ValidationRegex: "^9\\d{9}$",
 				},
 			}
 
 			notMatchedErr := fmt.Errorf("contact value doesn't match regex: '%s'", "^9\\d{9}$")
 
-			err := validateContact(webConfig, contact)
+			err := validateContact(contactsTemplate, contact)
 			So(err, ShouldResemble, notMatchedErr)
 		})
 
 		Convey("With matched regex pattern", func() {
-			webConfig := &api.WebConfig{
-				Contacts: []api.WebContact{
-					{
-						ContactType:     contactType,
-						ValidationRegex: `^\+79\d{9}$`,
-					},
+			contactsTemplate := []api.WebContact{
+				{
+					ContactType:     contactType,
+					ValidationRegex: `^\+79\d{9}$`,
 				},
 			}
 
-			err := validateContact(webConfig, contact)
+			err := validateContact(contactsTemplate, contact)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -127,6 +127,15 @@ func TestCreateContact(t *testing.T) {
 		},
 	}
 
+	webConfig := &api.WebConfig{
+		Contacts: []api.WebContact{
+			{
+				ContactType:     contactType,
+				ValidationRegex: "@mail.com",
+			},
+		},
+	}
+
 	Convey("Create for user", t, func() {
 		Convey("Success", func() {
 			contact := &dto.Contact{
@@ -134,7 +143,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -153,7 +162,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, auth, &contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, &contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 			So(contact.ID, ShouldResemble, contact.ID)
@@ -166,7 +175,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-			err := CreateContact(dataBase, auth, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
 		})
 
@@ -178,9 +187,33 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-			expected := CreateContact(dataBase, auth, contact, userLogin, "")
+			expected := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
+
+		webConfig.Contacts = []api.WebContact{
+			{
+				ContactType:     contactType,
+				ValidationRegex: "@yandex.ru",
+			},
+		}
+
+		Convey("Error invalid contact value", func() {
+			contact := &dto.Contact{
+				Value: contactValue,
+				Type:  contactType,
+			}
+			expectedErr := api.ErrorInvalidRequest(fmt.Errorf("contact value doesn't match regex: '%s'", "@yandex.ru"))
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
+			So(err, ShouldResemble, expectedErr)
+		})
+
+		webConfig.Contacts = []api.WebContact{
+			{
+				ContactType:     contactType,
+				ValidationRegex: "@mail.com",
+			},
+		}
 
 		Convey("Error create now allowed contact", func() {
 			contact := &dto.Contact{
@@ -189,7 +222,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  notAllowedContactType,
 			}
 			expectedErr := api.ErrorInvalidRequest(ErrNotAllowedContactType)
-			err := CreateContact(dataBase, auth, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(err, ShouldResemble, expectedErr)
 		})
 
@@ -215,7 +248,7 @@ func TestCreateContact(t *testing.T) {
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
 
-			err := CreateContact(dataBase, auth, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(err, ShouldBeNil)
 		})
 
@@ -226,7 +259,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-			expected := CreateContact(dataBase, auth, contact, userLogin, "")
+			expected := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
 				HTTPStatusCode: http.StatusInternalServerError,
@@ -243,7 +276,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, "", teamID)
+			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 		})
@@ -262,7 +295,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, auth, &contact, "", teamID)
+			err := CreateContact(dataBase, auth, webConfig, &contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 			So(contact.ID, ShouldResemble, contact.ID)
@@ -284,7 +317,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
-			err := CreateContact(dataBase, auth, &contact, "", teamID)
+			err := CreateContact(dataBase, auth, webConfig, &contact, "", teamID)
 			So(err, ShouldBeNil)
 			So(contact.TeamID, ShouldResemble, teamID)
 			So(contact.Name, ShouldResemble, expectedContact.Name)
@@ -297,7 +330,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  contactType,
 			}
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, nil)
-			err := CreateContact(dataBase, auth, contact, "", teamID)
+			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
 			So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("contact with this ID already exists")))
 		})
 
@@ -309,7 +342,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, err)
-			expected := CreateContact(dataBase, auth, contact, "", teamID)
+			expected := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
 			So(expected, ShouldResemble, api.ErrorInternalServer(err))
 		})
 
@@ -320,7 +353,7 @@ func TestCreateContact(t *testing.T) {
 				Type:  notAllowedContactType,
 			}
 			expectedErr := api.ErrorInvalidRequest(ErrNotAllowedContactType)
-			err := CreateContact(dataBase, auth, contact, "", teamID)
+			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
 			So(err, ShouldResemble, expectedErr)
 		})
 
@@ -346,7 +379,7 @@ func TestCreateContact(t *testing.T) {
 			dataBase.EXPECT().GetContact(contact.ID).Return(moira.ContactData{}, database.ErrNil)
 			dataBase.EXPECT().SaveContact(&expectedContact).Return(nil)
 
-			err := CreateContact(dataBase, auth, contact, "", teamID)
+			err := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
 			So(err, ShouldBeNil)
 		})
 
@@ -357,7 +390,7 @@ func TestCreateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops! Can not write contact")
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(err)
-			expected := CreateContact(dataBase, auth, contact, "", teamID)
+			expected := CreateContact(dataBase, auth, webConfig, contact, "", teamID)
 			So(expected, ShouldResemble, &api.ErrorResponse{
 				ErrorText:      err.Error(),
 				HTTPStatusCode: http.StatusInternalServerError,
@@ -389,6 +422,8 @@ func TestAdminsCreatesContact(t *testing.T) {
 		},
 	}
 
+	webConfig := &api.WebConfig{}
+
 	Convey("Create for user", t, func() {
 		Convey("The same user", func() {
 			contact := &dto.Contact{
@@ -397,7 +432,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -409,7 +444,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  adminLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, adminLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, adminLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, adminLogin)
 		})
@@ -421,7 +456,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  adminLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, userLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, userLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -433,7 +468,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, adminLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, adminLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -445,7 +480,7 @@ func TestAdminsCreatesContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(gomock.Any()).Return(nil)
-			err := CreateContact(dataBase, auth, contact, adminLogin, "")
+			err := CreateContact(dataBase, auth, webConfig, contact, adminLogin, "")
 			So(err, ShouldBeNil)
 			So(contact.User, ShouldResemble, userLogin)
 		})
@@ -472,6 +507,15 @@ func TestUpdateContact(t *testing.T) {
 		},
 	}
 
+	webConfig := &api.WebConfig{
+		Contacts: []api.WebContact{
+			{
+				ContactType:     contactType,
+				ValidationRegex: "@mail.com",
+			},
+		},
+	}
+
 	Convey("User update", t, func() {
 		Convey("Success", func() {
 			contactDTO := dto.Contact{
@@ -488,7 +532,7 @@ func TestUpdateContact(t *testing.T) {
 				User:  userLogin,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldBeNil)
 			So(expectedContact.User, ShouldResemble, userLogin)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -512,7 +556,7 @@ func TestUpdateContact(t *testing.T) {
 				User:  newUser,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldBeNil)
 			So(expectedContact.User, ShouldResemble, newUser)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -526,12 +570,40 @@ func TestUpdateContact(t *testing.T) {
 			}
 			expectedErr := api.ErrorInvalidRequest(ErrNotAllowedContactType)
 			contactID := uuid.Must(uuid.NewV4()).String()
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldResemble, expectedErr)
 			So(expectedContact.User, ShouldResemble, contactDTO.User)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
 			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
 		})
+
+		webConfig.Contacts = []api.WebContact{
+			{
+				ContactType:     contactType,
+				ValidationRegex: "@yandex.ru",
+			},
+		}
+
+		Convey("Error invalid contact value", func() {
+			contactDTO := dto.Contact{
+				Value: contactValue,
+				Type:  contactType,
+			}
+			expectedErr := api.ErrorInvalidRequest(fmt.Errorf("contact value doesn't match regex: '%s'", "@yandex.ru"))
+			contactID := uuid.Must(uuid.NewV4()).String()
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			So(err, ShouldResemble, expectedErr)
+			So(expectedContact.User, ShouldResemble, contactDTO.User)
+			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
+			So(expectedContact.Name, ShouldResemble, contactDTO.Name)
+		})
+
+		webConfig.Contacts = []api.WebContact{
+			{
+				ContactType:     contactType,
+				ValidationRegex: "@mail.com",
+			},
+		}
 
 		Convey("Successfully update not allowed contact with disabled auth", func() {
 			auth.Enabled = false
@@ -554,7 +626,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, User: userLogin})
 			So(err, ShouldBeNil)
 			So(expectedContact.User, ShouldResemble, userLogin)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -575,7 +647,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops")
 			dataBase.EXPECT().SaveContact(&contact).Return(err)
-			expectedContact, actual := UpdateContact(dataBase, auth, contactDTO, contact)
+			expectedContact, actual := UpdateContact(dataBase, auth, webConfig, contactDTO, contact)
 			So(actual, ShouldResemble, api.ErrorInternalServer(err))
 			So(expectedContact.User, ShouldResemble, contactDTO.User)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
@@ -596,7 +668,7 @@ func TestUpdateContact(t *testing.T) {
 				Team:  teamID,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
 			So(err, ShouldBeNil)
 			So(expectedContact.TeamID, ShouldResemble, teamID)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -617,7 +689,7 @@ func TestUpdateContact(t *testing.T) {
 				Team:  newTeam,
 			}
 			dataBase.EXPECT().SaveContact(&contact).Return(nil)
-			expectedContact, err := UpdateContact(dataBase, auth, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
+			expectedContact, err := UpdateContact(dataBase, auth, webConfig, contactDTO, moira.ContactData{ID: contactID, Team: teamID})
 			So(err, ShouldBeNil)
 			So(expectedContact.TeamID, ShouldResemble, newTeam)
 			So(expectedContact.ID, ShouldResemble, contactID)
@@ -637,7 +709,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 			err := fmt.Errorf("oooops")
 			dataBase.EXPECT().SaveContact(&contact).Return(err)
-			expectedContact, actual := UpdateContact(dataBase, auth, contactDTO, contact)
+			expectedContact, actual := UpdateContact(dataBase, auth, webConfig, contactDTO, contact)
 			So(actual, ShouldResemble, api.ErrorInternalServer(err))
 			So(expectedContact.TeamID, ShouldResemble, contactDTO.TeamID)
 			So(expectedContact.ID, ShouldResemble, contactDTO.ID)
@@ -962,6 +1034,57 @@ func Test_isContactExists(t *testing.T) {
 			actual, err := isContactExists(dataBase, contactID)
 			So(actual, ShouldBeFalse)
 			So(err, ShouldResemble, errReturned)
+		})
+	})
+}
+
+func TestValidateContact(t *testing.T) {
+	const (
+		contactType  = "phone"
+		contactValue = "+79998887766"
+	)
+
+	Convey("Test validateContact", t, func() {
+		contact := moira.ContactData{
+			Type:  contactType,
+			Value: contactValue,
+		}
+
+		Convey("With empty webConfig", func() {
+			webConfig := &api.WebConfig{}
+
+			err := validateContact(webConfig, contact)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("With not matched regex pattern", func() {
+			webConfig := &api.WebConfig{
+				Contacts: []api.WebContact{
+					{
+						ContactType:     contactType,
+						ValidationRegex: "^9\\d{9}$",
+					},
+				},
+			}
+
+			notMatchedErr := fmt.Errorf("contact value doesn't match regex: '%s'", "^9\\d{9}$")
+
+			err := validateContact(webConfig, contact)
+			So(err, ShouldResemble, notMatchedErr)
+		})
+
+		Convey("With matched regex pattern", func() {
+			webConfig := &api.WebConfig{
+				Contacts: []api.WebContact{
+					{
+						ContactType:     contactType,
+						ValidationRegex: `^\+79\d{9}$`,
+					},
+				},
+			}
+
+			err := validateContact(webConfig, contact)
+			So(err, ShouldBeNil)
 		})
 	})
 }

--- a/api/handler/contact.go
+++ b/api/handler/contact.go
@@ -101,8 +101,16 @@ func createNewContact(writer http.ResponseWriter, request *http.Request) {
 
 	userLogin := middleware.GetLogin(request)
 	auth := middleware.GetAuth(request)
+	webConfig := middleware.GetWebConfig(request)
 
-	if err := controller.CreateContact(database, auth, contact, userLogin, contact.TeamID); err != nil {
+	if err := controller.CreateContact(
+		database,
+		auth,
+		webConfig,
+		contact,
+		userLogin,
+		contact.TeamID,
+	); err != nil {
 		render.Render(writer, request, err) //nolint
 		return
 	}
@@ -155,8 +163,15 @@ func updateContact(writer http.ResponseWriter, request *http.Request) {
 	contactData := request.Context().Value(contactKey).(moira.ContactData)
 
 	auth := middleware.GetAuth(request)
+	webConfig := middleware.GetWebConfig(request)
 
-	contactDTO, err := controller.UpdateContact(database, auth, contactDTO, contactData)
+	contactDTO, err := controller.UpdateContact(
+		database,
+		auth,
+		webConfig,
+		contactDTO,
+		contactData,
+	)
 	if err != nil {
 		render.Render(writer, request, err) //nolint
 		return

--- a/api/handler/contact.go
+++ b/api/handler/contact.go
@@ -101,12 +101,12 @@ func createNewContact(writer http.ResponseWriter, request *http.Request) {
 
 	userLogin := middleware.GetLogin(request)
 	auth := middleware.GetAuth(request)
-	webConfig := middleware.GetWebConfig(request)
+	contactsTemplate := middleware.GetContactsTemplate(request)
 
 	if err := controller.CreateContact(
 		database,
 		auth,
-		webConfig,
+		contactsTemplate,
 		contact,
 		userLogin,
 		contact.TeamID,
@@ -163,12 +163,12 @@ func updateContact(writer http.ResponseWriter, request *http.Request) {
 	contactData := request.Context().Value(contactKey).(moira.ContactData)
 
 	auth := middleware.GetAuth(request)
-	webConfig := middleware.GetWebConfig(request)
+	contactsTemplate := middleware.GetContactsTemplate(request)
 
 	contactDTO, err := controller.UpdateContact(
 		database,
 		auth,
-		webConfig,
+		contactsTemplate,
 		contactDTO,
 		contactData,
 	)

--- a/api/handler/contact_test.go
+++ b/api/handler/contact_test.go
@@ -20,13 +20,14 @@ import (
 )
 
 const (
-	ContactIDKey   = "contactID"
-	ContactKey     = "contact"
-	AuthKey        = "auth"
-	LoginKey       = "login"
-	defaultContact = "testContact"
-	defaultLogin   = "testLogin"
-	defaultTeamID  = "testTeamID"
+	testContactIDKey = "contactID"
+	testContactKey   = "contact"
+	testAuthKey      = "auth"
+	testLoginKey     = "login"
+	testWebConfigKey = "webConfig"
+	defaultContact   = "testContact"
+	defaultLogin     = "testLogin"
+	defaultTeamID    = "testTeamID"
 )
 
 func TestGetAllContacts(t *testing.T) {
@@ -136,8 +137,8 @@ func TestGetContactById(t *testing.T) {
 			}
 
 			testRequest := httptest.NewRequest(http.MethodGet, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactIDKey, contactID))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{ID: contactID}))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactIDKey, contactID))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{ID: contactID}))
 
 			getContactById(responseWriter, testRequest)
 
@@ -165,8 +166,8 @@ func TestGetContactById(t *testing.T) {
 			}
 
 			testRequest := httptest.NewRequest(http.MethodGet, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactIDKey, contactID))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{ID: contactID}))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactIDKey, contactID))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{ID: contactID}))
 
 			getContactById(responseWriter, testRequest)
 
@@ -203,6 +204,15 @@ func TestCreateNewContact(t *testing.T) {
 			},
 		}
 
+		webConfig := &api.WebConfig{
+			Contacts: []api.WebContact{
+				{
+					ContactType:     "mail",
+					ValidationRegex: "@skbkontur.ru",
+				},
+			},
+		}
+
 		newContactDto := &dto.Contact{
 			ID:     defaultContact,
 			Name:   "Mail Alerts",
@@ -228,8 +238,9 @@ func TestCreateNewContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), AuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -260,8 +271,9 @@ func TestCreateNewContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -301,8 +313,9 @@ func TestCreateNewContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -332,8 +345,9 @@ func TestCreateNewContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -351,6 +365,52 @@ func TestCreateNewContact(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusInternalServerError)
 		})
 
+		Convey("Invalid request when trying to create a new contact with invalid value", func() {
+			expected := &api.ErrorResponse{
+				StatusText: "Invalid request",
+				ErrorText:  "contact value doesn't match regex: '@yandex.ru'",
+			}
+			jsonContact, err := json.Marshal(newContactDto)
+			So(err, ShouldBeNil)
+
+			webConfig.Contacts = []api.WebContact{
+				{
+					ContactType:     "mail",
+					ValidationRegex: "@yandex.ru",
+				},
+			}
+
+			mockDb.EXPECT().GetContact(newContactDto.ID).Return(moira.ContactData{}, db.ErrNil).Times(1)
+			database = mockDb
+
+			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest.Header.Add("content-type", "application/json")
+
+			createNewContact(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, err := io.ReadAll(response.Body)
+			So(err, ShouldBeNil)
+			contents := string(contentBytes)
+			actual := &api.ErrorResponse{}
+			err = json.Unmarshal([]byte(contents), actual)
+			So(err, ShouldBeNil)
+
+			So(actual, ShouldResemble, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		webConfig.Contacts = []api.WebContact{
+			{
+				ContactType:     "mail",
+				ValidationRegex: "@skbkontur.ru",
+			},
+		}
+
 		Convey("Trying to create a contact when both userLogin and teamID specified", func() {
 			newContactDto.TeamID = defaultTeamID
 			defer func() {
@@ -365,8 +425,9 @@ func TestCreateNewContact(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), LoginKey, login))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "auth", auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -405,6 +466,15 @@ func TestUpdateContact(t *testing.T) {
 			TeamID: "",
 		}
 
+		webConfig := &api.WebConfig{
+			Contacts: []api.WebContact{
+				{
+					ContactType:     "mail",
+					ValidationRegex: "@skbkontur.ru",
+				},
+			},
+		}
+
 		Convey("Successful contact updated", func() {
 			jsonContact, err := json.Marshal(updatedContactDto)
 			So(err, ShouldBeNil)
@@ -419,15 +489,15 @@ func TestUpdateContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact/"+contactID, bytes.NewBuffer(jsonContact))
-
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Name:  updatedContactDto.Name,
 				Type:  updatedContactDto.Type,
 				Value: updatedContactDto.Value,
 				User:  updatedContactDto.User,
 			}))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), AuthKey, &api.Authorization{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, &api.Authorization{
 				AllowedContactTypes: map[string]struct{}{
 					updatedContactDto.Type: {},
 				},
@@ -460,15 +530,15 @@ func TestUpdateContact(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact/"+contactID, bytes.NewBuffer(jsonContact))
-
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Name:  updatedContactDto.Name,
 				Type:  updatedContactDto.Type,
 				Value: updatedContactDto.Value,
 				User:  updatedContactDto.User,
 			}))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), AuthKey, &api.Authorization{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, &api.Authorization{
 				AllowedContactTypes: map[string]struct{}{
 					updatedContactDto.Type: {},
 				},
@@ -495,6 +565,60 @@ func TestUpdateContact(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 
+		Convey("Invalid request when trying to update contact with invalid value", func() {
+			expected := &api.ErrorResponse{
+				StatusText: "Invalid request",
+				ErrorText:  "contact value doesn't match regex: '@yandex.ru'",
+			}
+			jsonContact, err := json.Marshal(updatedContactDto)
+			So(err, ShouldBeNil)
+
+			webConfig.Contacts = []api.WebContact{
+				{
+					ContactType:     "mail",
+					ValidationRegex: "@yandex.ru",
+				},
+			}
+
+			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
+				ID:    contactID,
+				Name:  updatedContactDto.Name,
+				Type:  updatedContactDto.Type,
+				Value: updatedContactDto.Value,
+				User:  updatedContactDto.User,
+			}))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, &api.Authorization{
+				AllowedContactTypes: map[string]struct{}{
+					updatedContactDto.Type: {},
+				},
+			}))
+
+			testRequest.Header.Add("content-type", "application/json")
+
+			updateContact(responseWriter, testRequest)
+
+			response := responseWriter.Result()
+			defer response.Body.Close()
+			contentBytes, err := io.ReadAll(response.Body)
+			So(err, ShouldBeNil)
+			contents := string(contentBytes)
+			actual := &api.ErrorResponse{}
+			err = json.Unmarshal([]byte(contents), actual)
+			So(err, ShouldBeNil)
+
+			So(actual, ShouldResemble, expected)
+			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		webConfig.Contacts = []api.WebContact{
+			{
+				ContactType:     "mail",
+				ValidationRegex: "@skbkontur.ru",
+			},
+		}
+
 		Convey("Internal error when trying to update contact", func() {
 			expected := &api.ErrorResponse{
 				StatusText: "Internal Server Error",
@@ -513,13 +637,14 @@ func TestUpdateContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact/"+contactID, bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  updatedContactDto.Type,
 				Value: updatedContactDto.Value,
 				User:  updatedContactDto.User,
 			}))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), AuthKey, &api.Authorization{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, &api.Authorization{
 				AllowedContactTypes: map[string]struct{}{
 					updatedContactDto.Type: {},
 				},
@@ -561,7 +686,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -587,7 +712,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -614,7 +739,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -642,7 +767,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -679,7 +804,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -718,7 +843,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -762,7 +887,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -797,7 +922,7 @@ func TestRemoveContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodDelete, "/contact/"+contactID, nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactKey, moira.ContactData{
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  "mail",
 				Value: "moira@skbkontur.ru",
@@ -837,7 +962,7 @@ func TestSendTestContactNotification(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPost, "/contact/"+contactID+"/test", nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactIDKey, contactID))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactIDKey, contactID))
 
 			sendTestContactNotification(responseWriter, testRequest)
 
@@ -861,7 +986,7 @@ func TestSendTestContactNotification(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPost, "/contact/"+contactID+"/test", nil)
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), ContactIDKey, contactID))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactIDKey, contactID))
 
 			sendTestContactNotification(responseWriter, testRequest)
 

--- a/api/handler/contact_test.go
+++ b/api/handler/contact_test.go
@@ -20,14 +20,14 @@ import (
 )
 
 const (
-	testContactIDKey = "contactID"
-	testContactKey   = "contact"
-	testAuthKey      = "auth"
-	testLoginKey     = "login"
-	testWebConfigKey = "webConfig"
-	defaultContact   = "testContact"
-	defaultLogin     = "testLogin"
-	defaultTeamID    = "testTeamID"
+	testContactIDKey        = "contactID"
+	testContactKey          = "contact"
+	testAuthKey             = "auth"
+	testLoginKey            = "login"
+	testContactsTemplateKey = "contactsTemplate"
+	defaultContact          = "testContact"
+	defaultLogin            = "testLogin"
+	defaultTeamID           = "testTeamID"
 )
 
 func TestGetAllContacts(t *testing.T) {
@@ -204,12 +204,10 @@ func TestCreateNewContact(t *testing.T) {
 			},
 		}
 
-		webConfig := &api.WebConfig{
-			Contacts: []api.WebContact{
-				{
-					ContactType:     "mail",
-					ValidationRegex: "@skbkontur.ru",
-				},
+		contactsTemplate := []api.WebContact{
+			{
+				ContactType:     "mail",
+				ValidationRegex: "@skbkontur.ru",
 			},
 		}
 
@@ -240,7 +238,7 @@ func TestCreateNewContact(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -273,7 +271,7 @@ func TestCreateNewContact(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -315,7 +313,7 @@ func TestCreateNewContact(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -347,7 +345,7 @@ func TestCreateNewContact(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -373,7 +371,7 @@ func TestCreateNewContact(t *testing.T) {
 			jsonContact, err := json.Marshal(newContactDto)
 			So(err, ShouldBeNil)
 
-			webConfig.Contacts = []api.WebContact{
+			contactsTemplate = []api.WebContact{
 				{
 					ContactType:     "mail",
 					ValidationRegex: "@yandex.ru",
@@ -386,7 +384,7 @@ func TestCreateNewContact(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -404,7 +402,7 @@ func TestCreateNewContact(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 
-		webConfig.Contacts = []api.WebContact{
+		contactsTemplate = []api.WebContact{
 			{
 				ContactType:     "mail",
 				ValidationRegex: "@skbkontur.ru",
@@ -427,7 +425,7 @@ func TestCreateNewContact(t *testing.T) {
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testLoginKey, login))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testAuthKey, auth))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest.Header.Add("content-type", "application/json")
 
 			createNewContact(responseWriter, testRequest)
@@ -466,12 +464,10 @@ func TestUpdateContact(t *testing.T) {
 			TeamID: "",
 		}
 
-		webConfig := &api.WebConfig{
-			Contacts: []api.WebContact{
-				{
-					ContactType:     "mail",
-					ValidationRegex: "@skbkontur.ru",
-				},
+		contactsTemplate := []api.WebContact{
+			{
+				ContactType:     "mail",
+				ValidationRegex: "@skbkontur.ru",
 			},
 		}
 
@@ -489,7 +485,7 @@ func TestUpdateContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact/"+contactID, bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Name:  updatedContactDto.Name,
@@ -530,7 +526,7 @@ func TestUpdateContact(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact/"+contactID, bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Name:  updatedContactDto.Name,
@@ -573,7 +569,7 @@ func TestUpdateContact(t *testing.T) {
 			jsonContact, err := json.Marshal(updatedContactDto)
 			So(err, ShouldBeNil)
 
-			webConfig.Contacts = []api.WebContact{
+			contactsTemplate = []api.WebContact{
 				{
 					ContactType:     "mail",
 					ValidationRegex: "@yandex.ru",
@@ -581,7 +577,7 @@ func TestUpdateContact(t *testing.T) {
 			}
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact", bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Name:  updatedContactDto.Name,
@@ -612,7 +608,7 @@ func TestUpdateContact(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 
-		webConfig.Contacts = []api.WebContact{
+		contactsTemplate = []api.WebContact{
 			{
 				ContactType:     "mail",
 				ValidationRegex: "@skbkontur.ru",
@@ -637,7 +633,7 @@ func TestUpdateContact(t *testing.T) {
 			database = mockDb
 
 			testRequest := httptest.NewRequest(http.MethodPut, "/contact/"+contactID, bytes.NewBuffer(jsonContact))
-			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testWebConfigKey, webConfig))
+			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactsTemplateKey, contactsTemplate))
 			testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), testContactKey, moira.ContactData{
 				ID:    contactID,
 				Type:  updatedContactDto.Type,

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -38,6 +38,11 @@ func NewHandler(
 ) http.Handler {
 	database = db
 	searchIndex = index
+	var contactsTemplate []api.WebContact
+	if webConfig != nil {
+		contactsTemplate = webConfig.Contacts
+	}
+
 	router := chi.NewRouter()
 	router.Use(render.SetContentType(render.ContentTypeJSON))
 	router.Use(moiramiddle.UserContext)
@@ -111,8 +116,8 @@ func NewHandler(
 			router.Route("/subscription", subscription)
 			router.Route("/notification", notification)
 			router.Route("/teams", teams)
-			router.With(moiramiddle.WebConfigContext(
-				webConfig,
+			router.With(moiramiddle.ContactsTemplateContext(
+				contactsTemplate,
 			)).Route("/contact", func(router chi.Router) {
 				contact(router)
 				contactEvents(router)

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -111,7 +111,9 @@ func NewHandler(
 			router.Route("/subscription", subscription)
 			router.Route("/notification", notification)
 			router.Route("/teams", teams)
-			router.Route("/contact", func(router chi.Router) {
+			router.With(moiramiddle.WebConfigContext(
+				webConfig,
+			)).Route("/contact", func(router chi.Router) {
 				contact(router)
 				contactEvents(router)
 			})

--- a/api/handler/team_contact.go
+++ b/api/handler/team_contact.go
@@ -40,8 +40,16 @@ func createNewTeamContact(writer http.ResponseWriter, request *http.Request) {
 
 	teamID := middleware.GetTeamID(request)
 	auth := middleware.GetAuth(request)
+	webConfig := middleware.GetWebConfig(request)
 
-	if err := controller.CreateContact(database, auth, contact, "", teamID); err != nil {
+	if err := controller.CreateContact(
+		database,
+		auth,
+		webConfig,
+		contact,
+		"",
+		teamID,
+	); err != nil {
 		render.Render(writer, request, err) //nolint:errcheck
 		return
 	}

--- a/api/handler/team_contact.go
+++ b/api/handler/team_contact.go
@@ -40,12 +40,12 @@ func createNewTeamContact(writer http.ResponseWriter, request *http.Request) {
 
 	teamID := middleware.GetTeamID(request)
 	auth := middleware.GetAuth(request)
-	webConfig := middleware.GetWebConfig(request)
+	contactsTemplate := middleware.GetContactsTemplate(request)
 
 	if err := controller.CreateContact(
 		database,
 		auth,
-		webConfig,
+		contactsTemplate,
 		contact,
 		"",
 		teamID,

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -36,11 +36,11 @@ func SearchIndexContext(searcher moira.Searcher) func(next http.Handler) http.Ha
 	}
 }
 
-// WebConfigContext sets to requests context web config.
-func WebConfigContext(webConfig *api.WebConfig) func(next http.Handler) http.Handler {
+// ContactsTemplateContext sets to requests context contacts template.
+func ContactsTemplateContext(contactsTemplate []api.WebContact) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			ctx := context.WithValue(request.Context(), webConfig, webConfig)
+			ctx := context.WithValue(request.Context(), contactsTemplateKey, contactsTemplate)
 			next.ServeHTTP(writer, request.WithContext(ctx))
 		})
 	}

--- a/api/middleware/context.go
+++ b/api/middleware/context.go
@@ -36,6 +36,16 @@ func SearchIndexContext(searcher moira.Searcher) func(next http.Handler) http.Ha
 	}
 }
 
+// WebConfigContext sets to requests context web config.
+func WebConfigContext(webConfig *api.WebConfig) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			ctx := context.WithValue(request.Context(), webConfig, webConfig)
+			next.ServeHTTP(writer, request.WithContext(ctx))
+		})
+	}
+}
+
 // UserContext get x-webauth-user header and sets it in request context, if header is empty sets empty string.
 func UserContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -20,7 +20,7 @@ func (key ContextKey) String() string {
 var (
 	databaseKey          ContextKey = "database"
 	searcherKey          ContextKey = "searcher"
-	webConfigKey         ContextKey = "webConfig"
+	contactsTemplateKey  ContextKey = "contactsTemplate"
 	triggerIDKey         ContextKey = "triggerID"
 	clustersMetricTTLKey ContextKey = "clustersMetricTTL"
 	populateKey          ContextKey = "populated"
@@ -50,9 +50,9 @@ func GetDatabase(request *http.Request) moira.Database {
 	return request.Context().Value(databaseKey).(moira.Database)
 }
 
-// GetWebConfig gets web config from request context.
-func GetWebConfig(request *http.Request) *api.WebConfig {
-	return request.Context().Value(webConfigKey).(*api.WebConfig)
+// GetContactsTemplate gets contacts template from request context.
+func GetContactsTemplate(request *http.Request) []api.WebContact {
+	return request.Context().Value(contactsTemplateKey).([]api.WebContact)
 }
 
 // GetLogin gets user login string from request context, which was sets in UserContext middleware.

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -20,6 +20,7 @@ func (key ContextKey) String() string {
 var (
 	databaseKey          ContextKey = "database"
 	searcherKey          ContextKey = "searcher"
+	webConfigKey         ContextKey = "webConfig"
 	triggerIDKey         ContextKey = "triggerID"
 	clustersMetricTTLKey ContextKey = "clustersMetricTTL"
 	populateKey          ContextKey = "populated"
@@ -47,6 +48,11 @@ var (
 // GetDatabase gets moira.Database realization from request context.
 func GetDatabase(request *http.Request) moira.Database {
 	return request.Context().Value(databaseKey).(moira.Database)
+}
+
+// GetWebConfig gets web config from request context.
+func GetWebConfig(request *http.Request) *api.WebConfig {
+	return request.Context().Value(webConfigKey).(*api.WebConfig)
 }
 
 // GetLogin gets user login string from request context, which was sets in UserContext middleware.

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -140,10 +140,10 @@ func (auth *authorization) toApiConfig(webConfig *webConfig) api.Authorization {
 
 func (config *webConfig) validate() error {
 	for _, contactTemplate := range config.ContactsTemplate {
-		validationPattern := contactTemplate.ValidationRegex
-		if validationPattern != "" {
-			if _, err := regexp.Compile(validationPattern); err != nil {
-				return fmt.Errorf("contact template validation error '%s': %w", validationPattern, err)
+		ValidationRegex := contactTemplate.ValidationRegex
+		if ValidationRegex != "" {
+			if _, err := regexp.Compile(ValidationRegex); err != nil {
+				return fmt.Errorf("contact template regex error '%s': %w", ValidationRegex, err)
 			}
 		}
 	}

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -140,11 +140,13 @@ func (auth *authorization) toApiConfig(webConfig *webConfig) api.Authorization {
 
 func (config *webConfig) validate() error {
 	for _, contactTemplate := range config.ContactsTemplate {
-		ValidationRegex := contactTemplate.ValidationRegex
-		if ValidationRegex != "" {
-			if _, err := regexp.Compile(ValidationRegex); err != nil {
-				return fmt.Errorf("contact template regex error '%s': %w", ValidationRegex, err)
-			}
+		validationRegex := contactTemplate.ValidationRegex
+		if validationRegex == "" {
+			continue
+		}
+
+		if _, err := regexp.Compile(validationRegex); err != nil {
+			return fmt.Errorf("contact template regex error '%s': %w", validationRegex, err)
 		}
 	}
 

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/moira-alert/moira"
@@ -134,6 +136,19 @@ func (auth *authorization) toApiConfig(webConfig *webConfig) api.Authorization {
 		AdminList:           adminList,
 		AllowedContactTypes: allowedContactTypes,
 	}
+}
+
+func (config *webConfig) validate() error {
+	for _, contactTemplate := range config.ContactsTemplate {
+		validationPattern := contactTemplate.ValidationRegex
+		if validationPattern != "" {
+			if _, err := regexp.Compile(validationPattern); err != nil {
+				return fmt.Errorf("contact template validation error '%s': %w", validationPattern, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (config *webConfig) getSettings(isRemoteEnabled bool, remotes cmd.RemotesConfig) *api.WebConfig {

--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -251,14 +251,14 @@ func Test_webConfig_getSettings(t *testing.T) {
 
 func Test_webConfig_validate(t *testing.T) {
 	Convey("With empty web config", t, func() {
-		webConfig := webConfig{}
+		config := webConfig{}
 
-		err := webConfig.validate()
+		err := config.validate()
 		So(err, ShouldBeNil)
 	})
 
 	Convey("With invalid contact template pattern", t, func() {
-		webConfig := webConfig{
+		config := webConfig{
 			ContactsTemplate: []webContact{
 				{
 					ValidationRegex: "**",
@@ -266,12 +266,12 @@ func Test_webConfig_validate(t *testing.T) {
 			},
 		}
 
-		err := webConfig.validate()
+		err := config.validate()
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("With invalid contact template pattern", t, func() {
-		webConfig := webConfig{
+		config := webConfig{
 			ContactsTemplate: []webContact{
 				{
 					ValidationRegex: ".*",
@@ -279,7 +279,7 @@ func Test_webConfig_validate(t *testing.T) {
 			},
 		}
 
-		err := webConfig.validate()
+		err := config.validate()
 		So(err, ShouldBeNil)
 	})
 }

--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -248,3 +248,38 @@ func Test_webConfig_getSettings(t *testing.T) {
 		})
 	})
 }
+
+func Test_webConfig_validate(t *testing.T) {
+	Convey("With empty web config", t, func() {
+		webConfig := webConfig{}
+
+		err := webConfig.validate()
+		So(err, ShouldBeNil)
+	})
+
+	Convey("With invalid contact template pattern", t, func() {
+		webConfig := webConfig{
+			ContactsTemplate: []webContact{
+				{
+					ValidationRegex: "**",
+				},
+			},
+		}
+
+		err := webConfig.validate()
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("With invalid contact template pattern", t, func() {
+		webConfig := webConfig{
+			ContactsTemplate: []webContact{
+				{
+					ValidationRegex: ".*",
+				},
+			},
+		}
+
+		err := webConfig.validate()
+		So(err, ShouldBeNil)
+	})
+}

--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -270,7 +270,7 @@ func Test_webConfig_validate(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 
-	Convey("With invalid contact template pattern", t, func() {
+	Convey("With valid contact template pattern", t, func() {
 		config := webConfig{
 			ContactsTemplate: []webContact{
 				{

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -58,6 +58,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = applicationConfig.Web.validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Can not configure web config: %s\n", err.Error())
+		os.Exit(1)
+	}
+
 	apiConfig := applicationConfig.API.getSettings(
 		applicationConfig.ClustersMetricTTL(),
 		applicationConfig.Web.getFeatureFlags(),


### PR DESCRIPTION
# Add contact template validation

Previously contact template validation in web config was on the frontend, I moved it to the backend and added validation of the templates themselves