### PR TITLE
Fix/throw 503 if remote prometheus unavailable

### DIFF
--- a/api/dto/triggers.go
+++ b/api/dto/triggers.go
@@ -275,6 +275,8 @@ func (trigger *Trigger) Bind(request *http.Request) error {
 		return err
 	}
 
+	trigger.UpdatedBy = middleware.GetLogin(request)
+
 	return nil
 }
 

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -221,8 +221,6 @@ func getTriggerFromRequest(request *http.Request) (*dto.Trigger, *api.ErrorRespo
 			return nil, api.ErrorInternalServer(err)
 		}
 	}
-	// TODO: Should be transferred to render.Bind function
-	trigger.UpdatedBy = middleware.GetLogin(request)
 
 	return trigger, nil
 }

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -162,9 +162,8 @@ func is4xxCode(statusCode int64) bool {
 	return statusCode >= 400 && statusCode < 500
 }
 
-
 func errorResponseOnPrometheusError(promErr *prometheus.Error) *api.ErrorResponse {
-	type victoriaMetricsError = prometheus.ErrorType;
+	type victoriaMetricsError = prometheus.ErrorType
 
 	// In github.com/prometheus/client_golang/api/prometheus/v1 Error has field `Type`
 	// which can be used to understand "the reason" of error. There are some constants in the lib.
@@ -172,7 +171,7 @@ func errorResponseOnPrometheusError(promErr *prometheus.Error) *api.ErrorRespons
 	case prometheus.ErrBadData:
 		return api.ErrorInvalidRequest(fmt.Errorf("invalid prometheus targets: %w", promErr))
 
-	// If any error was occured from prometheus, we should return RemoteServiceUnavailable status.
+	// If any error was occurred from prometheus, we should return RemoteServiceUnavailable status.
 	case prometheus.ErrServer, victoriaMetricsError(strconv.Itoa(http.StatusServiceUnavailable)):
 		return api.ErrorRemoteServerUnavailable(fmt.Errorf("remote server error: %w", promErr))
 

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -171,7 +171,7 @@ func errorResponseOnPrometheusError(promErr *prometheus.Error) *api.ErrorRespons
 	case prometheus.ErrBadData:
 		return api.ErrorInvalidRequest(fmt.Errorf("invalid prometheus targets: %w", promErr))
 
-	// If any error was occurred from prometheus, we should return RemoteServiceUnavailable status.
+	// If any error has occurred in prometheus, we should return RemoteServiceUnavailable status.
 	case prometheus.ErrServer, victoriaMetricsError(strconv.Itoa(http.StatusServiceUnavailable)):
 		return api.ErrorRemoteServerUnavailable(fmt.Errorf("remote server error: %w", promErr))
 

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -181,7 +181,7 @@ func errorResponseOnPrometheusError(promErr *prometheus.Error) *api.ErrorRespons
 		return api.ErrorInternalServer(promErr)
 	}
 
