### PR TITLE
feat: validate trigger patterns

### DIFF
--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -258,13 +258,6 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 		return api.ErrInvalidRequestContent{ValidationError: err}
 	}
 
-	//// TODO(litleleprikon): Remove after https://github.com/moira-alert/moira/issues/550 will be resolved
-	//for _, pattern := range trigger.Patterns {
-	//	if pattern == asteriskPattern {
-	//		return api.ErrInvalidRequestContent{ValidationError: errAsteriskPatternNotAllowed}
-	//	}
-	//}
-
 	if trigger.Schedule == nil {
 		trigger.Schedule = moira.NewDefaultScheduleData()
 	} else {

--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -360,27 +360,25 @@ func checkRegexpInPattern(pattern string) error {
 		regExpInTagValueOpLen = len(regExpInTagValueOp)
 	)
 
+	endingRegexp := regexp.MustCompile(`["'][[:space:]]*[,)]`)
+
 	if strings.Contains(regExpInTagValueOp, pattern) {
-		indexOfRegexp := strings.Index(regExpInTagValueOp, pattern)
-		for indexOfRegexp != -1 {
-			indexOfRegexp += regExpInTagValueOpLen
+		indexOfTagValueRegexp := strings.Index(regExpInTagValueOp, pattern)
+		for indexOfTagValueRegexp != -1 {
+			indexOfTagValueRegexp += regExpInTagValueOpLen
 
-			endOfRegexp := -1
-			for _, possibleEnding := range []string{`",`, `")`, `',`, `')`} {
-				endOfRegexp = strings.Index(possibleEnding, pattern[indexOfRegexp:])
-			}
-
-			if endOfRegexp == -1 {
+			endOfTagValueRegexp := endingRegexp.FindStringIndex(pattern[indexOfTagValueRegexp:])
+			if endOfTagValueRegexp == nil {
 				return fmt.Errorf("unclosed tag value in pattern: %s", pattern)
 			}
 
-			_, err := regexp.Compile(pattern[indexOfRegexp:endOfRegexp])
+			_, err := regexp.Compile(pattern[indexOfTagValueRegexp:endOfTagValueRegexp[0]])
 			if err != nil {
 				return fmt.Errorf("invalid regular expression in trigger pattern: %s, err: %w",
-					pattern[indexOfRegexp:endOfRegexp], err)
+					pattern[indexOfTagValueRegexp:endOfTagValueRegexp[0]], err)
 			}
 
-			indexOfRegexp = strings.Index(regExpInTagValueOp, pattern[endOfRegexp:])
+			indexOfTagValueRegexp = strings.Index(regExpInTagValueOp, pattern[endOfTagValueRegexp[1]:])
 		}
 	}
 

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -304,37 +304,37 @@ func TestTriggerValidation(t *testing.T) {
 
 				testcases := []testcase{
 					{
-						givenTargets:   []string{"seriesByTag('Name=some.metric', 'Team=Moira', 'Env=~Env1|Env2')"},
+						givenTargets:   []string{"seriesByTag('name=some.metric', 'Team=Moira', 'Env=~Env1|Env2')"},
 						expectedErrRsp: nil,
 						caseDesc:       "with ' and at the end of query",
 					},
 					{
-						givenTargets:   []string{"seriesByTag(\"Name=some.metric\", \"Team=Moira\", \"Env=~Env1|Env2\")"},
+						givenTargets:   []string{"seriesByTag(\"name=some.metric\", \"Team=Moira\", \"Env=~Env1|Env2\")"},
 						expectedErrRsp: nil,
 						caseDesc:       "with \" and at the end of query",
 					},
 					{
-						givenTargets:   []string{"seriesByTag('Name=some.metric', 'Env=~Env1|Env2', 'Team=Moira')"},
+						givenTargets:   []string{"seriesByTag('name=some.metric', 'Env=~Env1|Env2', 'Team=Moira')"},
 						expectedErrRsp: nil,
 						caseDesc:       "with ' in the middle of query",
 					},
 					{
-						givenTargets:   []string{"seriesByTag(\"Name=some.metric\", \"Env=~Env1|Env2\", \"Team=Moira\")"},
+						givenTargets:   []string{"seriesByTag(\"name=some.metric\", \"Env=~Env1|Env2\", \"Team=Moira\")"},
 						expectedErrRsp: nil,
 						caseDesc:       "with \" in the middle of query",
 					},
 					{
-						givenTargets:   []string{"seriesByTag('Name=some.metric', 'Env=~Env1|Env2'   , 'Team=Moira')"},
+						givenTargets:   []string{"seriesByTag('name=some.metric', 'Env=~Env1|Env2'   , 'Team=Moira')"},
 						expectedErrRsp: nil,
 						caseDesc:       "in the middle of query with some spaces",
 					},
 					{
-						givenTargets:   []string{"seriesByTag('Name=some.metric', \"Vasya=~.*\" , 'Team=Moira', 'Env=~Env1|Env2')"},
+						givenTargets:   []string{"seriesByTag('name=some.metric', \"Vasya=~.*\" , 'Team=Moira', 'Env=~Env1|Env2')"},
 						expectedErrRsp: nil,
 						caseDesc:       "more than one regexp",
 					},
 					{
-						givenTargets: []string{"seriesByTag('Name=some.metric', \"Vasya=~+\", 'Team=Moira', 'BestTeam=Moira', 'Env=~Env1|Env2')"},
+						givenTargets: []string{"seriesByTag('name=some.metric', \"Vasya=~+\", 'Team=Moira', 'BestTeam=Moira', 'Env=~Env1|Env2')"},
 						expectedErrRsp: api.ErrInvalidRequestContent{
 							ValidationError: fmt.Errorf(
 								"bad regexp in tag 'Vasya': %w",
@@ -346,7 +346,7 @@ func TestTriggerValidation(t *testing.T) {
 						caseDesc: "with bad regexp (only '+')",
 					},
 					{
-						givenTargets: []string{"seriesByTag('Name=some.metric', \"Vasya=~*\", 'Team=Moira', 'BestTeam=Moira', 'Env=~Env1|Env2')"},
+						givenTargets: []string{"seriesByTag('name=some.metric', \"Vasya=~*\", 'Team=Moira', 'BestTeam=Moira', 'Env=~Env1|Env2')"},
 						expectedErrRsp: api.ErrInvalidRequestContent{
 							ValidationError: fmt.Errorf(
 								"bad regexp in tag 'Vasya': %w",
@@ -358,9 +358,33 @@ func TestTriggerValidation(t *testing.T) {
 						caseDesc: "with bad regexp (only '*')",
 					},
 					{
-						givenTargets:   []string{"seriesByTag('Name=some.metric', \"Vasya=~\" , 'Team=Moira', 'Env=~Env1|Env2')"},
+						givenTargets:   []string{"seriesByTag('name=some.metric', \"Vasya=~\" , 'Team=Moira', 'Env=~Env1|Env2')"},
 						expectedErrRsp: nil,
 						caseDesc:       "with empty regexp",
+					},
+					{
+						givenTargets: []string{"seriesByTag('name=another.metric','Env=Env3','App=Moira','op=~*POST*')"},
+						expectedErrRsp: api.ErrInvalidRequestContent{
+							ValidationError: fmt.Errorf(
+								"bad regexp in tag 'op': %w",
+								&syntax.Error{
+									Code: syntax.ErrMissingRepeatArgument,
+									Expr: "*",
+								}),
+						},
+						caseDesc: "with bad regexp (incorrect use of '*')",
+					},
+					{
+						givenTargets: []string{"seriesByTag('name=other.metric','Env=Env1', 'App=Moira-API', 'ResCode=~^(?!200)')"},
+						expectedErrRsp: api.ErrInvalidRequestContent{
+							ValidationError: fmt.Errorf(
+								"bad regexp in tag 'ResCode': %w",
+								&syntax.Error{
+									Code: syntax.ErrInvalidPerlOp,
+									Expr: "(?!",
+								}),
+						},
+						caseDesc: "with bad regexp (incorrect use of '*')",
 					},
 				}
 

--- a/api/dto/triggers_test.go
+++ b/api/dto/triggers_test.go
@@ -384,7 +384,19 @@ func TestTriggerValidation(t *testing.T) {
 									Expr: "(?!",
 								}),
 						},
-						caseDesc: "with bad regexp (incorrect use of '*')",
+						caseDesc: "with bad regexp '(?1'",
+					},
+					{
+						givenTargets: []string{"seriesByTag('name=other.metric','Env=Env1', 'App=Moira-API', 'ResCode=~(4**)')"},
+						expectedErrRsp: api.ErrInvalidRequestContent{
+							ValidationError: fmt.Errorf(
+								"bad regexp in tag 'ResCode': %w",
+								&syntax.Error{
+									Code: syntax.ErrInvalidRepeatOp,
+									Expr: "**",
+								}),
+						},
+						caseDesc: "with bad regexp '(4**)'",
 					},
 				}
 


### PR DESCRIPTION
# PR Summary

Before this PR you could create trigger with `seriesByTag` function, that have invalid regular expressions in tag values.
Now validation is added.
