### PR TITLE
feat(api): Feature flag to forbid creating teams for non-admins

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -7,6 +7,7 @@ type Authorization struct {
 	AllowedContactTypes           map[string]struct{}
 	AllowedExtraAdminContactTypes map[string]struct{}
 	LimitedChangeTriggerOwners    map[string]struct{}
+	FeatureFlags                  AuthorizationFeatureFlags
 }
 
 // IsEnabled returns true if auth is enabled and false otherwise.
@@ -45,4 +46,8 @@ func (auth *Authorization) GetRole(login string) Role {
 	}
 
 	return RoleUser
+}
+
+type AuthorizationFeatureFlags struct {
+	ForbidNonAdminsCreateSubscriptions bool
 }

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -49,5 +49,5 @@ func (auth *Authorization) GetRole(login string) Role {
 }
 
 type AuthorizationFeatureFlags struct {
-	ForbidNonAdminsCreateSubscriptions bool
+	ForbidNonAdminsCreateTeams bool
 }

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -132,7 +132,9 @@ func NewHandler(
 			router.Route("/subscription", subscription)
 			router.Route("/notification", notification)
 			router.With(contactsTemplateMiddleware).
-				Route("/teams", teams)
+				Route("/teams", func(router chi.Router) {
+					teams(router, &apiConfig.Authorization)
+				})
 			router.With(contactsTemplateMiddleware).
 				Route("/contact", func(router chi.Router) {
 					contact(router)

--- a/api/handler/team.go
+++ b/api/handler/team.go
@@ -13,7 +13,7 @@ import (
 )
 
 func teams(router chi.Router, auth *api.Authorization) {
-	teamCreateMiddleware := middleware.AdminOnlyByFeatureFlagMiddleware(auth.FeatureFlags.ForbidNonAdminsCreateSubscriptions)
+	teamCreateMiddleware := middleware.AdminOnlyByFeatureFlagMiddleware(auth.FeatureFlags.ForbidNonAdminsCreateTeams)
 
 	router.With(
 		middleware.Paginate(getAllTeamsDefaultPage, getAllTeamsDefaultSize),

--- a/api/handler/team.go
+++ b/api/handler/team.go
@@ -12,20 +12,22 @@ import (
 	"github.com/moira-alert/moira/api/middleware"
 )
 
-func teams(router chi.Router) {
+func teams(router chi.Router, auth *api.Authorization) {
+	teamCreateMiddleware := middleware.AdminOnlyByFeatureFlagMiddleware(auth.FeatureFlags.ForbidNonAdminsCreateSubscriptions)
+
 	router.With(
 		middleware.Paginate(getAllTeamsDefaultPage, getAllTeamsDefaultSize),
 		middleware.SearchTextContext(regexp.MustCompile(getAllTeamsDefaultRegexTemplate)),
 		middleware.SortOrderContext(api.AscSortOrder),
 	).Get("/all", searchTeams)
 	router.Get("/", getAllTeamsForUser)
-	router.Post("/", createTeam)
+	router.With(teamCreateMiddleware).Post("/", createTeam)
 	router.Route("/{teamId}", func(router chi.Router) {
 		router.Use(middleware.TeamContext)
 		router.Use(usersFilterForTeams)
 		router.Get("/", getTeam)
-		router.Patch("/", updateTeam)
-		router.Delete("/", deleteTeam)
+		router.With(teamCreateMiddleware).Patch("/", updateTeam)
+		router.With(teamCreateMiddleware).Delete("/", deleteTeam)
 		router.Route("/users", func(router chi.Router) {
 			router.Get("/", getTeamUsers)
 			router.Put("/", setTeamUsers)

--- a/api/handler/team_test.go
+++ b/api/handler/team_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -16,9 +17,13 @@ import (
 	"github.com/moira-alert/moira/api"
 	"github.com/moira-alert/moira/api/dto"
 	"github.com/moira-alert/moira/api/middleware"
+	db "github.com/moira-alert/moira/database"
+	"github.com/moira-alert/moira/logging/zerolog_adapter"
+	metricsource "github.com/moira-alert/moira/metric_source"
+	mock_metric_source "github.com/moira-alert/moira/mock/metric_source"
 	mock_moira_alert "github.com/moira-alert/moira/mock/moira-alert"
+	"github.com/stretchr/testify/require"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 )
 
@@ -32,11 +37,9 @@ func fillContextForTestSearchTeams(ctx context.Context, testPage, testSize int64
 }
 
 func Test_searchTeams(t *testing.T) {
-	Convey("Test searching teams", t, func() {
+	t.Run("Test searching teams", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
-
-		responseWriter := httptest.NewRecorder()
 		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
 		database = mockDb
 
@@ -59,7 +62,8 @@ func Test_searchTeams(t *testing.T) {
 			})
 		}
 
-		Convey("when everything ok returns ok", func() {
+		t.Run("when everything ok returns ok", func(t *testing.T) {
+			responseWriter := httptest.NewRecorder()
 			mockDb.EXPECT().GetAllTeams().Return(testTeams, nil)
 
 			testRequest := httptest.NewRequest(http.MethodGet, "/api/teams/all", nil)
@@ -85,19 +89,20 @@ func Test_searchTeams(t *testing.T) {
 			response := responseWriter.Result()
 			defer response.Body.Close()
 
-			So(response.StatusCode, ShouldEqual, http.StatusOK)
+			require.Equal(t, http.StatusOK, response.StatusCode)
 
 			content, err := io.ReadAll(response.Body)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 
 			var gotDTO dto.TeamsList
 
 			err = json.Unmarshal(content, &gotDTO)
-			So(err, ShouldBeNil)
-			So(gotDTO, ShouldResemble, expectedDTO)
+			require.NoError(t, err)
+			require.Equal(t, expectedDTO, gotDTO)
 		})
 
-		Convey("when db returns error returns internal server error", func() {
+		t.Run("when db returns error returns internal server error", func(t *testing.T) {
+			responseWriter := httptest.NewRecorder()
 			dbErr := errors.New("some error from db")
 
 			mockDb.EXPECT().GetAllTeams().Return(nil, dbErr)
@@ -129,16 +134,123 @@ func Test_searchTeams(t *testing.T) {
 			response := responseWriter.Result()
 			defer response.Body.Close()
 
-			So(response.StatusCode, ShouldEqual, http.StatusInternalServerError)
+			require.Equal(t, http.StatusInternalServerError, response.StatusCode)
 
 			content, err := io.ReadAll(response.Body)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 
 			var gotDTO errorResponse
 
 			err = json.Unmarshal(content, &gotDTO)
-			So(err, ShouldBeNil)
-			So(gotDTO, ShouldResemble, expectedDTO)
+			require.NoError(t, err)
+			require.Equal(t, expectedDTO, gotDTO)
 		})
+	})
+}
+
+func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	logger, _ := zerolog_adapter.GetLogger("Test")
+	mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
+	mockSource := mock_metric_source.NewMockMetricSource(mockCtrl)
+	provider := metricsource.CreateTestMetricSourceProvider(mockSource, mockSource, mockSource)
+
+	handlerNoAuth := NewHandler(mockDb, logger, nil, &api.Config{Limits: api.GetTestLimitsConfig()}, provider, nil, nil)
+
+	handlerNoFf := NewHandler(mockDb, logger, nil, &api.Config{
+		Limits: api.GetTestLimitsConfig(),
+		Authorization: api.Authorization{
+			Enabled: true,
+		}}, provider, nil, nil)
+
+	adminLogin := "superman"
+	nonAdminLogin := "batman"
+	handlerWithFf := NewHandler(mockDb, logger, nil, &api.Config{
+		Limits: api.GetTestLimitsConfig(),
+		Authorization: api.Authorization{
+			Enabled:   true,
+			AdminList: map[string]struct{}{adminLogin: {}},
+			FeatureFlags: api.AuthorizationFeatureFlags{
+				ForbidNonAdminsCreateSubscriptions: true,
+			},
+		}}, provider, nil, nil)
+
+	t.Run("when auth is disabled, everything is allowed", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
+
+		mockDb.EXPECT().GetTeam("team1").Return(moira.Team{}, db.ErrNil)
+		mockDb.EXPECT().SaveTeam("team1", gomock.Any()).Return(nil)
+		mockDb.EXPECT().GetUserTeams("anonymous").Return([]string{}, nil)
+		mockDb.EXPECT().SaveTeamsAndUsers("team1", gomock.Any(), gomock.Any()).Return(nil)
+
+		url := fmt.Sprintf("/api/teams")
+		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
+		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
+
+		handlerNoAuth.ServeHTTP(responseWriter, testRequest)
+
+		response := responseWriter.Result()
+		defer response.Body.Close()
+
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("when auth is enabled, and feature flag is down, everything is allowed", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
+
+		mockDb.EXPECT().GetTeam("team1").Return(moira.Team{}, db.ErrNil)
+		mockDb.EXPECT().SaveTeam("team1", gomock.Any()).Return(nil)
+		mockDb.EXPECT().GetUserTeams("anonymous").Return([]string{}, nil)
+		mockDb.EXPECT().SaveTeamsAndUsers("team1", gomock.Any(), gomock.Any()).Return(nil)
+
+		url := fmt.Sprintf("/api/teams")
+		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
+		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
+
+		handlerNoFf.ServeHTTP(responseWriter, testRequest)
+
+		response := responseWriter.Result()
+		defer response.Body.Close()
+
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("when auth is enabled, and feature flag is up, everything is allowed for admin", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
+
+		mockDb.EXPECT().GetTeam("team1").Return(moira.Team{}, db.ErrNil)
+		mockDb.EXPECT().SaveTeam("team1", gomock.Any()).Return(nil)
+		mockDb.EXPECT().GetUserTeams(adminLogin).Return([]string{}, nil)
+		mockDb.EXPECT().SaveTeamsAndUsers("team1", gomock.Any(), gomock.Any()).Return(nil)
+
+		url := fmt.Sprintf("/api/teams")
+		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
+		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
+		testRequest.Header.Add("x-webauth-user", adminLogin)
+
+		handlerWithFf.ServeHTTP(responseWriter, testRequest)
+
+		response := responseWriter.Result()
+		defer response.Body.Close()
+
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("when auth is enabled, and feature flag is up, nothing is allowed for non admin", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
+
+		url := fmt.Sprintf("/api/teams")
+		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
+		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
+		testRequest.Header.Add("x-webauth-user", nonAdminLogin)
+
+		handlerWithFf.ServeHTTP(responseWriter, testRequest)
+
+		response := responseWriter.Result()
+		defer response.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, response.StatusCode)
 	})
 }

--- a/api/handler/team_test.go
+++ b/api/handler/team_test.go
@@ -176,7 +176,7 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 			Enabled:   true,
 			AdminList: map[string]struct{}{adminLogin: {}},
 			FeatureFlags: api.AuthorizationFeatureFlags{
-				ForbidNonAdminsCreateSubscriptions: true,
+				ForbidNonAdminsCreateTeams: true,
 			},
 		},
 	}, provider, nil, nil)

--- a/api/handler/team_test.go
+++ b/api/handler/team_test.go
@@ -40,6 +40,7 @@ func Test_searchTeams(t *testing.T) {
 	t.Run("Test searching teams", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
+
 		mockDb := mock_moira_alert.NewMockDatabase(mockCtrl)
 		database = mockDb
 
@@ -64,6 +65,7 @@ func Test_searchTeams(t *testing.T) {
 
 		t.Run("when everything ok returns ok", func(t *testing.T) {
 			responseWriter := httptest.NewRecorder()
+
 			mockDb.EXPECT().GetAllTeams().Return(testTeams, nil)
 
 			testRequest := httptest.NewRequest(http.MethodGet, "/api/teams/all", nil)
@@ -163,7 +165,8 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 		Limits: api.GetTestLimitsConfig(),
 		Authorization: api.Authorization{
 			Enabled: true,
-		}}, provider, nil, nil)
+		},
+	}, provider, nil, nil)
 
 	adminLogin := "superman"
 	nonAdminLogin := "batman"
@@ -175,7 +178,8 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 			FeatureFlags: api.AuthorizationFeatureFlags{
 				ForbidNonAdminsCreateSubscriptions: true,
 			},
-		}}, provider, nil, nil)
+		},
+	}, provider, nil, nil)
 
 	t.Run("when auth is disabled, everything is allowed", func(t *testing.T) {
 		responseWriter := httptest.NewRecorder()
@@ -185,7 +189,7 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 		mockDb.EXPECT().GetUserTeams("anonymous").Return([]string{}, nil)
 		mockDb.EXPECT().SaveTeamsAndUsers("team1", gomock.Any(), gomock.Any()).Return(nil)
 
-		url := fmt.Sprintf("/api/teams")
+		url := "/api/teams"
 		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
 		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
 
@@ -205,7 +209,7 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 		mockDb.EXPECT().GetUserTeams("anonymous").Return([]string{}, nil)
 		mockDb.EXPECT().SaveTeamsAndUsers("team1", gomock.Any(), gomock.Any()).Return(nil)
 
-		url := fmt.Sprintf("/api/teams")
+		url := "/api/teams"
 		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
 		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
 
@@ -225,7 +229,7 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 		mockDb.EXPECT().GetUserTeams(adminLogin).Return([]string{}, nil)
 		mockDb.EXPECT().SaveTeamsAndUsers("team1", gomock.Any(), gomock.Any()).Return(nil)
 
-		url := fmt.Sprintf("/api/teams")
+		url := "/api/teams"
 		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
 		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
 		testRequest.Header.Add("x-webauth-user", adminLogin)
@@ -241,7 +245,7 @@ func TestAdminOnlyTeamEditingFeatureFlag(t *testing.T) {
 	t.Run("when auth is enabled, and feature flag is up, nothing is allowed for non admin", func(t *testing.T) {
 		responseWriter := httptest.NewRecorder()
 
-		url := fmt.Sprintf("/api/teams")
+		url := "/api/teams"
 		body := `{"id":"team1","name":"Team 1","description":"Team 1 Desc"}`
 		testRequest := httptest.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(body)))
 		testRequest.Header.Add("x-webauth-user", nonAdminLogin)

--- a/api/middleware/authorization.go
+++ b/api/middleware/authorization.go
@@ -25,3 +25,14 @@ func AdminOnlyMiddleware() func(next http.Handler) http.Handler {
 		return http.HandlerFunc(fn)
 	}
 }
+
+// AdminOnlyMiddleware returns 403 if request for made by non-admin user.
+func AdminOnlyByFeatureFlagMiddleware(featureFlag bool) func(next http.Handler) http.Handler {
+	if featureFlag {
+		return AdminOnlyMiddleware()
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(next.ServeHTTP)
+	}
+}

--- a/api/middleware/authorization.go
+++ b/api/middleware/authorization.go
@@ -26,7 +26,7 @@ func AdminOnlyMiddleware() func(next http.Handler) http.Handler {
 	}
 }
 
-// AdminOnlyMiddleware returns 403 if request for made by non-admin user.
+// AdminOnlyByFeatureFlagMiddleware returns 403 if request for made by non-admin user if featureFlag is enabled, otherwise does nothing.
 func AdminOnlyByFeatureFlagMiddleware(featureFlag bool) func(next http.Handler) http.Handler {
 	if featureFlag {
 		return AdminOnlyMiddleware()

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -146,7 +146,7 @@ type authorization struct {
 
 type AuthorizationFeatureFlags struct {
 	// Disabled by default. If enabled, only admins will be able to create new teams.
-	ForbidNonAdminsCreateSubscriptions bool `yaml:"forbid_non_admins_to_create_subscriptions"`
+	ForbidNonAdminsCreateTeams bool `yaml:"forbid_non_admins_to_create_teams"`
 }
 
 type sentryConfig struct {
@@ -244,7 +244,7 @@ func (auth *authorization) toApiConfig(webConfig *webConfig) api.Authorization {
 		LimitedChangeTriggerOwners:    canChangeTriggersList,
 		AllowedExtraAdminContactTypes: extraAdminsContactTypes,
 		FeatureFlags: api.AuthorizationFeatureFlags{
-			ForbidNonAdminsCreateSubscriptions: auth.FeatureFlags.ForbidNonAdminsCreateSubscriptions,
+			ForbidNonAdminsCreateTeams: auth.FeatureFlags.ForbidNonAdminsCreateTeams,
 		},
 	}
 }

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -140,6 +140,13 @@ type authorization struct {
 	AdminList []string `yaml:"admin_list"`
 	// List for control trigger deletion and editing, if createdBy fit in this list: only who create trigger can delete it.
 	LimitedChangeTriggerOwners []string `yaml:"limited_change_trigger_owners"`
+	// List of feature flags that can be enabled for authorization in moira
+	FeatureFlags AuthorizationFeatureFlags `yaml:"feature_flags"`
+}
+
+type AuthorizationFeatureFlags struct {
+	// Disabled by default. If enabled, only admins will be able to create new teams.
+	ForbidNonAdminsCreateSubscriptions bool `yaml:"forbid_non_admins_to_create_subscriptions"`
 }
 
 type sentryConfig struct {
@@ -236,6 +243,9 @@ func (auth *authorization) toApiConfig(webConfig *webConfig) api.Authorization {
 		AllowedContactTypes:           allowedContactTypes,
 		LimitedChangeTriggerOwners:    canChangeTriggersList,
 		AllowedExtraAdminContactTypes: extraAdminsContactTypes,
+		FeatureFlags: api.AuthorizationFeatureFlags{
+			ForbidNonAdminsCreateSubscriptions: auth.FeatureFlags.ForbidNonAdminsCreateSubscriptions,
+		},
 	}
 }
 


### PR DESCRIPTION
Добавлен фича-флаг для авторизации `forbid_non_admins_to_create_teams`
Когда он поднят, создавать, менять и удалять команды могут только админы

Логика добавления пользователей, контактов и подписок в команду не изменилась 