### PR TITLE
feat: insecure tls option for webhook

### DIFF
--- a/senders/webhook/webhook.go
+++ b/senders/webhook/webhook.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,12 +14,13 @@ import (
 
 // Structure that represents the Webhook configuration in the YAML file.
 type config struct {
-	URL      string            `mapstructure:"url" validate:"required"`
-	Body     string            `mapstructure:"body"`
-	Headers  map[string]string `mapstructure:"headers"`
-	User     string            `mapstructure:"user"`
-	Password string            `mapstructure:"password"`
-	Timeout  int               `mapstructure:"timeout"`
+	URL         string            `mapstructure:"url" validate:"required"`
+	Body        string            `mapstructure:"body"`
+	Headers     map[string]string `mapstructure:"headers"`
+	User        string            `mapstructure:"user"`
+	Password    string            `mapstructure:"password"`
+	Timeout     int               `mapstructure:"timeout"`
+	InsecureTLS bool              `mapstructure:"insecure_tls"`
 }
 
 // Sender implements moira sender interface via webhook.
@@ -69,8 +71,13 @@ func (sender *Sender) Init(senderSettings interface{}, logger moira.Logger, loca
 
 	sender.log = logger
 	sender.client = &http.Client{
-		Timeout:   time.Duration(timeout) * time.Second,
-		Transport: &http.Transport{DisableKeepAlives: true},
+		Timeout: time.Duration(timeout) * time.Second,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: cfg.InsecureTLS,
+			},
+		},
 	}
 
 	senderSettingsMap := senderSettings.(map[string]interface{})

--- a/senders/webhook/webhook_test.go
+++ b/senders/webhook/webhook_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -67,8 +68,13 @@ func TestSender_Init(t *testing.T) {
 				url:     testURL,
 				headers: defaultHeaders,
 				client: &http.Client{
-					Timeout:   30 * time.Second,
-					Transport: &http.Transport{DisableKeepAlives: true},
+					Timeout: 30 * time.Second,
+					Transport: &http.Transport{
+						DisableKeepAlives: true,
+						TLSClientConfig: &tls.Config{
+							InsecureSkipVerify: false,
+						},
+					},
 				},
 				log: logger,
 			})
@@ -83,7 +89,8 @@ func TestSender_Init(t *testing.T) {
 				"headers": map[string]string{
 					"testHeader": "test",
 				},
-				"timeout": 120,
+				"timeout":      120,
+				"insecure_tls": true,
 			}
 			sender := Sender{}
 			expectedHeaders := maps.Clone(defaultHeaders)
@@ -98,8 +105,13 @@ func TestSender_Init(t *testing.T) {
 				password: testPass,
 				headers:  expectedHeaders,
 				client: &http.Client{
-					Timeout:   120 * time.Second,
-					Transport: &http.Transport{DisableKeepAlives: true},
+					Timeout: 120 * time.Second,
+					Transport: &http.Transport{
+						DisableKeepAlives: true,
+						TLSClientConfig: &tls.Config{
+							InsecureSkipVerify: true,
+						},
+					},
 				},
 				log: logger,
 			})
@@ -120,8 +132,13 @@ func TestSender_Init(t *testing.T) {
 				url:     testURL,
 				headers: defaultHeaders,
 				client: &http.Client{
-					Timeout:   30 * time.Second,
-					Transport: &http.Transport{DisableKeepAlives: true},
+					Timeout: 30 * time.Second,
+					Transport: &http.Transport{
+						DisableKeepAlives: true,
+						TLSClientConfig: &tls.Config{
+							InsecureSkipVerify: false,
+						},
+					},
 				},
 				log:     logger,
 				metrics: senderMetrics,


### PR DESCRIPTION
# PR Summary

Add `insecure_tls` option for webhook sender (same as for mattermost sender)