### PR TITLE
fix: Extra Message in team settings

### DIFF
--- a/api/controller/contact.go
+++ b/api/controller/contact.go
@@ -33,16 +33,7 @@ func GetAllContacts(database moira.Database) (*dto.ContactList, *api.ErrorRespon
 	}
 
 	for _, contact := range contacts {
-		contactsList.List = append(contactsList.List, dto.TeamContact{
-			Type:         contact.Type,
-			Name:         contact.Name,
-			Value:        contact.Value,
-			ID:           contact.ID,
-			User:         contact.User,
-			TeamID:       contact.Team,
-			Team:         contact.Team,
-			ExtraMessage: contact.ExtraMessage,
-		})
+		contactsList.List = append(contactsList.List, dto.MakeTeamContact(contact))
 	}
 
 	return &contactsList, nil

--- a/api/controller/team.go
+++ b/api/controller/team.go
@@ -587,15 +587,7 @@ func GetTeamSettings(database moira.Database, teamID string) (dto.TeamSettings, 
 			continue
 		}
 
-		teamSettings.Contacts = append(teamSettings.Contacts, dto.TeamContact{
-			ID:     contact.ID,
-			Name:   contact.Name,
-			User:   contact.User,
-			TeamID: contact.Team,
-			Team:   contact.Team,
-			Type:   contact.Type,
-			Value:  contact.Value,
-		})
+		teamSettings.Contacts = append(teamSettings.Contacts, dto.MakeTeamContact(contact))
 	}
 
 	return teamSettings, nil

--- a/api/dto/team.go
+++ b/api/dto/team.go
@@ -126,6 +126,19 @@ type TeamContact struct {
 	ExtraMessage string `json:"extra_message,omitempty"`
 }
 
+func MakeTeamContact(contact *moira.ContactData) TeamContact {
+	return TeamContact{
+		ID:           contact.ID,
+		Name:         contact.Name,
+		User:         contact.User,
+		TeamID:       contact.Team,
+		Team:         contact.Team,
+		Type:         contact.Type,
+		Value:        contact.Value,
+		ExtraMessage: contact.ExtraMessage,
+	}
+}
+
 // Render is a function that implements chi Renderer interface for TeamContact.
 func (TeamContact) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil


### PR DESCRIPTION
Значение extra_message не попадало в настройки контакта из-за ошибки инициализации dto.TeamContact