### PR TITLE
fix: selfstate sender disables as dedicated actor

### DIFF
--- a/notifier/selfstate/selfstate_test.go
+++ b/notifier/selfstate/selfstate_test.go
@@ -374,6 +374,17 @@ func TestSelfCheckWorker_enableNotifierIfNeed(t *testing.T) {
 		So(notifierEnabled, ShouldBeFalse)
 	})
 
+	Convey("Should not enable if notifier is disabled by a trigger", t, func() {
+		mock.database.EXPECT().GetNotifierState().Return(moira.NotifierState{
+			State: moira.SelfStateERROR,
+			Actor: moira.SelfStateActorTrigger,
+		}, nil)
+
+		notifierEnabled, err := mock.selfCheckWorker.enableNotifierIfPossible()
+		So(err, ShouldBeNil)
+		So(notifierEnabled, ShouldBeFalse)
+	})
+
 	Convey("Should not enable notifier if it is already enabled", t, func() {
 		mock.database.EXPECT().GetNotifierState().Return(moira.NotifierState{
 			State: moira.SelfStateOK,

--- a/senders/selfstate/selfstate.go
+++ b/senders/selfstate/selfstate.go
@@ -44,7 +44,7 @@ func (sender *Sender) SendEvents(events moira.NotificationEvents, contact moira.
 		return nil
 	default:
 		if selfState.State != state.ToSelfState() {
-			if err := sender.Database.SetNotifierState(moira.SelfStateActorAutomatic, moira.SelfStateERROR); err != nil {
+			if err := sender.Database.SetNotifierState(moira.SelfStateActorTrigger, moira.SelfStateERROR); err != nil {
 				return fmt.Errorf("failed to disable notifications: %s", err.Error())
 			}
 		}

--- a/senders/selfstate/selfstate_test.go
+++ b/senders/selfstate/selfstate_test.go
@@ -64,7 +64,7 @@ func TestSender_SendEvents(t *testing.T) {
 					dataBase.EXPECT().GetNotifierState().Return(moira.NotifierState{
 						State: selfStateInitial,
 					}, nil)
-					dataBase.EXPECT().SetNotifierState(moira.SelfStateActorAutomatic, selfStateFinal).Return(nil)
+					dataBase.EXPECT().SetNotifierState(moira.SelfStateActorTrigger, selfStateFinal).Return(nil)
 
 					testEvents := []moira.NotificationEvent{{State: subjectState}}
 					err := sender.SendEvents(testEvents, testContact, testTrigger, testPlots, testThrottled)

--- a/state.go
+++ b/state.go
@@ -25,6 +25,7 @@ const (
 // Moira notifier management actors.
 const (
 	SelfStateActorAutomatic = "AUTO"
+	SelfStateActorTrigger   = "TRIGGER"
 	SelfStateActorManual    = "MANUAL"
 )
 


### PR DESCRIPTION
# PR Summary
Selfstate sender should disable notifier as AUTO actor with MANUAL rights.
