### PR TITLE
feat: Add metadata field to team

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -124,6 +124,7 @@ func GetTestLimitsConfig() LimitsConfig {
 		Team: TeamLimits{
 			MaxNameSize:        DefaultTeamNameMaxSize,
 			MaxDescriptionSize: DefaultTeamDescriptionMaxSize,
+			MaxMetadataSize:    DefaultTeamMetadataMaxSize,
 		},
 	}
 }
@@ -131,6 +132,7 @@ func GetTestLimitsConfig() LimitsConfig {
 const (
 	DefaultTeamNameMaxSize        = 100
 	DefaultTeamDescriptionMaxSize = 1000
+	DefaultTeamMetadataMaxSize    = 200
 )
 
 // TeamLimits contains all limits applied for triggers.
@@ -139,6 +141,8 @@ type TeamLimits struct {
 	MaxNameSize int
 	// MaxNameSize is the amount of characters allowed in team description.
 	MaxDescriptionSize int
+	// MaxMetadataSize is the amount of characters allowed in team metadata.
+	MaxMetadataSize int
 }
 
 // ContactLimits defines limits for contact-related configurations.

--- a/api/dto/team.go
+++ b/api/dto/team.go
@@ -18,6 +18,7 @@ type TeamModel struct {
 	ID          string `json:"id" binding:"required" example:"d5d98eb3-ee18-4f75-9364-244f67e23b54"`
 	Name        string `json:"name" binding:"required" example:"Infrastructure Team"`
 	Description string `json:"description" example:"Team that holds all members of infrastructure division"`
+	Metadata    string `json:"metadata" example:"test_team"`
 }
 
 // NewTeamModel is a constructor function that creates a new TeamModel using moira.Team.
@@ -26,6 +27,7 @@ func NewTeamModel(team moira.Team) TeamModel {
 		ID:          team.ID,
 		Name:        team.Name,
 		Description: team.Description,
+		Metadata:    team.Metadata,
 	}
 }
 
@@ -45,6 +47,10 @@ func (t TeamModel) Bind(request *http.Request) error {
 		return fmt.Errorf("team description cannot be longer than %d characters", limits.Team.MaxDescriptionSize)
 	}
 
+	if utf8.RuneCountInString(t.Metadata) > limits.Team.MaxMetadataSize {
+		return fmt.Errorf("team metadata cannot be longer than %d characters", limits.Team.MaxMetadataSize)
+	}
+
 	return nil
 }
 
@@ -59,6 +65,7 @@ func (t TeamModel) ToMoiraTeam() moira.Team {
 		ID:          t.ID,
 		Name:        t.Name,
 		Description: t.Description,
+		Metadata:    t.Metadata,
 	}
 }
 

--- a/api/dto/team.go
+++ b/api/dto/team.go
@@ -18,7 +18,7 @@ type TeamModel struct {
 	ID          string `json:"id" binding:"required" example:"d5d98eb3-ee18-4f75-9364-244f67e23b54"`
 	Name        string `json:"name" binding:"required" example:"Infrastructure Team"`
 	Description string `json:"description" example:"Team that holds all members of infrastructure division"`
-	Metadata    string `json:"metadata" example:"test_team"`
+	Metadata    string `json:"metadata" example:"{\"meta_id\":\"example_id\"}"`
 }
 
 // NewTeamModel is a constructor function that creates a new TeamModel using moira.Team.

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -106,6 +106,8 @@ type TeamLimitsConfig struct {
 	MaxNameSize int `yaml:"max_name_size"`
 	// MaxDescriptionSize is the max amount of characters allowed in team description.
 	MaxDescriptionSize int `yaml:"max_description_size"`
+	// MaxMetadataSize is the max amount of characters allowed in team metadata.
+	MaxMetadataSize int `yaml:"max_metadata_size"`
 }
 
 // ContactLimits defines limits for contact-related configurations.
