### PR TITLE
feat(api): Add ability filer who can delete triggers

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -2,9 +2,10 @@ package api
 
 // Authorization contains authorization configuration.
 type Authorization struct {
-	AdminList           map[string]struct{}
-	Enabled             bool
-	AllowedContactTypes map[string]struct{}
+	AdminList             map[string]struct{}
+	Enabled               bool
+	AllowedContactTypes   map[string]struct{}
+	CanRemoveTriggersList map[string]struct{}
 }
 
 // IsEnabled returns true if auth is enabled and false otherwise.
@@ -32,7 +33,7 @@ var (
 	RoleAdmin     Role = "admin"
 )
 
-// Returns the role of the given user.
+// GetRole Returns the role of the given user.
 func (auth *Authorization) GetRole(login string) Role {
 	if !auth.IsEnabled() {
 		return RoleUndefined

--- a/api/handler/config.go
+++ b/api/handler/config.go
@@ -17,10 +17,10 @@ import (
 //	@failure	422	{object}	api.ErrorRenderExample	"Render error"
 //	@router		/config [get]
 func getWebConfig(webConfig *api.WebConfig) http.HandlerFunc {
-	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	return func(writer http.ResponseWriter, request *http.Request) {
 		if err := render.Render(writer, request, webConfig); err != nil {
 			render.Render(writer, request, api.ErrorRender(err)) //nolint
 			return
 		}
-	})
+	}
 }

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -125,6 +125,8 @@ type authorization struct {
 	Enabled bool `yaml:"enabled"`
 	// List of logins of users who are considered to be admins.
 	AdminList []string `yaml:"admin_list"`
+	// List for control trigger deletion, if createdBy fit in this list: only who create trigger can delete it.
+	CanRemoveTriggersList []string `yaml:"can_remove_triggers_list"`
 }
 
 type sentryConfig struct {
@@ -203,10 +205,16 @@ func (auth *authorization) toApiConfig(webConfig *webConfig) api.Authorization {
 		allowedContactTypes[contactTemplate.ContactType] = struct{}{}
 	}
 
+	canDeleteTriggersList := make(map[string]struct{}, len(auth.CanRemoveTriggersList))
+	for _, login := range auth.CanRemoveTriggersList {
+		canDeleteTriggersList[login] = struct{}{}
+	}
+
 	return api.Authorization{
-		Enabled:             auth.Enabled,
-		AdminList:           adminList,
-		AllowedContactTypes: allowedContactTypes,
+		Enabled:               auth.Enabled,
+		AdminList:             adminList,
+		AllowedContactTypes:   allowedContactTypes,
+		CanRemoveTriggersList: canDeleteTriggersList,
 	}
 }
 

--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -42,6 +42,7 @@ func Test_apiConfig_getSettings(t *testing.T) {
 				AllowedContactTypes: map[string]struct{}{
 					"test": {},
 				},
+				CanRemoveTriggersList: make(map[string]struct{}),
 			},
 		}
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -75,6 +75,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Can not configure log: %s\n", err.Error())
 		os.Exit(1)
 	}
+
 	defer logger.Info().
 		String("moira_version", MoiraVersion).
 		Msg("Moira API stopped")


### PR DESCRIPTION
# PR Summary

If we added by list username or service-login, triggers, that be created by these login can be deleted only by admins or this person.


