### PR TITLE
feat: deprecate convey

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Easiest way to get redis is via docker:
 docker run -p 6379:6379 -d redis:alpine
 ```
 
-We are using [testify](https://github.com/stretchr/testify) as primary way to write tests. So, Moira contains tests based on GoConvey, we don't recommend writing tests on it.
+We use [testify](https://github.com/stretchr/testify) as the primary way to write new tests. Moira contains some legacy tests based on GoConvey, we don't recommend writing tests using it.
 
 To run test use ``go test ./...`` or run [GoConvey](http://goconvey.co/):
 


### PR DESCRIPTION
# PR Summary

GoConvey is so frustrating on use. Let's migrate to testify. This PR fixes conversation about using testify for new tests.