@@ -116,6 +118,15 @@ type ContactLimits struct {
 
 // ToLimits converts LimitsConfig to api.LimitsConfig.
 func (conf LimitsConfig) ToLimits() api.LimitsConfig {
+	if conf.Team.MaxNameSize == 0 {
+		conf.Team.MaxNameSize = api.DefaultTeamNameMaxSize
+	}
+	if conf.Team.MaxDescriptionSize == 0 {
+		conf.Team.MaxDescriptionSize = api.DefaultTeamDescriptionMaxSize
+	}
+	if conf.Team.MaxMetadataSize == 0 {
+		conf.Team.MaxMetadataSize = api.DefaultTeamMetadataMaxSize
+	}
 	return api.LimitsConfig{
 		Pager: api.PagerLimits{
 			TTL: conf.Pager.TTL,
@@ -126,6 +137,7 @@ func (conf LimitsConfig) ToLimits() api.LimitsConfig {
 		Team: api.TeamLimits{
 			MaxNameSize:        conf.Team.MaxNameSize,
 			MaxDescriptionSize: conf.Team.MaxDescriptionSize,
+			MaxMetadataSize:    conf.Team.MaxMetadataSize,
 		},
 		Contact: api.ContactLimits{
 			TestNotificationWaitTime: conf.Contact.TestNotificationWaitTime,

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -121,12 +121,15 @@ func (conf LimitsConfig) ToLimits() api.LimitsConfig {
 	if conf.Team.MaxNameSize == 0 {
 		conf.Team.MaxNameSize = api.DefaultTeamNameMaxSize
 	}
+
 	if conf.Team.MaxDescriptionSize == 0 {
 		conf.Team.MaxDescriptionSize = api.DefaultTeamDescriptionMaxSize
 	}
+
 	if conf.Team.MaxMetadataSize == 0 {
 		conf.Team.MaxMetadataSize = api.DefaultTeamMetadataMaxSize
 	}
+
 	return api.LimitsConfig{
 		Pager: api.PagerLimits{
 			TTL: conf.Pager.TTL,

--- a/cmd/api/config_test.go
+++ b/cmd/api/config_test.go
@@ -50,6 +50,13 @@ func Test_apiConfig_getSettings(t *testing.T) {
 				},
 				LimitedChangeTriggerOwners: make(map[string]struct{}),
 			},
+			Limits: api.LimitsConfig{
+				Team: api.TeamLimits{
+					MaxNameSize:        api.DefaultTeamNameMaxSize,
+					MaxDescriptionSize: api.DefaultTeamDescriptionMaxSize,
+					MaxMetadataSize:    api.DefaultTeamMetadataMaxSize,
+				},
+			},
 		}
 
 		result := apiConf.getSettings(metricTTLs, api.FeatureFlags{IsReadonlyEnabled: true}, webConfig)

--- a/database/redis/reply/team.go
+++ b/database/redis/reply/team.go
@@ -14,12 +14,14 @@ import (
 type teamStorageElement struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Metadata    string `json:"metadata"`
 }
 
 func newTeamStorageElement(team moira.Team) teamStorageElement {
 	return teamStorageElement{
 		Name:        team.Name,
 		Description: team.Description,
+		Metadata:    team.Metadata,
 	}
 }
 
@@ -27,6 +29,7 @@ func (t *teamStorageElement) toTeam() moira.Team {
 	return moira.Team{
 		Name:        t.Name,
 		Description: t.Description,
+		Metadata:    t.Metadata,
 	}
 }
 

--- a/database/redis/teams_test.go
+++ b/database/redis/teams_test.go
@@ -31,6 +31,7 @@ func TestTeamStoring(t *testing.T) {
 		ID:          teamID,
 		Name:        "Test team",
 		Description: "Test team description",
+		Metadata:    "Test team metadata",
 	}
 
 	Convey("Teams Manipulation", t, func() {
@@ -260,6 +261,7 @@ func TestSaveAndGetTeam(t *testing.T) {
 			ID:          "someTeamID",
 			Name:        "Test team name",
 			Description: "Test description",
+			Metadata:    "Test metadata",
 		}
 
 		Convey("when no team, get returns database.ErrNil", func() {

--- a/datatypes.go
+++ b/datatypes.go
@@ -212,6 +212,7 @@ type Team struct {
 	ID          string
 	Name        string
 	Description string
+	Metadata    string
 }
 
 // ContactData represents contact object.


### PR DESCRIPTION
Добавил в команду строковое поле metadata для дополнительных машиночитаемых данных
 
Плюс заполнение дефолтных лимитов, если они не заданы в конфиге