-	// In other cases we are trying to classificate error as client error or server.
+	// In other cases we are trying to classify error as client error or server.
 	statusCode, err := strconv.ParseInt(string(promErr.Type), 10, 64)
 	if err != nil {
 		return api.ErrorInternalServer(promErr)

--- a/api/handler/triggers_test.go
+++ b/api/handler/triggers_test.go
@@ -275,7 +275,6 @@ func TestGetTriggerFromRequest(t *testing.T) {
 					prometheus.ErrClient,
 					prometheus.ErrExec,
 					prometheus.ErrTimeout,
-					prometheus.ErrServer,
 				}
 
 				for _, errType := range otherTypes {
@@ -442,64 +441,68 @@ func TestCreateTriggerHandler(t *testing.T) {
 	mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
 	database = mockDb
 
+	mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any()).AnyTimes()
+	mockDb.EXPECT().GetTriggerLastCheck(gomock.Any()).AnyTimes()
+	mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any()).AnyTimes()
+
 	Convey("When createTrigger was called with normal input", t, func() {
 		urls := []string{
 			"/",
 			fmt.Sprintf("/trigger?%s", validateFlag),
 		}
 
-		Convey("should return RemoteServerUnavailable if remote unavailable, url=", func() {
-			prometheusRemote := mock_metric_source.NewMockMetricSource(mockCtrl)
-			prometheusRemote.EXPECT().GetMetricsTTLSeconds().Return(int64(3600)).AnyTimes()
-			prometheusRemote.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &prometheus.Error{Type: "503"}).AnyTimes()
-			sourceProvider := metricSource.CreateTestMetricSourceProvider(nil, nil, prometheusRemote)
-			for _, url := range urls {
-				mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
-				mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
-				mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
-				mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
-				mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
+		Convey("should return RemoteServerUnavailable if remote unavailable, ", func() {
+			fetchRemoteErrorTypes := []prometheus.ErrorType{
+				// Prometheus error format
+				prometheus.ErrServer,
+				// VictoriaMetrics error format
+				"503",
+			}
 
-				triggerWarnValue := float64(10)
-				triggerErrorValue := float64(15)
-				triggerDTO := dto.Trigger{
-					TriggerModel: dto.TriggerModel{
-						Name:          "Test trigger",
-						Tags:          []string{"123"},
-						WarnValue:     &triggerWarnValue,
-						ErrorValue:    &triggerErrorValue,
-						Targets:       []string{"my.metric"},
-						TriggerSource: moira.PrometheusRemote,
-					},
+			for _, fetchRemoteErrorType := range fetchRemoteErrorTypes {
+				prometheusRemote := mock_metric_source.NewMockMetricSource(mockCtrl)
+				prometheusRemote.EXPECT().GetMetricsTTLSeconds().Return(int64(3600)).AnyTimes()
+				prometheusRemote.EXPECT().Fetch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &prometheus.Error{Type: fetchRemoteErrorType}).AnyTimes()
+				sourceProvider := metricSource.CreateTestMetricSourceProvider(nil, nil, prometheusRemote)
+
+				for _, url := range urls {
+					triggerWarnValue := float64(10)
+					triggerErrorValue := float64(15)
+					triggerDTO := dto.Trigger{
+						TriggerModel: dto.TriggerModel{
+							Name:          "Test trigger",
+							Tags:          []string{"123"},
+							WarnValue:     &triggerWarnValue,
+							ErrorValue:    &triggerErrorValue,
+							Targets:       []string{"my.metric"},
+							TriggerSource: moira.PrometheusRemote,
+						},
+					}
+					jsonTrigger, _ := json.Marshal(triggerDTO)
+					testRequest := httptest.NewRequest("", url, bytes.NewBuffer(jsonTrigger))
+					testRequest.Header.Add("content-type", "application/json")
+					testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
+					testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "clustersMetricTTL", MakeTestTTLs()))
+					testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "limits", api.GetTestLimitsConfig()))
+
+					responseWriter := httptest.NewRecorder()
+					createTrigger(responseWriter, testRequest)
+
+					Convey(fmt.Sprintf("url=%s, error=%s", url, fetchRemoteErrorType), func() {
+						response := responseWriter.Result()
+						defer response.Body.Close()
+						So(response.StatusCode, ShouldEqual, http.StatusServiceUnavailable)
+						So(isTriggerCreated(response), ShouldBeFalse)
+					})
 				}
-				jsonTrigger, _ := json.Marshal(triggerDTO)
-				testRequest := httptest.NewRequest("", url, bytes.NewBuffer(jsonTrigger))
-				testRequest.Header.Add("content-type", "application/json")
-				testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "metricSourceProvider", sourceProvider))
-				testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "clustersMetricTTL", MakeTestTTLs()))
-				testRequest = testRequest.WithContext(middleware.SetContextValueForTest(testRequest.Context(), "limits", api.GetTestLimitsConfig()))
-
-				responseWriter := httptest.NewRecorder()
-				createTrigger(responseWriter, testRequest)
-
-				Convey(url, func() {
-					response := responseWriter.Result()
-					defer response.Body.Close()
-					So(response.StatusCode, ShouldEqual, http.StatusServiceUnavailable)
-					So(isTriggerCreated(response), ShouldBeFalse)
-				})
 			}
 		})
 
 		Convey("should return success message, url=", func() {
 			sourceProvider := metricSource.CreateTestMetricSourceProvider(localSource, remoteSource, nil)
 			for _, url := range urls {
-				mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
-				mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
-				mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
-				mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
-				mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
-
 				triggerWarnValue := float64(10)
 				triggerErrorValue := float64(15)
 				triggerDTO := dto.Trigger{
@@ -587,12 +590,6 @@ func TestCreateTriggerHandler(t *testing.T) {
 		jsonTrigger, _ := json.Marshal(trigger)
 
 		Convey("without validate like before", func() {
-			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
-			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
-			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
-			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
-			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
-
 			request := httptest.NewRequest("", "/", bytes.NewBuffer(jsonTrigger))
 			request.Header.Add("content-type", "application/json")
 			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
@@ -611,12 +608,6 @@ func TestCreateTriggerHandler(t *testing.T) {
 		})
 
 		Convey("with validate", func() {
-			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
-			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
-			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
-			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
-			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
-
 			request := httptest.NewRequest("", fmt.Sprintf("/trigger?%s", validateFlag), bytes.NewBuffer(jsonTrigger))
 			request.Header.Add("content-type", "application/json")
 			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))
@@ -675,12 +666,6 @@ func TestCreateTriggerHandler(t *testing.T) {
 		jsonTrigger, _ := json.Marshal(triggerDTO)
 
 		Convey("without validate like before", func() {
-			mockDb.EXPECT().AcquireTriggerCheckLock(gomock.Any(), gomock.Any()).Return(nil)
-			mockDb.EXPECT().DeleteTriggerCheckLock(gomock.Any())
-			mockDb.EXPECT().GetTriggerLastCheck(gomock.Any())
-			mockDb.EXPECT().SetTriggerLastCheck(gomock.Any(), gomock.Any(), gomock.Any())
-			mockDb.EXPECT().SaveTrigger(gomock.Any(), gomock.Any())
-
 			request := httptest.NewRequest("", "/", bytes.NewBuffer(jsonTrigger))
 			request.Header.Add("content-type", "application/json")
 			request = request.WithContext(middleware.SetContextValueForTest(request.Context(), "metricSourceProvider", sourceProvider))


### PR DESCRIPTION
# PR Summary
When trigger is recovering from request context, it's fetches remote prometheus (if needed). If prometheus unavailable (throws server error or 503 HTTP-code), then moira-api throwsa an internal server error. This is incorrect behavior.
At now errors of prometheus server converts to moira-api errors like:

|prometheus server response |moira-api response code|
|-------------------------------------------|--------------------------------------|
|server_error (prometheus format)|503|
|503 (VictoriaMetrics format)|503|