### PR TITLE
fix: Unify contact dto between /team/settings and /contact

### DIFF
--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -26,7 +26,19 @@ func GetAllContacts(database moira.Database) (*dto.ContactList, *api.ErrorRespon
 		return nil, api.ErrorInternalServer(err)
 	}
 	contactsList := dto.ContactList{
-		List: contacts,
+		List: make([]dto.TeamContact, 0, len(contacts)),
+	}
+
+	for _, contact := range contacts {
+		contactsList.List = append(contactsList.List, dto.TeamContact{
+			Type:   contact.Type,
+			Name:   contact.Name,
+			Value:  contact.Value,
+			ID:     contact.ID,
+			User:   contact.User,
+			TeamID: contact.Team,
+			Team:   contact.Team,
+		})
 	}
 	return &contactsList, nil
 }

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -48,14 +48,28 @@ func TestGetAllContacts(t *testing.T) {
 		dataBase.EXPECT().GetAllContacts().Return(contacts, nil)
 		actual, err := GetAllContacts(dataBase)
 		So(err, ShouldBeNil)
-		So(actual, ShouldResemble, &dto.ContactList{List: contacts})
+		expectedContacts := []dto.TeamContact{
+			{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Type:  "mail",
+				User:  "user1",
+				Value: "good@mail.com",
+			},
+			{
+				ID:    uuid.Must(uuid.NewV4()).String(),
+				Type:  "pushover",
+				User:  "user2",
+				Value: "ggg1",
+			},
+		}
+		So(actual, ShouldResemble, &dto.ContactList{List: expectedContacts})
 	})
 
 	Convey("No contacts", t, func() {
 		dataBase.EXPECT().GetAllContacts().Return(make([]*moira.ContactData, 0), nil)
 		contacts, err := GetAllContacts(dataBase)
 		So(err, ShouldBeNil)
-		So(contacts, ShouldResemble, &dto.ContactList{List: make([]*moira.ContactData, 0)})
+		So(contacts, ShouldResemble, &dto.ContactList{List: make([]dto.TeamContact, 0)})
 	})
 }
 

