### PR TITLE
feat(api): print trigger id when it already exists

### DIFF
--- a/api/controller/triggers.go
+++ b/api/controller/triggers.go
@@ -35,7 +35,7 @@ func CreateTrigger(dataBase moira.Database, trigger *dto.TriggerModel, timeSerie
 			return nil, api.ErrorInternalServer(err)
 		}
 		if exists {
-			return nil, api.ErrorInvalidRequest(fmt.Errorf("trigger with this ID already exists"))
+			return nil, api.ErrorInvalidRequest(fmt.Errorf("trigger with this ID (%s) already exists", trigger.ID))
 		}
 	}
 	resp, err := saveTrigger(dataBase, trigger.ToMoiraTrigger(), trigger.ID, timeSeriesNames)

--- a/api/controller/triggers_test.go
+++ b/api/controller/triggers_test.go
@@ -73,8 +73,8 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Trigger already exists", t, func() {
-		triggerId := uuid.Must(uuid.NewV4())
-		triggerModel := dto.TriggerModel{ID: triggerId.String()}
+		triggerId := uuid.Must(uuid.NewV4()).String()
+		triggerModel := dto.TriggerModel{ID: triggerId}
 		trigger := triggerModel.ToMoiraTrigger()
 		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(*trigger, nil)
 		resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))

--- a/api/controller/triggers_test.go
+++ b/api/controller/triggers_test.go
@@ -73,11 +73,12 @@ func TestCreateTrigger(t *testing.T) {
 	})
 
 	Convey("Trigger already exists", t, func() {
-		triggerModel := dto.TriggerModel{ID: uuid.Must(uuid.NewV4()).String()}
+		triggerId := uuid.Must(uuid.NewV4())
+		triggerModel := dto.TriggerModel{ID: triggerId.String()}
 		trigger := triggerModel.ToMoiraTrigger()
 		dataBase.EXPECT().GetTrigger(triggerModel.ID).Return(*trigger, nil)
 		resp, err := CreateTrigger(dataBase, &triggerModel, make(map[string]bool))
-		So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("trigger with this ID already exists")))
+		So(err, ShouldResemble, api.ErrorInvalidRequest(fmt.Errorf("trigger with this ID (%s) already exists", triggerId)))
 		So(resp, ShouldBeNil)
 	})
 


### PR DESCRIPTION
# PR Summary

Added a trigger id to api response on creating trigger (PUT /api/trigger/)

## Additional information

None

## Closes/Relates #issue

None