### PR TITLE
fix: trigger schedule fill

### DIFF
--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -41,6 +41,9 @@ var (
 
 	// errAsteriskPatternNotAllowed is returned then one of Trigger.Patterns contain only "*".
 	errAsteriskPatternNotAllowed = errors.New("pattern \"*\" is not allowed to use")
+
+	// errNoAllowedDays is returned then all days disabled in moira.ScheduleData.
+	errNoAllowedDays = errors.New("no allowed days in trigger schedule")
 )
 
 // TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved.
@@ -311,12 +314,21 @@ func checkScheduleFilling(gotSchedule *moira.ScheduleData) (*moira.ScheduleData,
 	}
 
 	newDaysForSchedule := make([]moira.ScheduleDataDay, 0, len(scheduleDaysMap))
+	someDayEnabled := false
 	for _, day := range defaultSchedule.Days {
 		newDaysForSchedule = append(newDaysForSchedule,
 			moira.ScheduleDataDay{
 				Name:    day.Name,
 				Enabled: scheduleDaysMap[day.Name],
 			})
+
+		if scheduleDaysMap[day.Name] {
+			someDayEnabled = true
+		}
+	}
+
+	if !someDayEnabled {
+		return nil, errNoAllowedDays
 	}
 
 	return &moira.ScheduleData{

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -545,9 +545,7 @@ func Test_checkScheduleFilling(t *testing.T) {
 
 			gotSchedule, err := checkScheduleFilling(givenSchedule)
 
-			So(err, ShouldResemble, api.ErrInvalidRequestContent{
-				ValidationError: fmt.Errorf("bad day names in schedule: %s, %s", badMondayName, badFridayName),
-			})
+			So(err, ShouldResemble, fmt.Errorf("bad day names in schedule: %s, %s", badMondayName, badFridayName))
 			So(gotSchedule, ShouldBeNil)
 		})
 	})

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -3,7 +3,9 @@ package dto
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -441,4 +443,137 @@ func TestCreateTriggerModel(t *testing.T) {
 
 		So(CreateTriggerModel(trigger), ShouldResemble, expTriggerModel)
 	})