--- a/api/controller/contact_test.go
+++ b/api/controller/contact_test.go
@@ -50,13 +50,13 @@ func TestGetAllContacts(t *testing.T) {
 		So(err, ShouldBeNil)
 		expectedContacts := []dto.TeamContact{
 			{
-				ID:    uuid.Must(uuid.NewV4()).String(),
+				ID:    contacts[0].ID,
 				Type:  "mail",
 				User:  "user1",
 				Value: "good@mail.com",
 			},
 			{
-				ID:    uuid.Must(uuid.NewV4()).String(),
+				ID:    contacts[1].ID,
 				Type:  "pushover",
 				User:  "user2",
 				Value: "ggg1",

--- a/api/controller/team.go
+++ b/api/controller/team.go
@@ -499,7 +499,7 @@ func CheckUserPermissionsForTeam(
 func GetTeamSettings(database moira.Database, teamID string) (dto.TeamSettings, *api.ErrorResponse) {
 	teamSettings := dto.TeamSettings{
 		TeamID:        teamID,
-		Contacts:      make([]moira.ContactData, 0),
+		Contacts:      make([]dto.TeamContact, 0),
 		Subscriptions: make([]moira.SubscriptionData, 0),
 	}
 
@@ -526,10 +526,21 @@ func GetTeamSettings(database moira.Database, teamID string) (dto.TeamSettings, 
 	if err != nil {
 		return dto.TeamSettings{}, api.ErrorInternalServer(err)
 	}
+
 	for _, contact := range contacts {
-		if contact != nil {
-			teamSettings.Contacts = append(teamSettings.Contacts, *contact)
+		if contact == nil {
+			continue
 		}
+
+		teamSettings.Contacts = append(teamSettings.Contacts, dto.TeamContact{
+			ID:     contact.ID,
+			Name:   contact.Name,
+			User:   contact.User,
+			TeamID: contact.Team,
+			Team:   contact.Team,
+			Type:   contact.Type,
+			Value:  contact.Value,
+		})
 	}
 	return teamSettings, nil
 }

--- a/api/controller/team_test.go
+++ b/api/controller/team_test.go
@@ -912,18 +912,44 @@ func TestGetTeamSettings(t *testing.T) {
 
 	Convey("Success get team settings", t, func() {
 		subscriptionIDs := []string{uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String()}
-		subscriptions := []*moira.SubscriptionData{{ID: subscriptionIDs[0]}, {ID: subscriptionIDs[1]}}
 		contactIDs := []string{uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String()}
+
+		subscriptions := []*moira.SubscriptionData{{ID: subscriptionIDs[0]}, {ID: subscriptionIDs[1]}}
 		contacts := []*moira.ContactData{{ID: contactIDs[0]}, {ID: contactIDs[1]}}
+		contactsDto := []dto.TeamContact{{ID: contactIDs[0]}, {ID: contactIDs[1]}}
+
 		database.EXPECT().GetTeamSubscriptionIDs(teamID).Return(subscriptionIDs, nil)
 		database.EXPECT().GetSubscriptions(subscriptionIDs).Return(subscriptions, nil)
 		database.EXPECT().GetTeamContactIDs(teamID).Return(contactIDs, nil)
 		database.EXPECT().GetContacts(contactIDs).Return(contacts, nil)
+
 		settings, err := GetTeamSettings(database, teamID)
 		So(err, ShouldBeNil)
 		So(settings, ShouldResemble, dto.TeamSettings{
 			TeamID:        teamID,
-			Contacts:      []moira.ContactData{*contacts[0], *contacts[1]},
+			Contacts:      contactsDto,
+			Subscriptions: []moira.SubscriptionData{*subscriptions[0], *subscriptions[1]},
+		})
+	})
+
+	Convey("Success get team settings with team_id", t, func() {
+		subscriptionIDs := []string{uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String()}
+		contactIDs := []string{uuid.Must(uuid.NewV4()).String(), uuid.Must(uuid.NewV4()).String()}
+
+		subscriptions := []*moira.SubscriptionData{{ID: subscriptionIDs[0]}, {ID: subscriptionIDs[1]}}
+		contacts := []*moira.ContactData{{ID: contactIDs[0], Team: teamID}, {ID: contactIDs[1], Team: teamID}}
+		contactsDto := []dto.TeamContact{{ID: contactIDs[0], Team: teamID, TeamID: teamID}, {ID: contactIDs[1], Team: teamID, TeamID: teamID}}
+
+		database.EXPECT().GetTeamSubscriptionIDs(teamID).Return(subscriptionIDs, nil)
+		database.EXPECT().GetSubscriptions(subscriptionIDs).Return(subscriptions, nil)
+		database.EXPECT().GetTeamContactIDs(teamID).Return(contactIDs, nil)
+		database.EXPECT().GetContacts(contactIDs).Return(contacts, nil)
+
+		settings, err := GetTeamSettings(database, teamID)
+		So(err, ShouldBeNil)
+		So(settings, ShouldResemble, dto.TeamSettings{
+			TeamID:        teamID,
+			Contacts:      contactsDto,
 			Subscriptions: []moira.SubscriptionData{*subscriptions[0], *subscriptions[1]},
 		})
 	})
@@ -937,7 +963,7 @@ func TestGetTeamSettings(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(settings, ShouldResemble, dto.TeamSettings{
 			TeamID:        teamID,
-			Contacts:      make([]moira.ContactData, 0),
+			Contacts:      make([]dto.TeamContact, 0),
 			Subscriptions: make([]moira.SubscriptionData, 0),
 		})
 	})

--- a/api/dto/contact.go
+++ b/api/dto/contact.go
@@ -4,12 +4,10 @@ package dto
 import (
 	"fmt"
 	"net/http"
-
-	"github.com/moira-alert/moira"
 )
 
 type ContactList struct {
-	List []*moira.ContactData `json:"list"`
+	List []TeamContact `json:"list"`
 }
 
 func (*ContactList) Render(w http.ResponseWriter, r *http.Request) error {

--- a/api/dto/team.go
+++ b/api/dto/team.go
@@ -103,12 +103,29 @@ func (TeamMembers) Render(w http.ResponseWriter, r *http.Request) error {
 // TeamSettings is a structure that contains info about team: contacts and subscriptions.
 type TeamSettings struct {
 	TeamID        string                   `json:"team_id" example:"d5d98eb3-ee18-4f75-9364-244f67e23b54"`
-	Contacts      []moira.ContactData      `json:"contacts"`
+	Contacts      []TeamContact            `json:"contacts"`
 	Subscriptions []moira.SubscriptionData `json:"subscriptions"`
 }
 
 // Render is a function that implements chi Renderer interface for TeamSettings.
 func (TeamSettings) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+// TODO: Replace with dto.Contact after the next release.
+type TeamContact struct {
+	Type   string `json:"type" example:"mail"`
+	Name   string `json:"name,omitempty" example:"Mail Alerts"`
+	Value  string `json:"value" example:"devops@example.com"`
+	ID     string `json:"id,omitempty" example:"1dd38765-c5be-418d-81fa-7a5f879c2315"`
+	User   string `json:"user,omitempty" example:""`
+	TeamID string `json:"team_id,omitempty"`
+	// This field is deprecated
+	Team string `json:"team,omitempty"`
+}
+
+// Render is a function that implements chi Renderer interface for TeamContact.
+func (TeamContact) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 

--- a/api/handler/contact_test.go
+++ b/api/handler/contact_test.go
@@ -53,7 +53,7 @@ func TestGetAllContacts(t *testing.T) {
 			database = mockDb
 
 			expected := &dto.ContactList{
-				List: []*moira.ContactData{
+				List: []dto.TeamContact{
 					{
 						ID:    defaultContact,
 						Type:  "mail",


### PR DESCRIPTION
Replace moira.ContactData with dto.TeamContact, deprecate team field