### PR TITLE
fix(api): fixed trigger validation

### DIFF
--- a/api/dto/target.go
+++ b/api/dto/target.go
@@ -175,7 +175,7 @@ func graphiteTargetVerification(targets []string, ttl time.Duration, triggerSour
 // It is wrapper to handle slice of trees.
 func DoesAnyTreeHaveError(trees []TreeOfProblems) bool {
 	for _, tree := range trees {
-		if tree.TreeOfProblems.hasError() {
+		if !tree.SyntaxOk || tree.TreeOfProblems.hasError() {
 			return true
 		}
 	}

--- a/api/dto/target_test.go
+++ b/api/dto/target_test.go
@@ -28,6 +28,14 @@ func TestTargetVerification(t *testing.T) {
 			So(problems[0].SyntaxOk, ShouldBeFalse)
 		})
 
+		Convey("Check target with unrecognized syntax error", func() {
+			targets := []string{`alias(test.one,'One'))`}
+			problems, err := TargetVerification(targets, 10, moira.GraphiteLocal)
+			So(err, ShouldBeNil)
+			So(problems[0].SyntaxOk, ShouldBeFalse)
+			So(problems[0].TreeOfProblems, ShouldBeNil)
+		})
+
 		Convey("Check correct construction", func() {
 			targets := []string{`alias(test.one,'One')`}
 			problems, err := TargetVerification(targets, 10, moira.GraphiteLocal)

--- a/api/handler/trigger.go
+++ b/api/handler/trigger.go
@@ -117,7 +117,7 @@ func validateTargets(request *http.Request, trigger *dto.Trigger) ([]dto.TreeOfP
 	}
 
 	for _, tree := range treesOfProblems {
-		if tree.TreeOfProblems != nil {
+		if tree.TreeOfProblems != nil || !tree.SyntaxOk {
 			return treesOfProblems, nil
 		}
 	}


### PR DESCRIPTION
# PR Summary

Fixed a trigger validation. When trigger's targets contains any syntax errors cannot be recognized by go-graphite expression parser. But moira can detect some of these errors. In this case, target state changes to `SyntaxOk = false` but `ThreeOfProblems` is nil and moira's api doesn't have any react on `SyntaxOk = false` state.

So, this PR fixes this problem and allows moira's api do a valid target syntax error recognizing