### PR TITLE
fix(swagger): Change body type to any in trigger create and update spec

### DIFF
--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -41,7 +41,7 @@ func trigger(router chi.Router) {
 //	@param		validate	query		bool									false	"For validating targets"
 //	@param		body		body		dto.Trigger								true	"Trigger data"
 //	@success	200			{object}	dto.SaveTriggerResponse					"Updated trigger"
-//	@failure	400			{object}	api.ErrorInvalidRequestExample			"Bad request from client"
+//	@failure	400			{object}	interface{}								"Bad request from client"
 //	@failure	404			{object}	api.ErrorNotFoundExample				"Resource not found"
 //	@failure	422			{object}	api.ErrorRenderExample					"Render error"
 //	@failure	500			{object}	api.ErrorInternalServerExample			"Internal server error"

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -41,7 +41,7 @@ func trigger(router chi.Router) {
 //	@param		validate	query		bool									false	"For validating targets"
 //	@param		body		body		dto.Trigger								true	"Trigger data"
 //	@success	200			{object}	dto.SaveTriggerResponse					"Updated trigger"
-//	@failure	400			{object}	interface{}								"Bad request from client"
+//	@failure	400			{object}	interface{}								"Bad request from client. Could be api.ErrorInvalidRequestExample or dto.SaveTriggerResponse"
 //	@failure	404			{object}	api.ErrorNotFoundExample				"Resource not found"
 //	@failure	422			{object}	api.ErrorRenderExample					"Render error"
 //	@failure	500			{object}	api.ErrorInternalServerExample			"Internal server error"

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -106,7 +106,7 @@ func getUnusedTriggers(writer http.ResponseWriter, request *http.Request) {
 //	@param		validate	query		bool									false	"For validating targets"
 //	@param		trigger		body		dto.Trigger								true	"Trigger data"
 //	@success	200			{object}	dto.SaveTriggerResponse					"Trigger created successfully"
-//	@failure	400			{object}	api.ErrorInvalidRequestExample			"Bad request from client"
+//	@failure	400			{object}	interface{}								"Bad request from client"
 //	@failure	422			{object}	api.ErrorRenderExample					"Render error"
 //	@failure	500			{object}	api.ErrorInternalServerExample			"Internal server error"
 //	@failure	503			{object}	api.ErrorRemoteServerUnavailableExample	"Remote server unavailable"

--- a/api/handler/triggers.go
+++ b/api/handler/triggers.go
@@ -106,7 +106,7 @@ func getUnusedTriggers(writer http.ResponseWriter, request *http.Request) {
 //	@param		validate	query		bool									false	"For validating targets"
 //	@param		trigger		body		dto.Trigger								true	"Trigger data"
 //	@success	200			{object}	dto.SaveTriggerResponse					"Trigger created successfully"
-//	@failure	400			{object}	interface{}								"Bad request from client"
+//	@failure	400			{object}	interface{}								"Bad request from client. Could be api.ErrorInvalidRequestExample or dto.SaveTriggerResponse"
 //	@failure	422			{object}	api.ErrorRenderExample					"Render error"
 //	@failure	500			{object}	api.ErrorInternalServerExample			"Internal server error"
 //	@failure	503			{object}	api.ErrorRemoteServerUnavailableExample	"Remote server unavailable"


### PR DESCRIPTION
Может вернуть как обычная ошибка, так и 400 с описанием дерева проблем, если был использовал флаг `?validate=true`. `openapi 2.0` не поддерживает `oneOf` в параметрах типа, так что лучшее, что мы можем сделать — обобщить тип до `interface{}`

[ПР в client-go](https://github.com/moira-alert/client-go/pull/14)