+}
+
+func Test_checkScheduleFilling(t *testing.T) {
+	Convey("Testing checking schedule filling", t, func() {
+		defaultSchedule := moira.NewDefaultScheduleData()
+
+		Convey("With not all days missing days filled with false", func() {
+			days := slices.Clone(defaultSchedule.Days)
+
+			givenSchedule := &moira.ScheduleData{
+				Days:           days[:len(days)-1],
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			days[len(days)-1].Enabled = false
+
+			expectedSchedule := &moira.ScheduleData{
+				Days:           days,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			gotSchedule, err := checkScheduleFilling(givenSchedule)
+
+			So(err, ShouldBeNil)
+			So(gotSchedule, ShouldResemble, expectedSchedule)
+		})
+
+		Convey("When days shuffled return ordered", func() {
+			days := slices.Clone(defaultSchedule.Days)
+
+			shuffledDays := shuffleArray(days)
+
+			givenSchedule := &moira.ScheduleData{
+				Days:           shuffledDays,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			expectedSchedule := &moira.ScheduleData{
+				Days:           defaultSchedule.Days,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			gotSchedule, err := checkScheduleFilling(givenSchedule)
+
+			So(err, ShouldBeNil)
+			So(gotSchedule, ShouldResemble, expectedSchedule)
+		})
+
+		Convey("When days shuffled and some are missed return ordered and filled missing", func() {
+			days := slices.Clone(defaultSchedule.Days)
+
+			shuffledDays := shuffleArray(days[:len(days)-2])
+
+			days[len(days)-1].Enabled = false
+			days[len(days)-2].Enabled = false
+
+			givenSchedule := &moira.ScheduleData{
+				Days:           shuffledDays,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			expectedSchedule := &moira.ScheduleData{
+				Days:           days,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			gotSchedule, err := checkScheduleFilling(givenSchedule)
+
+			So(err, ShouldBeNil)
+			So(gotSchedule, ShouldResemble, expectedSchedule)
+		})
+
+		Convey("With bad day names error returned", func() {
+			days := slices.Clone(defaultSchedule.Days)
+
+			badMondayName := "Monday"
+			badFridayName := "Friday"
+
+			days[0].Name = badMondayName
+			days[4].Name = badFridayName
+
+			givenSchedule := &moira.ScheduleData{
+				Days:           days,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			gotSchedule, err := checkScheduleFilling(givenSchedule)
+
+			So(err, ShouldResemble, api.ErrInvalidRequestContent{
+				ValidationError: fmt.Errorf("bad day names in schedule: %s, %s", badMondayName, badFridayName),
+			})
+			So(gotSchedule, ShouldBeNil)
+		})
+	})
+}
+
+func shuffleArray[S interface{ ~[]E }, E any](slice S) S {
+	slice = slices.Clone(slice)
+	shuffledSlice := make(S, 0, len(slice))
+
+	for len(slice) > 0 {
+		randomIdx := rand.Intn(len(slice))
+		shuffledSlice = append(shuffledSlice, slice[randomIdx])
+
+		switch {
+		case randomIdx == len(slice)-1:
+			slice = slice[:len(slice)-1]
+		case randomIdx == 0:
+			if len(slice) > 1 {
+				slice = slice[1:]
+			} else {
+				slice = nil
+			}
+		default:
+			slice = append(slice[:randomIdx], slice[randomIdx+1:]...)
+		}
+	}
+
+	return shuffledSlice
 }

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -548,6 +548,26 @@ func Test_checkScheduleFilling(t *testing.T) {
 			So(err, ShouldResemble, fmt.Errorf("bad day names in schedule: %s, %s", badMondayName, badFridayName))
 			So(gotSchedule, ShouldBeNil)
 		})
+
+		Convey("With no enabled days error returned", func() {
+			days := slices.Clone(defaultSchedule.Days)
+
+			for i := range days {
+				days[i].Enabled = false
+			}
+
+			givenSchedule := &moira.ScheduleData{
+				Days:           days,
+				TimezoneOffset: defaultSchedule.TimezoneOffset,
+				StartOffset:    defaultSchedule.StartOffset,
+				EndOffset:      defaultSchedule.EndOffset,
+			}
+
+			gotSchedule, err := checkScheduleFilling(givenSchedule)
+
+			So(err, ShouldResemble, errNoAllowedDays)
+			So(gotSchedule, ShouldBeNil)
+		})
 	})
 }
 

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -109,15 +109,8 @@ func TestGetTriggerFromRequest(t *testing.T) {
 		request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
 		request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "limits", api.GetTestLimitsConfig()))
 
-		triggerDTO.Schedule = moira.NewDefaultScheduleData()
-		triggerDTO.Schedule.TimezoneOffset = 0
-		triggerDTO.Schedule.StartOffset = 0
-		triggerDTO.Schedule.EndOffset = 0
-		for i := range triggerDTO.Schedule.Days {
-			if i != 0 {
-				triggerDTO.Schedule.Days[i].Enabled = false
-			}
-		}
+		triggerDTO.Schedule.Days = moira.GetFilledScheduleDataDays(false)
+		triggerDTO.Schedule.Days[0].Enabled = true
 
 		Convey("It should be parsed successfully", func() {
 			triggerDTO.TTL = moira.DefaultTTL

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -72,17 +72,24 @@ func TestGetTriggerFromRequest(t *testing.T) {
 		ttlState := moira.TTLState("NODATA")
 		triggerDTO := dto.Trigger{
 			TriggerModel: dto.TriggerModel{
-				ID:             "test_id",
-				Name:           "Test trigger",
-				Desc:           new(string),
-				Targets:        []string{"foo.bar"},
-				WarnValue:      &triggerWarnValue,
-				ErrorValue:     &triggerErrorValue,
-				TriggerType:    "rising",
-				Tags:           []string{"Normal", "DevOps", "DevOpsGraphite-duty"},
-				TTLState:       &ttlState,
-				TTL:            0,
-				Schedule:       &moira.ScheduleData{},
+				ID:          "test_id",
+				Name:        "Test trigger",
+				Desc:        new(string),
+				Targets:     []string{"foo.bar"},
+				WarnValue:   &triggerWarnValue,
+				ErrorValue:  &triggerErrorValue,
+				TriggerType: "rising",
+				Tags:        []string{"Normal", "DevOps", "DevOpsGraphite-duty"},
+				TTLState:    &ttlState,
+				TTL:         0,
+				Schedule: &moira.ScheduleData{
+					Days: []moira.ScheduleDataDay{
+						{
+							Name:    "Mon",
+							Enabled: true,
+						},
+					},
+				},
 				Expression:     "",
 				Patterns:       []string{},
 				TriggerSource:  moira.GraphiteLocal,
@@ -107,7 +114,9 @@ func TestGetTriggerFromRequest(t *testing.T) {
 		triggerDTO.Schedule.StartOffset = 0
 		triggerDTO.Schedule.EndOffset = 0
 		for i := range triggerDTO.Schedule.Days {
-			triggerDTO.Schedule.Days[i].Enabled = false
+			if i != 0 {
+				triggerDTO.Schedule.Days[i].Enabled = false
+			}
 		}
 
 		Convey("It should be parsed successfully", func() {

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -102,6 +102,14 @@ func TestGetTriggerFromRequest(t *testing.T) {
 		request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
 		request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "limits", api.GetTestLimitsConfig()))
 
+		triggerDTO.Schedule = moira.NewDefaultScheduleData()
+		triggerDTO.Schedule.TimezoneOffset = 0
+		triggerDTO.Schedule.StartOffset = 0
+		triggerDTO.Schedule.EndOffset = 0
+		for i := range triggerDTO.Schedule.Days {
+			triggerDTO.Schedule.Days[i].Enabled = false
+		}
+
 		Convey("It should be parsed successfully", func() {
 			triggerDTO.TTL = moira.DefaultTTL
 

--- a/datatypes.go
+++ b/datatypes.go
@@ -246,7 +246,7 @@ type PlottingData struct {
 
 // ScheduleData represents subscription schedule.
 type ScheduleData struct {
-	Days           []ScheduleDataDay `json:"days"`
+	Days           []ScheduleDataDay `json:"days" validate:"dive"`
 	TimezoneOffset int64             `json:"tzOffset" example:"-60" format:"int64"`
 	StartOffset    int64             `json:"startOffset" example:"0" format:"int64"`
 	EndOffset      int64             `json:"endOffset" example:"1439" format:"int64"`
@@ -254,8 +254,40 @@ type ScheduleData struct {
 
 // ScheduleDataDay represents week day of schedule.
 type ScheduleDataDay struct {
-	Enabled bool   `json:"enabled" example:"true"`
-	Name    string `json:"name,omitempty" example:"Mon"`
+	Enabled bool    `json:"enabled" example:"true"`
+	Name    DayName `json:"name,omitempty" example:"Mon" validate:"oneof=Mon Tue Wed Thu Fri Sat Sun"`
+}
+
+// DayName represents the day name used in ScheduleDataDay.
+type DayName string
+
+// Constants for day names.
+const (
+	Monday    DayName = "Mon"
+	Tuesday   DayName = "Tue"
+	Wednesday DayName = "Wed"
+	Thursday  DayName = "Thu"
+	Friday    DayName = "Fri"
+	Saturday  DayName = "Sat"
+	Sunday    DayName = "Sun"
+)
+
+// DaysOrder represents the order of days in week.
+var DaysOrder = [...]DayName{Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday}
+
+// GetFilledScheduleDataDays returns slice of ScheduleDataDay with ScheduleDataDay.Enabled field set from param.
+// Days are ordered with DaysOrder.
+func GetFilledScheduleDataDays(enabled bool) []ScheduleDataDay {
+	days := make([]ScheduleDataDay, 0, len(DaysOrder))
+
+	for _, d := range DaysOrder {
+		days = append(days, ScheduleDataDay{
+			Name:    d,
+			Enabled: enabled,
+		})
+	}
+
+	return days
 }
 
 const (
@@ -270,15 +302,7 @@ const (
 // NewDefaultScheduleData returns the default ScheduleData which can be used in Trigger.
 func NewDefaultScheduleData() *ScheduleData {
 	return &ScheduleData{
-		Days: []ScheduleDataDay{
-			{Name: "Mon", Enabled: true},
-			{Name: "Tue", Enabled: true},
-			{Name: "Wed", Enabled: true},
-			{Name: "Thu", Enabled: true},
-			{Name: "Fri", Enabled: true},
-			{Name: "Sat", Enabled: true},
-			{Name: "Sun", Enabled: true},
-		},
+		Days:           GetFilledScheduleDataDays(true),
 		TimezoneOffset: DefaultTimezoneOffset,
 		StartOffset:    DefaultStartOffset,
 		EndOffset:      DefaultEndOffset,


### PR DESCRIPTION
# PR Summary

Before this PR `Trigger` with not all days in the schedule could be created.

Now the following rules will be applied:
- if some days are missed they will be marked `Enabled = false`;
- if day name not in `[Mon, Tue, Wed, Thu, Fri, Sat, Sun]` the error will be returned;
- if days are unordered they will be ordered from `Mon` to `Sun`;
- if there is no days with `Enabled = true` the error will be returned;