### PR TITLE
refactor: hide credentials in tg sender

### DIFF
--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -80,8 +80,9 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 
 	sender.logger = logger
 	sender.bot, err = telebot.NewBot(telebot.Settings{
-		Token:  cfg.APIToken,
-		Poller: &telebot.LongPoller{Timeout: pollerTimeout},
+		Token:   cfg.APIToken,
+		Poller:  &telebot.LongPoller{Timeout: pollerTimeout},
+		OnError: sender.customOnErrorFunc,
 	})
 	if err != nil {
 		return sender.removeTokenFromError(err)
@@ -122,4 +123,12 @@ func (sender *Sender) runTelebot(contactType string) {
 
 func telegramLockKey(contactType string) string {
 	return telegramLockPrefix + contactType
+}
+
+func (sender *Sender) customOnErrorFunc(err error, _ telebot.Context) {
+	err = sender.removeTokenFromError(err)
+
+	sender.logger.Error().
+		Error(err).
+		Msg("Error inside telebot")
 }

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -125,10 +125,12 @@ func telegramLockKey(contactType string) string {
 	return telegramLockPrefix + contactType
 }
 
+const errorInsideTelebotMsg = "Error inside telebot"
+
 func (sender *Sender) customOnErrorFunc(err error, _ telebot.Context) {
 	err = sender.removeTokenFromError(err)
 
 	sender.logger.Error().
 		Error(err).
-		Msg("Error inside telebot")
+		Msg(errorInsideTelebotMsg)
 }

--- a/senders/telegram/init.go
+++ b/senders/telegram/init.go
@@ -130,7 +130,7 @@ const errorInsideTelebotMsg = "Error inside telebot"
 func (sender *Sender) customOnErrorFunc(err error, _ telebot.Context) {
 	err = sender.removeTokenFromError(err)
 
-	sender.logger.Error().
+	sender.logger.Warning().
 		Error(err).
 		Msg(errorInsideTelebotMsg)
 }

--- a/senders/telegram/init_test.go
+++ b/senders/telegram/init_test.go
@@ -1,7 +1,11 @@
 package telegram
 
 import (
+	"errors"
 	"fmt"
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	"go.uber.org/mock/gomock"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,5 +33,28 @@ func TestInit(t *testing.T) {
 			So(sender.logger, ShouldResemble, logger)
 			So(sender.apiToken, ShouldResemble, "123")
 		})
+	})
+}
+
+func Test_customOnErrorFunc(t *testing.T) {
+	Convey("test customOnErrorFunc hides credential and logs", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		logger := mock_moira_alert.NewMockLogger(mockCtrl)
+		eventsBuilder := mock_moira_alert.NewMockEventBuilder(mockCtrl)
+
+		sender := Sender{
+			logger:   logger,
+			apiToken: "1111111111:SecretTokenabc_987654321hellokonturmoira",
+		}
+
+		err := fmt.Errorf("https://some.api.of.telegram/bot%s/update failed to update", sender.apiToken)
+
+		logger.EXPECT().Error().Return(eventsBuilder).AnyTimes()
+		eventsBuilder.EXPECT().Error(errors.New(strings.ReplaceAll(err.Error(), sender.apiToken, hidden))).Return(eventsBuilder)
+		eventsBuilder.EXPECT().Msg(errorInsideTelebotMsg)
+
+		sender.customOnErrorFunc(err, nil)
 	})
 }

--- a/senders/telegram/init_test.go
+++ b/senders/telegram/init_test.go
@@ -52,7 +52,7 @@ func Test_customOnErrorFunc(t *testing.T) {
 
 		err := fmt.Errorf("https://some.api.of.telegram/bot%s/update failed to update", sender.apiToken)
 
-		logger.EXPECT().Error().Return(eventsBuilder).AnyTimes()
+		logger.EXPECT().Warning().Return(eventsBuilder).AnyTimes()
 		eventsBuilder.EXPECT().Error(errors.New(strings.ReplaceAll(err.Error(), sender.apiToken, hidden))).Return(eventsBuilder)
 		eventsBuilder.EXPECT().Msg(errorInsideTelebotMsg)
 

--- a/senders/telegram/init_test.go
+++ b/senders/telegram/init_test.go
@@ -3,11 +3,12 @@ package telegram
 import (
 	"errors"
 	"fmt"
-	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
-	"go.uber.org/mock/gomock"
 	"strings"
 	"testing"
 	"time"
+
+	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	"go.uber.org/mock/gomock"
 
 	logging "github.com/moira-alert/moira/logging/zerolog_adapter"
 	. "github.com/smartystreets/goconvey/convey"


### PR DESCRIPTION
# PR Summary

Package telebot used in tg sender has internal logging, and when error occurs it writes uri (**with token!**) to logs.

This PR fixes it.