### PR TITLE
perf(filter): replace map with slice in hot path

### DIFF
--- a/filter/series_by_tag_pattern_index.go
+++ b/filter/series_by_tag_pattern_index.go
@@ -59,7 +59,13 @@ func NewSeriesByTagPatternIndex(
 		}
 
 		if patternMatching.nameTagValue == "" {
-			withoutStrictNameTagPatternMatchers = append(withoutStrictNameTagPatternMatchers, patternAndHandler{pattern, patternMatching.matchingHandler})
+			withoutStrictNameTagPatternMatchers = append(
+				withoutStrictNameTagPatternMatchers,
+				patternAndHandler{
+					pattern: pattern,
+					handler: patternMatching.matchingHandler,
+				},
+			)
 		} else {
 			namesPrefixTree.AddWithPayload(patternMatching.nameTagValue, pattern, patternMatching.matchingHandler)
 		}

--- a/filter/series_by_tag_pattern_index.go
+++ b/filter/series_by_tag_pattern_index.go
@@ -11,9 +11,14 @@ type SeriesByTagPatternIndex struct {
 	// namesPrefixTree stores MatchingHandler's for patterns that have name tag in prefix tree structure
 	namesPrefixTree *PrefixTree
 	// withoutStrictNameTagPatternMatchers stores MatchingHandler's for patterns that have no name tag
-	withoutStrictNameTagPatternMatchers map[string]MatchingHandler
+	withoutStrictNameTagPatternMatchers []patternAndHandler
 	// Flags for compatibility with different graphite behaviours
 	compatibility Compatibility
+}
+
+type patternAndHandler struct {
+	pattern string
+	handler MatchingHandler
 }
 
 // NewSeriesByTagPatternIndex creates new SeriesByTagPatternIndex using seriesByTag patterns and parsed specs comes from ParseSeriesByTag.
@@ -25,7 +30,7 @@ func NewSeriesByTagPatternIndex(
 	metrics *metrics.FilterMetrics,
 ) *SeriesByTagPatternIndex {
 	namesPrefixTree := &PrefixTree{Logger: logger, Root: &PatternNode{}}
-	withoutStrictNameTagPatternMatchers := make(map[string]MatchingHandler)
+	withoutStrictNameTagPatternMatchers := make([]patternAndHandler, 0)
 
 	var patternMatchingEvicted int64
 
@@ -54,7 +59,7 @@ func NewSeriesByTagPatternIndex(
 		}
 
 		if patternMatching.nameTagValue == "" {
-			withoutStrictNameTagPatternMatchers[pattern] = patternMatching.matchingHandler
+			withoutStrictNameTagPatternMatchers = append(withoutStrictNameTagPatternMatchers, patternAndHandler{pattern, patternMatching.matchingHandler})
 		} else {
 			namesPrefixTree.AddWithPayload(patternMatching.nameTagValue, pattern, patternMatching.matchingHandler)
 		}
@@ -80,9 +85,9 @@ func (index *SeriesByTagPatternIndex) MatchPatterns(metricName string, labels ma
 	}
 	index.namesPrefixTree.MatchWithValue(metricName, callback)
 
-	for pattern, matchingHandler := range index.withoutStrictNameTagPatternMatchers {
-		if matchingHandler(metricName, labels) {
-			matchedPatterns = append(matchedPatterns, pattern)
+	for _, patternAndHandler := range index.withoutStrictNameTagPatternMatchers {
+		if patternAndHandler.handler(metricName, labels) {
+			matchedPatterns = append(matchedPatterns, patternAndHandler.pattern)
 		}
 	}
 


### PR DESCRIPTION
Обратили внимание, что итерация по мапе занимает порядка 8% производительности фильтра, решили заменить её на слайс