### PR TITLE
perf(filter): Optimize maps read/writes in hot path

### DIFF
--- a/filter/prefix_tree.go
+++ b/filter/prefix_tree.go
@@ -113,26 +113,23 @@ func (source *PrefixTree) Match(metric string) []string {
 }
 
 // MatchWithValue finds metric in tree and returns payloads for all matched nodes.
-func (source *PrefixTree) MatchWithValue(metric string) map[string]MatchingHandler {
+func (source *PrefixTree) MatchWithValue(metric string, callback func(string, MatchingHandler)) {
 	nodes, _ := source.findNodes(metric)
 	if nodes == nil {
-		return map[string]MatchingHandler{}
+		return
 	}
 
-	matched := make(map[string]MatchingHandler)
 	for _, node := range nodes {
 		if node.Terminal {
 			if node.Payload == nil {
-				matched[node.Prefix] = nil
+				callback(node.Prefix, nil)
 			}
 
 			for pattern, matchingHandler := range node.Payload {
-				matched[pattern] = matchingHandler
+				callback(pattern, matchingHandler)
 			}
 		}
 	}
-
-	return matched
 }
 
 func (source *PrefixTree) findNodes(metric string) ([]*PatternNode, int) {

--- a/filter/prefix_tree_test.go
+++ b/filter/prefix_tree_test.go
@@ -19,7 +19,12 @@ func TestPrefixTree(t *testing.T) {
 		})
 
 		Convey("MatchWithValue should return empty map", func() {
-			matchedPatterns := prefixTree.MatchWithValue("any_string")
+			matchedPatterns := map[string]MatchingHandler{}
+			prefixTree.MatchWithValue("any_string", func(s string, mh MatchingHandler) {
+				_, ok := matchedPatterns[s]
+				So(ok, ShouldBeFalse)
+				matchedPatterns[s] = mh
+			})
 			So(matchedPatterns, ShouldResemble, map[string]MatchingHandler{})
 		})
 	})
@@ -96,14 +101,28 @@ func TestPrefixTree(t *testing.T) {
 					"Complex.matching.pattern": nil,
 					"Complex.*.*":              nil,
 				}
-				matchedPatterns := prefixTree.MatchWithValue(metric)
+
+				matchedPatterns := map[string]MatchingHandler{}
+				prefixTree.MatchWithValue(metric, func(s string, mh MatchingHandler) {
+					_, ok := matchedPatterns[s]
+					So(ok, ShouldBeFalse)
+					matchedPatterns[s] = mh
+				})
+
 				So(matchedPatterns, ShouldResemble, matchedValue)
 			})
 
 			Convey("For metrics not from tree", func() {
 				metric := "Simple.notmatching.pattern"
 				matchedValue := map[string]MatchingHandler{}
-				matchedPatterns := prefixTree.MatchWithValue(metric)
+
+				matchedPatterns := map[string]MatchingHandler{}
+				prefixTree.MatchWithValue(metric, func(s string, mh MatchingHandler) {
+					_, ok := matchedPatterns[s]
+					So(ok, ShouldBeFalse)
+					matchedPatterns[s] = mh
+				})
+
 				So(matchedPatterns, ShouldResemble, matchedValue)
 			})
 		})
@@ -143,7 +162,13 @@ func TestPrefixTree(t *testing.T) {
 				}},
 			}
 			for _, testCase := range testCases {
-				matchedPatterns := prefixTree.MatchWithValue(testCase.Metric)
+				matchedPatterns := map[string]MatchingHandler{}
+				prefixTree.MatchWithValue(testCase.Metric, func(s string, mh MatchingHandler) {
+					_, ok := matchedPatterns[s]
+					So(ok, ShouldBeFalse)
+					matchedPatterns[s] = mh
+				})
+
 				So(len(matchedPatterns), ShouldEqual, len(testCase.MatchedPatterns))
 				for pKey, pValue := range testCase.MatchedPatterns {
 					So(matchedPatterns, ShouldContainKey, pKey)
@@ -162,7 +187,13 @@ func TestPrefixTree(t *testing.T) {
 				"Simple.notmatching.pattern",
 			}
 			for _, testCase := range testCases {
-				matchedPatterns := prefixTree.MatchWithValue(testCase)
+				matchedPatterns := map[string]MatchingHandler{}
+				prefixTree.MatchWithValue(testCase, func(s string, mh MatchingHandler) {
+					_, ok := matchedPatterns[s]
+					So(ok, ShouldBeFalse)
+					matchedPatterns[s] = mh
+				})
+
 				So(matchedPatterns, ShouldResemble, map[string]MatchingHandler{})
 			}
 		})

--- a/filter/series_by_tag_pattern_index.go
+++ b/filter/series_by_tag_pattern_index.go
@@ -73,12 +73,12 @@ func NewSeriesByTagPatternIndex(
 func (index *SeriesByTagPatternIndex) MatchPatterns(metricName string, labels map[string]string) []string {
 	matchedPatterns := make([]string, 0)
 
-	matchingHandlersWithCorrespondingNameTag := index.namesPrefixTree.MatchWithValue(metricName)
-	for pattern, matchingHandler := range matchingHandlersWithCorrespondingNameTag {
+	callback := func(pattern string, matchingHandler MatchingHandler) {
 		if matchingHandler(metricName, labels) {
 			matchedPatterns = append(matchedPatterns, pattern)
 		}
 	}
+	index.namesPrefixTree.MatchWithValue(metricName, callback)
 
 	for pattern, matchingHandler := range index.withoutStrictNameTagPatternMatchers {
 		if matchingHandler(metricName, labels) {


### PR DESCRIPTION
Профилировки показали, что заполнение и чтение мапы в методе MatchWithValue префиксного дерева потребляет порядка 18% времени CPU в фильтрах. Заменил заполнение мапы на передачу колбека